### PR TITLE
docs(changelog): consolidate v2.9.0 → v2.9.207

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,87 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.9.202] — 2026-04-27 · Preview · Per-host options expansion (v2.9.1 → v2.9.202)
+
+> **Preview release.** Published as `applegater/caddyui:v2.9.202` and `:preview` (multi-arch `linux/amd64` + `linux/arm64`). The `:latest` tag is intentionally **not** updated — pull `:preview` to test, then a follow-up release will promote to `:latest` once verified in the field.
+
+### Added
+
+This batch is a sustained expansion of the **per-host configuration surface** introduced in v2.9.0. Every option below is a column on `proxy_hosts`, a field on the proxy-host edit form, and a Caddy-JSON builder branch in `internal/caddy/client.go`. Defaults are off / empty so existing rows behave identically until you opt in. Grouped by category for readability.
+
+#### Request headers forwarded to upstream
+- **`add_x_real_ip`** (v2.9.149) — `X-Real-IP: {http.request.remote.host}`.
+- **`add_x_real_scheme`** (v2.9.191) — `X-Real-Scheme: {http.request.scheme}`.
+- **`add_x_forwarded_scheme`** (v2.9.143) — `X-Forwarded-Scheme: {http.request.scheme}`.
+- **`add_x_forwarded_uri`** (v2.9.199) — `X-Forwarded-URI: {http.request.uri}`.
+- **`strip_incoming_x_forwarded_for`** (v2.9.150) — drop client-supplied `X-Forwarded-For` before Caddy adds its own.
+- **`add_x_request_path` / `add_x_request_method` / `add_x_request_query` / `add_x_request_hostname` / `add_x_request_referer` / `add_x_request_origin`** (v2.9.181, .188, .189, .201, .197, .198) — toggle individual `X-Request-*` debug/trace headers populated from `{http.request.*}` placeholders.
+- **`add_x_request_start`** (v2.9.140) — `X-Request-Start: t={time.now.unix_ms}` for upstream latency tracing.
+- **`add_origin_header`** (v2.9.159) — set a static `Origin` request header.
+- **`add_x_forwarded_user` / `add_x_forwarded_email` / `add_x_forwarded_groups` / `add_x_forwarded_roles`** (v2.9.190, .194, .193, .195) — static identity headers for trusted-network impersonation patterns.
+
+#### Response headers (security & cache)
+- **`add_x_permitted_cross_domain_policies` / `add_document_policy` / `add_origin_agent_cluster`** (v2.9.167, .156, .192) — modern cross-origin / isolation hints.
+- **`add_x_xss_protection_disabled` / `add_x_download_options` / `add_x_no_archive` / `add_x_dns_prefetch_control`** (v2.9.202, .177, .200, .163) — security-hardening toggles.
+- **`add_x_powered_by` / `add_x_clacks_overhead` / `add_x_ua_compatible`** (v2.9.154, .182, .183) — custom branding / legacy-IE / GNU-tradition headers.
+- **`add_cors_vary_header`** (v2.9.152) — `Vary: Origin` on every response (CDN-correctness for CORS).
+- **`add_link_preload`** (v2.9.145) — `Link: …` resource hints.
+- **`add_accept_ranges`** (v2.9.164) — `Accept-Ranges: bytes` to advertise byte-range support.
+- **`add_content_disposition` / `add_content_language`** (v2.9.165, .175) — content metadata headers.
+- **`response_cache_ttl_sec`** (v2.9.144) — emits `Cache-Control: max-age=N`.
+- **`add_age_zero` / `add_pragma_no_cache` / `add_surrogate_control` / `add_warning_header`** (v2.9.185, .179, .186, .187) — cache-bypass / CDN-only / RFC-7234 advisory directives.
+- **`add_server_timing_header`** (v2.9.161) — `Server-Timing: upstream;dur=…` for browser DevTools timing.
+- **`add_clear_site_data`** (v2.9.162) — `Clear-Site-Data` value for logout / data-purge endpoints.
+- **`add_request_id_to_response`** (v2.9.147) — copy the request trace ID into the response.
+- **`add_accept_ch` / `add_critical_ch`** (v2.9.173, .176) — Client Hints negotiation.
+- **`add_alt_svc`** (v2.9.174) — advertise alternative services (HTTP/3 upgrade, etc.).
+- **`add_service_worker_allowed`** (v2.9.172) — expand SW scope beyond script URL.
+- **`add_report_to` / `add_nel_header`** (v2.9.169, .170) — Reporting API + Network Error Logging.
+- **`strip_response_headers`** (v2.9.168) — comma-separated list of response headers to delete from upstream replies.
+
+#### Request blocking (returns 403 / 405)
+- **`deny_path_regexp`** (v2.9.146) — 403 when path matches a regexp.
+- **`block_query_params`** (v2.9.155) — 403 when any of the named query parameters are present.
+- **`block_query_param_regexp`** (v2.9.196) — 403 when the raw query string matches a regexp.
+- **`deny_user_agent_regexp`** (v2.9.178) — 403 when User-Agent matches a regexp.
+- **`block_http_methods`** (v2.9.171) — 405 with `Allow:` header for listed methods.
+
+#### Active health checks
+- **`health_check_tls_server_name`** (v2.9.148) — SNI override for probe connections.
+- **`health_check_tls_insecure_skip_verify`** (v2.9.151) — skip cert verification on probes.
+- **`health_check_user_agent`** (v2.9.180) — custom User-Agent for probe requests.
+
+#### Upstream TLS
+- **`upstream_tls_alpn`** (v2.9.153) — ALPN protocol list for upstream TLS.
+- **`upstream_tls_ca_pem_inline`** (v2.9.160) — inline PEM CA bundle for upstream verification.
+- **`upstream_tls_server_name_from_host`** (v2.9.166) — derive upstream SNI from the incoming `Host` header (dynamic).
+
+#### Forward auth
+- **`forward_auth_skip_paths`** (v2.9.184) — comma-separated path prefixes that bypass `forward_auth` (health, metrics, public assets) by wrapping the auth handler in a `not { path … }` subroute.
+
+#### Load balancing & connections
+- **`lb_random_choose_count`** (v2.9.142) — number of upstreams sampled by the `random_choice` LB policy.
+- **`upstream_keepalive_max_lifetime_sec`** (v2.9.158) — `transport.keep_alive.maximum_connection_lifetime`.
+
+#### Maintenance window
+- **`maintenance_window_timezone`** (v2.9.141) — evaluate the configured maintenance window in a specific IANA tz instead of the host clock.
+- **`maintenance_redirect_url`** (v2.9.157) — when set, the maintenance handler returns a 302 redirect instead of the default 503 HTML page.
+
+### Internal
+- **DB migrations are additive only.** Each v2.9.x option lands as an `ALTER TABLE proxy_hosts ADD COLUMN <name> … DEFAULT <off>` guarded by `columnExists2`, so upgrading is a no-op for existing rows. Downgrade is supported (older builds simply ignore the new columns).
+- **`scanProxyHost` / `proxyHostBaseCols` / `CreateProxyHost` / `UpdateProxyHost` extended uniformly.** No schema fan-out or feature-table indirection — every option is a flat column read by the same scan path. Cuts query overhead for list views to a single `SELECT`.
+
+### Docker
+- Published as `applegater/caddyui:v2.9.202` and `:preview` (multi-arch `linux/amd64` + `linux/arm64`).
+- **`:latest` is intentionally not bumped.** A follow-up release will promote `:preview` once tested in the field.
+
+### Upgrade note
+- Pull `:preview` (not `:latest`) to test: `docker pull applegater/caddyui:preview`.
+- DB schema migration runs automatically on first start; no manual SQL needed.
+- All new options default to off / empty — existing rows behave identically until you edit them and opt in.
+
+---
+
 ## [2.7.9] — 2026-04-26 · Source column on /raw-routes + Recent advanced routes on dashboard
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
-## [2.9.202] — 2026-04-27 · Preview · Per-host options expansion (v2.9.1 → v2.9.202)
+## [2.9.0 → 2.9.207] — 2026-04-27 · Preview · Per-host options expansion + analytics speedup
 
-> **Preview release.** Published as `applegater/caddyui:v2.9.202` and `:preview` (multi-arch `linux/amd64` + `linux/arm64`). The `:latest` tag is intentionally **not** updated — pull `:preview` to test, then a follow-up release will promote to `:latest` once verified in the field.
+> **Preview release.** Published as `applegater/caddyui:v2.9.207` and `:preview` (multi-arch `linux/amd64` + `linux/arm64`). Each numeric tag in the v2.9.0 → v2.9.207 range was an internal-only build during development; this entry consolidates them into one published changelog so the public history stays readable. The `:latest` tag is intentionally **not** updated — pull `:preview` to test, then a follow-up release will promote to `:latest` once verified in the field.
 
 ### Added
 
@@ -75,14 +75,29 @@ This batch is a sustained expansion of the **per-host configuration surface** in
 - **DB migrations are additive only.** Each v2.9.x option lands as an `ALTER TABLE proxy_hosts ADD COLUMN <name> … DEFAULT <off>` guarded by `columnExists2`, so upgrading is a no-op for existing rows. Downgrade is supported (older builds simply ignore the new columns).
 - **`scanProxyHost` / `proxyHostBaseCols` / `CreateProxyHost` / `UpdateProxyHost` extended uniformly.** No schema fan-out or feature-table indirection — every option is a flat column read by the same scan path. Cuts query overhead for list views to a single `SELECT`.
 
+### Fixed
+- **`/redirection-hosts` rendered an empty page.** The list template called `{{range .TagList}}` but `TagList()` was only defined on `ProxyHost`, never on `RedirectionHost`. `html/template` aborts execution on a missing method, so the page silently broke. Added the matching method on `RedirectionHost`. (v2.9.204)
+- **"Test Upstream" button reported `host and port are required`** even with both fields filled in. Root cause: the handler called `r.ParseForm()` first, which initialises `r.Form` to non-nil for any content type — and `r.FormValue()` only triggers `ParseMultipartForm` automatically when `r.Form` is still nil. Result: multipart bodies (which the JS sends via `FormData`) were silently empty. Removed the redundant `ParseForm()` so `FormValue` auto-parses correctly. (v2.9.203)
+- **Pasting the same Caddyfile twice silently created duplicate raw routes.** `postCaddyfileImport` blindly created a new row per adapted route while the parallel `postImport` path (sync from Caddy admin API) properly deduped against existing proxies, redirects, and raw routes. Brought `postCaddyfileImport` to parity — duplicates now report as `skipped` in the result table instead of being created. (v2.9.205)
+
+### Performance — analytics
+- **SQLite tuned for analytics workloads.** New PRAGMAs in the connection DSN: `cache_size=-262144` (256 MiB page cache, was ~2 MiB default), `mmap_size=268435456` (256 MiB mmap window for index scans), `synchronous=NORMAL` (safe with WAL, faster writes during analytics reads), `temp_store=MEMORY` (GROUP BY / DISTINCT temp tables stay in RAM). Existing WAL mode + busy_timeout retained. (v2.9.206)
+- **`access_daily` rollup is now actually used.** The schema for it was added in v2.7.0 but never populated and never queried — every analytics card scanned `access_events` directly even for 30/90/365-day windows. v2.9.206 adds a startup + hourly aggregator (`AggregateAccessDaily`) that backfills missing UTC days. v2.9.207 extends the rollup with per-status-class buckets (`s2xx`/`s3xx`/`s4xx`/`s5xx`/`s_other`) and an idempotent column migration for existing tables. The aggregator detects pre-status-bucket rows and re-aggregates them.
+- **`AccessTotalsSince` and `StatusBucketsSince` rollup-aware.** Long windows (≥ today's UTC midnight in the past) now read past-day totals from `access_daily` and only scan `access_events` for today, dropping the cost of "Last 30 days" / "Last 90 days" / status-pie cards from `O(rows-in-window)` to `O(rows-today + days-in-window)`. Multi-second scans become ~10ms lookups on installs with millions of events. Visitor counts from the rollup are best-effort approximate (same IP across multiple days counted multiple times) — schema comment already noted this. (v2.9.206 — totals; v2.9.207 — status)
+- **Two missing indexes on `access_events`** for the status-code breakdown card and unique-visitor count: `idx_access_events_status_ts(status, ts)` and `idx_access_events_client_ip_ts(client_ip, ts)`. `path` was deliberately *not* indexed — high-cardinality and the index would be larger than the table; top-paths queries already use the `(host, ts)` range scan + GROUP BY which is fast enough. (v2.9.206)
+
+### UI
+- **API Tokens** sidebar entry added between **API** and the admin section (visible to all authenticated users, not just admin). The route, handler, and template existed since the API tokens feature shipped, but there was never a link to reach them from the UI. New `key` icon added to the icon helper. (v2.9.207)
+
 ### Docker
-- Published as `applegater/caddyui:v2.9.202` and `:preview` (multi-arch `linux/amd64` + `linux/arm64`).
+- Published as `applegater/caddyui:v2.9.207` and `:preview` (multi-arch `linux/amd64` + `linux/arm64`).
 - **`:latest` is intentionally not bumped.** A follow-up release will promote `:preview` once tested in the field.
 
 ### Upgrade note
 - Pull `:preview` (not `:latest`) to test: `docker pull applegater/caddyui:preview`.
 - DB schema migration runs automatically on first start; no manual SQL needed.
 - All new options default to off / empty — existing rows behave identically until you edit them and opt in.
+- On first start with v2.9.207 the access_daily backfill aggregator runs once for installs with historical events. Watch for `access_daily: aggregated N day(s)` in the log; subsequent loads of `/analytics` are then instant.
 
 ---
 

--- a/internal/caddy/client.go
+++ b/internal/caddy/client.go
@@ -3,11 +3,14 @@ package caddy
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -96,6 +99,71 @@ type LoadedConfig struct {
 
 func (c *Client) Load(cfg map[string]any) error {
 	return c.send(http.MethodPost, "/load", cfg)
+}
+
+// UpstreamStatus is one entry from Caddy's /reverse_proxy/upstreams response.
+type UpstreamStatus struct {
+	Address     string `json:"address"`
+	NumRequests int    `json:"num_requests"`
+	Fails       int    `json:"fails"`
+	Healthy     bool   // computed: fails == 0
+}
+
+// CaddyVersion holds the version information returned by Caddy's root endpoint.
+type CaddyVersion struct {
+	Version string `json:"version"`
+}
+
+// GetVersion fetches Caddy's version from the admin API root endpoint.
+// Returns empty string on error — callers should treat "" as "unknown".
+func (c *Client) GetVersion(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.AdminURL+"/", nil)
+	if err != nil {
+		return "", err
+	}
+	c.applyAuth(req)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("caddy version: status %d", resp.StatusCode)
+	}
+	var v CaddyVersion
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return "", err
+	}
+	return v.Version, nil
+}
+
+// GetUpstreamHealth fetches the live upstream health from Caddy's admin API.
+// Returns nil without error when the endpoint isn't available (older Caddy).
+func (c *Client) GetUpstreamHealth(ctx context.Context) ([]UpstreamStatus, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.AdminURL+"/reverse_proxy/upstreams", nil)
+	if err != nil {
+		return nil, err
+	}
+	c.applyAuth(req)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil // endpoint not available
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("caddy upstreams: status %d", resp.StatusCode)
+	}
+	var result []UpstreamStatus
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	for i := range result {
+		result[i].Healthy = result[i].Fails == 0
+	}
+	return result, nil
 }
 
 // Validate POSTs the given config to /load?validate_only=true. Caddy runs the full
@@ -195,18 +263,613 @@ func BuildProxyRoute(p models.ProxyHost, advancedHandlers []any) map[string]any 
 		"handler":   "reverse_proxy",
 		"upstreams": upstreams,
 	}
-	// Enable round-robin load balancing when there are multiple upstreams.
+	// Load balancing: StickySessions overrides all; otherwise respect LBPolicy;
+	// default to round_robin for multi-upstream hosts.
 	if len(upstreams) > 1 {
-		reverseProxy["load_balancing"] = map[string]any{
-			"selection_policy": map[string]any{"policy": "round_robin"},
+		policyMap := map[string]any{"policy": "round_robin"}
+		if p.StickySessions {
+			cookieName := p.StickyCookieName
+			if cookieName == "" {
+				cookieName = "lb_backend"
+			}
+			cookiePolicy := map[string]any{"policy": "cookie", "name": cookieName}
+			// v2.9.45: lb_cookie_path — scope the sticky-session cookie to a sub-path.
+			if p.LBCookiePath != "" {
+				cookiePolicy["path"] = p.LBCookiePath
+			}
+			// v2.9.83: lb_cookie_secret — HMAC secret to sign/verify cookie values.
+			if p.LBCookieSecret != "" {
+				cookiePolicy["secret"] = p.LBCookieSecret
+			}
+			// v2.9.122: lb_cookie_httponly — HttpOnly flag on the sticky cookie.
+			if p.LBCookieHTTPOnly {
+				cookiePolicy["http_only"] = true
+			}
+			// v2.9.123: lb_cookie_secure — Secure flag on the sticky cookie.
+			if p.LBCookieSecure {
+				cookiePolicy["secure"] = true
+			}
+			// v2.9.124: lb_cookie_same_site — SameSite attribute on the sticky cookie.
+			if p.LBCookieSameSite != "" {
+				cookiePolicy["same_site"] = p.LBCookieSameSite
+			}
+			// v2.9.133: lb_cookie_max_age_sec — max-age of the sticky cookie in seconds (0 = session).
+			if p.LBCookieMaxAgeSec > 0 {
+				cookiePolicy["max_age"] = p.LBCookieMaxAgeSec
+			}
+			policyMap = cookiePolicy
+		} else if p.LBPolicy != "" {
+			policyMap = map[string]any{"policy": p.LBPolicy}
+			// v2.9.99: lb_header_field — header name for the 'header' sticky selection policy.
+			if p.LBHeaderField != "" {
+				policyMap["field"] = p.LBHeaderField
+			}
+			// v2.9.142: lb_random_choose_count — "choose" count for the random_choice policy.
+			if p.LBRandomChooseCount > 0 && p.LBPolicy == "random_choice" {
+				policyMap["choose"] = p.LBRandomChooseCount
+			}
+		}
+		lbCfg := map[string]any{"selection_policy": policyMap}
+		// v2.9.17: try_duration / try_interval for upstream retry timing.
+		if p.LBTryDurationSec > 0 {
+			lbCfg["try_duration"] = fmt.Sprintf("%ds", p.LBTryDurationSec)
+		}
+		if p.LBTryIntervalMS > 0 {
+			lbCfg["try_interval"] = fmt.Sprintf("%dms", p.LBTryIntervalMS)
+		}
+		reverseProxy["load_balancing"] = lbCfg
+	}
+	needsTransport := p.ForwardScheme == "https" ||
+		p.UpstreamTimeoutSec > 0 || p.ReadTimeoutSec > 0 || p.DialTimeoutSec > 0 || p.WriteTimeoutSec > 0 ||
+		p.ResponseHeaderTimeoutSec > 0 || p.MaxConnDurationSec > 0 || p.UpstreamMaxRespHeaderKB > 0 ||
+		p.TLSHandshakeTimeoutSec > 0 || p.ExpectContinueTimeoutSec > 0 || p.UpstreamTLSCAPEMFile != "" ||
+		p.KeepaliveDisabled || p.DialFallbackDelayMS > 0 || p.UpstreamNetwork != "" || p.DNSResolver != "" ||
+		p.UpstreamTLSMinVersion != "" || p.ForwardProxyURL != "" || p.UpstreamResolveTimeoutSec > 0 ||
+		p.UpstreamReadBufferSizeKB > 0 || p.UpstreamWriteBufferSizeKB > 0 ||
+		p.UpstreamTLSClientCertFile != "" || p.UpstreamLocalAddr != "" ||
+		p.UpstreamTLSRenegotiation != "" || p.UpstreamTLSCurves != "" || p.UpstreamTLSMaxVersion != "" ||
+		p.UpstreamTLSPins != "" || p.UpstreamTLSCipherSuites != "" || p.UpstreamTLSEarlyData ||
+		p.UpstreamTLSALPN != "" || p.UpstreamTLSCAPEMInline != "" ||
+		p.UpstreamTLSServerNameFromHost
+	if needsTransport {
+		transport := map[string]any{"protocol": "http"}
+		if p.ForwardScheme == "https" {
+			// v2.9.9: ssl_verify_upstream — when false (the default), skip TLS
+			// verification so self-signed or internal CA certs are accepted.
+			// When true, use the system trust store for proper verification.
+			tlsCfg := map[string]any{}
+			if !p.SSLVerifyUpstream {
+				tlsCfg["insecure_skip_verify"] = true
+			}
+			if p.UpstreamSNI != "" {
+				tlsCfg["server_name"] = p.UpstreamSNI
+			}
+			transport["tls"] = tlsCfg
+		}
+		// Timeout hierarchy: per-field overrides > combined upstream_timeout_sec.
+		dialDur := p.UpstreamTimeoutSec
+		if p.DialTimeoutSec > 0 {
+			dialDur = p.DialTimeoutSec
+		}
+		if dialDur > 0 {
+			transport["dial_timeout"] = fmt.Sprintf("%ds", dialDur)
+		}
+		// v2.9.29: ResponseHeaderTimeoutSec overrides UpstreamTimeoutSec for response_header_timeout.
+		respHdrDur := p.UpstreamTimeoutSec
+		if p.ResponseHeaderTimeoutSec > 0 {
+			respHdrDur = p.ResponseHeaderTimeoutSec
+		}
+		if respHdrDur > 0 {
+			transport["response_header_timeout"] = fmt.Sprintf("%ds", respHdrDur)
+		}
+		if p.ReadTimeoutSec > 0 {
+			transport["read_timeout"] = fmt.Sprintf("%ds", p.ReadTimeoutSec)
+		}
+		// v2.9.22: write_timeout — time allowed to write the request body to upstream.
+		if p.WriteTimeoutSec > 0 {
+			transport["write_timeout"] = fmt.Sprintf("%ds", p.WriteTimeoutSec)
+		}
+		// v2.9.23: upstream TLS minimum version — merges into the tls sub-object.
+		if p.UpstreamTLSMinVersion != "" {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			tlsCfg["min_version"] = "tls" + p.UpstreamTLSMinVersion
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.59: upstream_tls_ca_pem_file — custom CA bundle for upstream TLS verification.
+		if p.UpstreamTLSCAPEMFile != "" {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			tlsCfg["root_ca_pem_files"] = []any{p.UpstreamTLSCAPEMFile}
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.86/87: mutual TLS client certificate for upstream connections.
+		if p.UpstreamTLSClientCertFile != "" {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			tlsCfg["client_certificate_file"] = p.UpstreamTLSClientCertFile
+			if p.UpstreamTLSClientKeyFile != "" {
+				tlsCfg["client_certificate_key_file"] = p.UpstreamTLSClientKeyFile
+			}
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.95: upstream_tls_renegotiation — TLS renegotiation policy for upstream connections.
+		if p.UpstreamTLSRenegotiation != "" {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			tlsCfg["renegotiation"] = p.UpstreamTLSRenegotiation
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.96: upstream_tls_curves — comma-separated TLS curve preferences for upstream connections.
+		if p.UpstreamTLSCurves != "" {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			curves := []any{}
+			for _, c := range strings.Split(p.UpstreamTLSCurves, ",") {
+				c = strings.TrimSpace(c)
+				if c != "" {
+					curves = append(curves, c)
+				}
+			}
+			if len(curves) > 0 {
+				tlsCfg["curves"] = curves
+			}
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.97: upstream_tls_max_version — maximum TLS version for upstream connections.
+		if p.UpstreamTLSMaxVersion != "" {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			tlsCfg["max_version"] = "tls" + p.UpstreamTLSMaxVersion
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.98: upstream_tls_pins — pin the upstream certificate by SPKI SHA-256 fingerprint(s).
+		if p.UpstreamTLSPins != "" {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			pins := []any{}
+			for _, pin := range strings.Split(p.UpstreamTLSPins, "\n") {
+				pin = strings.TrimSpace(pin)
+				if pin != "" && !strings.HasPrefix(pin, "#") {
+					pins = append(pins, pin)
+				}
+			}
+			if len(pins) > 0 {
+				tlsCfg["pins"] = pins
+			}
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.119: upstream_tls_cipher_suites — restrict cipher suites for upstream TLS connections.
+		if p.UpstreamTLSCipherSuites != "" {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			var suites []any
+			for _, s := range strings.Split(p.UpstreamTLSCipherSuites, ",") {
+				s = strings.TrimSpace(s)
+				if s != "" {
+					suites = append(suites, s)
+				}
+			}
+			if len(suites) > 0 {
+				tlsCfg["cipher_suites"] = suites
+			}
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.125: upstream_tls_early_data — allow TLS 1.3 early data (0-RTT) for upstream connections.
+		if p.UpstreamTLSEarlyData {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			tlsCfg["early_data"] = true
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.160: upstream_tls_ca_pem_inline — inline PEM CA certificate for upstream TLS verification.
+		if p.UpstreamTLSCAPEMInline != "" {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			tlsCfg["root_ca_pem"] = p.UpstreamTLSCAPEMInline
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.153: upstream_tls_alpn — ALPN protocol list for upstream TLS connections.
+		if p.UpstreamTLSALPN != "" {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			alpnList := []any{}
+			for _, proto := range strings.Split(p.UpstreamTLSALPN, ",") {
+				proto = strings.TrimSpace(proto)
+				if proto != "" {
+					alpnList = append(alpnList, proto)
+				}
+			}
+			if len(alpnList) > 0 {
+				tlsCfg["alpn"] = alpnList
+			}
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.166: upstream_tls_server_name_from_host — derive upstream TLS SNI from the Host header.
+		if p.UpstreamTLSServerNameFromHost {
+			tlsCfg, _ := transport["tls"].(map[string]any)
+			if tlsCfg == nil {
+				tlsCfg = map[string]any{}
+			}
+			tlsCfg["server_name"] = "{http.request.host}"
+			transport["tls"] = tlsCfg
+		}
+		// v2.9.23: forward_proxy_url — chain outbound requests through an HTTP proxy.
+		if p.ForwardProxyURL != "" {
+			transport["forward_proxy_url"] = p.ForwardProxyURL
+		}
+		// v2.9.31: max_conn_duration — maximum lifetime of an upstream TCP connection.
+		if p.MaxConnDurationSec > 0 {
+			transport["max_conn_duration"] = fmt.Sprintf("%ds", p.MaxConnDurationSec)
+		}
+		// v2.9.42: upstream_max_resp_header_kb — limit response header bytes from upstream.
+		if p.UpstreamMaxRespHeaderKB > 0 {
+			transport["max_response_header_size"] = p.UpstreamMaxRespHeaderKB * 1024
+		}
+		// v2.9.60: keepalive_disabled — force every upstream request to use a new connection.
+		if p.KeepaliveDisabled {
+			transport["keep_alive"] = map[string]any{"enabled": false}
+		}
+		// v2.9.47: tls_handshake_timeout_sec — timeout for TLS handshake with upstream.
+		if p.TLSHandshakeTimeoutSec > 0 {
+			transport["tls_handshake_timeout"] = fmt.Sprintf("%ds", p.TLSHandshakeTimeoutSec)
+		}
+		// v2.9.48: expect_continue_timeout_sec — wait for upstream 100-Continue response.
+		if p.ExpectContinueTimeoutSec > 0 {
+			transport["expect_continue_timeout"] = fmt.Sprintf("%ds", p.ExpectContinueTimeoutSec)
+		}
+		// v2.9.62: dial_fallback_delay_ms — time to wait before trying next upstream on dial failure.
+		if p.DialFallbackDelayMS > 0 {
+			transport["dial_fallback_delay"] = fmt.Sprintf("%dms", p.DialFallbackDelayMS)
+		}
+		// v2.9.63: upstream_network — force IPv4 or IPv6 for upstream TCP connections.
+		if p.UpstreamNetwork != "" {
+			transport["network"] = p.UpstreamNetwork
+		}
+		// v2.9.64: dns_resolver — custom DNS server for upstream hostname resolution.
+		// v2.9.69: upstream_resolve_timeout_sec — timeout added to the resolver map.
+		if p.DNSResolver != "" || p.UpstreamResolveTimeoutSec > 0 {
+			resolver, _ := transport["resolver"].(map[string]any)
+			if resolver == nil {
+				resolver = map[string]any{}
+			}
+			if p.DNSResolver != "" {
+				resolver["addresses"] = []any{p.DNSResolver}
+			}
+			if p.UpstreamResolveTimeoutSec > 0 {
+				resolver["timeout"] = fmt.Sprintf("%ds", p.UpstreamResolveTimeoutSec)
+			}
+			transport["resolver"] = resolver
+		}
+		// v2.9.70: upstream_read_buffer_size_kb — transport read buffer size.
+		if p.UpstreamReadBufferSizeKB > 0 {
+			transport["read_buffer_size"] = p.UpstreamReadBufferSizeKB * 1024
+		}
+		// v2.9.71: upstream_write_buffer_size_kb — transport write buffer size.
+		if p.UpstreamWriteBufferSizeKB > 0 {
+			transport["write_buffer_size"] = p.UpstreamWriteBufferSizeKB * 1024
+		}
+		// v2.9.94: upstream_local_addr — bind this local IP for upstream connections.
+		if p.UpstreamLocalAddr != "" {
+			transport["local_address"] = p.UpstreamLocalAddr
+		}
+		reverseProxy["transport"] = transport
+	}
+	// v2.9.32: decompress_response — decompress gzip/br upstream responses before
+	// forwarding to the client (enables response-body transforms downstream).
+	if p.DecompressResponse {
+		reverseProxy["decompress_response"] = true
+	}
+	// v2.9.4: active upstream health check.
+	if p.HealthCheckURI != "" {
+		interval := p.HealthCheckIntervalSec
+		if interval <= 0 {
+			interval = 30
+		}
+		timeoutSec := p.HealthCheckTimeoutSec
+		if timeoutSec <= 0 {
+			timeoutSec = 5
+		}
+		activeCheck := map[string]any{
+			"uri":      p.HealthCheckURI,
+			"interval": fmt.Sprintf("%ds", interval),
+			"timeout":  fmt.Sprintf("%ds", timeoutSec),
+		}
+		if p.HealthCheckMethod != "" && p.HealthCheckMethod != "GET" {
+			activeCheck["method"] = p.HealthCheckMethod
+		}
+		// v2.9.5: custom headers sent with each active health-check probe.
+		if p.HealthCheckHeaders != "" && p.HealthCheckHeaders != "{}" {
+			var hdrMap map[string]string
+			if json.Unmarshal([]byte(p.HealthCheckHeaders), &hdrMap) == nil && len(hdrMap) > 0 {
+				hdrs := map[string][]string{}
+				for k, v := range hdrMap {
+					hdrs[k] = []string{v}
+				}
+				activeCheck["headers"] = hdrs
+			}
+		}
+		// v2.9.15: expected status code and response body regexp.
+		if p.HealthCheckExpectStatus > 0 {
+			activeCheck["expect_status"] = p.HealthCheckExpectStatus
+		}
+		if p.HealthCheckExpectBody != "" {
+			activeCheck["expect_body"] = p.HealthCheckExpectBody
+		}
+		if p.HealthCheckFollowRedirects {
+			activeCheck["follow_redirects"] = true
+		}
+		// v2.9.43: health_check_port — probe on a different port than the traffic upstreams.
+		if p.HealthCheckPort > 0 {
+			activeCheck["port"] = p.HealthCheckPort
+		}
+		// v2.9.55: health_check_max_size_kb — cap response body bytes read during health probes.
+		if p.HealthCheckMaxSizeKB > 0 {
+			activeCheck["max_size"] = p.HealthCheckMaxSizeKB * 1024
+		}
+		// v2.9.75: health_check_body — request body sent with each probe request.
+		if p.HealthCheckBody != "" {
+			activeCheck["body"] = p.HealthCheckBody
+		}
+		// v2.9.85: health_check_content_type — Content-Type for health check probe requests.
+		if p.HealthCheckContentType != "" {
+			existing, _ := activeCheck["headers"].(map[string][]string)
+			if existing == nil {
+				existing = map[string][]string{}
+			}
+			existing["Content-Type"] = []string{p.HealthCheckContentType}
+			activeCheck["headers"] = existing
+		}
+		// v2.9.111: health_check_host_override — Host header override for health check probes.
+		if p.HealthCheckHostOverride != "" {
+			existing, _ := activeCheck["headers"].(map[string][]string)
+			if existing == nil {
+				existing = map[string][]string{}
+			}
+			existing["Host"] = []string{p.HealthCheckHostOverride}
+			activeCheck["headers"] = existing
+		}
+		// v2.9.180: health_check_user_agent — custom User-Agent for active health check probes.
+		if p.HealthCheckUserAgent != "" {
+			existing, _ := activeCheck["headers"].(map[string][]string)
+			if existing == nil {
+				existing = map[string][]string{}
+			}
+			existing["User-Agent"] = []string{p.HealthCheckUserAgent}
+			activeCheck["headers"] = existing
+		}
+		// v2.9.148: health_check_tls_server_name — TLS SNI override for health check connections.
+		if p.HealthCheckTLSServerName != "" {
+			activeCheck["tls_server_name"] = p.HealthCheckTLSServerName
+		}
+		// v2.9.151: health_check_tls_insecure_skip_verify — skip TLS cert verification for health check probes.
+		if p.HealthCheckTLSInsecureSkipVerify {
+			activeCheck["tls_insecure_skip_verify"] = true
+		}
+		reverseProxy["health_checks"] = map[string]any{
+			"active": activeCheck,
 		}
 	}
-	if p.ForwardScheme == "https" {
-		reverseProxy["transport"] = map[string]any{
-			"protocol": "http",
-			"tls":      map[string]any{"insecure_skip_verify": true},
+
+	// v2.9.5: passive health check — detect failures in live traffic without
+	// sending dedicated probe requests.
+	if p.PassiveFailDurationSec > 0 || p.PassiveMaxFails > 0 || p.PassiveUnhealthyLatencyMS > 0 || p.PassiveUnhealthyStatusCodes != "" || p.PassiveUnhealthyCount > 0 {
+		passive := map[string]any{}
+		if p.PassiveFailDurationSec > 0 {
+			passive["fail_duration"] = fmt.Sprintf("%ds", p.PassiveFailDurationSec)
+		}
+		if p.PassiveMaxFails > 0 {
+			passive["max_fails"] = p.PassiveMaxFails
+		}
+		// v2.9.46: passive_unhealthy_latency_ms — flag upstream unhealthy above this latency.
+		if p.PassiveUnhealthyLatencyMS > 0 {
+			passive["unhealthy_latency"] = fmt.Sprintf("%dms", p.PassiveUnhealthyLatencyMS)
+		}
+		// v2.9.84: passive_unhealthy_status_codes — specific HTTP codes that trigger passive unhealthy.
+		if p.PassiveUnhealthyStatusCodes != "" {
+			var codes []any
+			for _, s := range strings.Split(p.PassiveUnhealthyStatusCodes, ",") {
+				s = strings.TrimSpace(s)
+				if code, err := strconv.Atoi(s); err == nil && code >= 100 && code <= 599 {
+					codes = append(codes, code)
+				}
+			}
+			if len(codes) > 0 {
+				passive["unhealthy_status"] = codes
+			}
+		}
+		// v2.9.130: passive_unhealthy_count — flag upstream overloaded above this many concurrent requests.
+		if p.PassiveUnhealthyCount > 0 {
+			passive["unhealthy_request_count"] = p.PassiveUnhealthyCount
+		}
+		if hc, ok := reverseProxy["health_checks"].(map[string]any); ok {
+			hc["passive"] = passive
+		} else {
+			reverseProxy["health_checks"] = map[string]any{"passive": passive}
 		}
 	}
+
+	// Configure upstream retry on failure.
+	if p.UpstreamRetries > 0 || p.RetryStatusCodes != "" || p.LBRetryOn != "" {
+		lb, _ := reverseProxy["load_balancing"].(map[string]any)
+		if lb == nil {
+			lb = map[string]any{}
+		}
+		if p.UpstreamRetries > 0 {
+			lb["retries"] = p.UpstreamRetries
+		}
+		// v2.9.22: retry_status_codes — retry on specific upstream HTTP response codes.
+		if p.RetryStatusCodes != "" {
+			var codes []any
+			for _, s := range strings.Split(p.RetryStatusCodes, ",") {
+				s = strings.TrimSpace(s)
+				if s == "" {
+					continue
+				}
+				var code int
+				if _, err := fmt.Sscanf(s, "%d", &code); err == nil && code > 0 {
+					codes = append(codes, code)
+				}
+			}
+			if len(codes) > 0 {
+				lb["retry_status_codes"] = codes
+			}
+		}
+		// v2.9.113: lb_retry_on — retry trigger conditions ("error","5xx","4xx","connect_error","timeout","reset").
+		if p.LBRetryOn != "" {
+			var triggers []any
+			for _, t := range strings.Split(p.LBRetryOn, ",") {
+				t = strings.TrimSpace(t)
+				if t != "" {
+					triggers = append(triggers, t)
+				}
+			}
+			if len(triggers) > 0 {
+				lb["retry_on"] = triggers
+			}
+		}
+		reverseProxy["load_balancing"] = lb
+	}
+
+	// v2.9.4: keepalive connection pooling.
+	// v2.9.14: also triggered when only idle timeout is set (KeepaliveConns may be 0).
+	// Merge into transport if it already exists (set by ForwardScheme==https or UpstreamTimeoutSec>0).
+	if p.KeepaliveConns > 0 || p.KeepaliveIdleTimeoutSec > 0 {
+		transport, _ := reverseProxy["transport"].(map[string]any)
+		if transport == nil {
+			transport = map[string]any{"protocol": "http"}
+		}
+		idleTimeout := "90s"
+		if p.KeepaliveIdleTimeoutSec > 0 {
+			idleTimeout = fmt.Sprintf("%ds", p.KeepaliveIdleTimeoutSec)
+		}
+		ka := map[string]any{
+			"enabled":      true,
+			"idle_timeout": idleTimeout,
+		}
+		if p.KeepaliveConns > 0 {
+			ka["max_idle_conns_per_host"] = p.KeepaliveConns
+		}
+		transport["keep_alive"] = ka
+		reverseProxy["transport"] = transport
+	}
+
+	if p.MaxConnsPerHost > 0 {
+		transport, _ := reverseProxy["transport"].(map[string]any)
+		if transport == nil {
+			transport = map[string]any{"protocol": "http"}
+		}
+		keepAlive, _ := transport["keep_alive"].(map[string]any)
+		if keepAlive == nil {
+			keepAlive = map[string]any{"enabled": true}
+		}
+		keepAlive["max_conns_per_host"] = p.MaxConnsPerHost
+		transport["keep_alive"] = keepAlive
+		reverseProxy["transport"] = transport
+	}
+
+	// v2.9.50/51: upstream keepalive pool — max total idle conns and probe interval.
+	// v2.9.115: upstream_keepalive_probes — TCP keepalive probe count.
+	if p.UpstreamMaxIdleConns > 0 || p.UpstreamKeepAliveProbeIntervalSec > 0 || p.UpstreamKeepaliveProbes > 0 || p.UpstreamKeepaliveMaxLifetimeSec > 0 {
+		transport, _ := reverseProxy["transport"].(map[string]any)
+		if transport == nil {
+			transport = map[string]any{"protocol": "http"}
+		}
+		keepAlive, _ := transport["keep_alive"].(map[string]any)
+		if keepAlive == nil {
+			keepAlive = map[string]any{"enabled": true}
+		}
+		if p.UpstreamMaxIdleConns > 0 {
+			keepAlive["max_idle_conns"] = p.UpstreamMaxIdleConns
+		}
+		if p.UpstreamKeepAliveProbeIntervalSec > 0 {
+			keepAlive["probe_interval"] = fmt.Sprintf("%ds", p.UpstreamKeepAliveProbeIntervalSec)
+		}
+		if p.UpstreamKeepaliveProbes > 0 {
+			keepAlive["probes"] = p.UpstreamKeepaliveProbes
+		}
+		// v2.9.158: upstream_keepalive_max_lifetime_sec — max duration before a keepalive connection is recycled.
+		if p.UpstreamKeepaliveMaxLifetimeSec > 0 {
+			keepAlive["maximum_connection_lifetime"] = fmt.Sprintf("%ds", p.UpstreamKeepaliveMaxLifetimeSec)
+		}
+		transport["keep_alive"] = keepAlive
+		reverseProxy["transport"] = transport
+	}
+
+	if p.ForceHTTP1 {
+		transport, _ := reverseProxy["transport"].(map[string]any)
+		if transport == nil {
+			transport = map[string]any{"protocol": "http"}
+		}
+		transport["versions"] = []any{"1.1"}
+		reverseProxy["transport"] = transport
+	}
+
+	// v2.9.5: H2C (HTTP/2 cleartext) transport — useful for gRPC backends that
+	// don't use TLS. Sets the allowed versions to "h2c" and "2" so Caddy
+	// upgrades the upstream connection without requiring SSL.
+	if p.H2CEnabled {
+		transport, _ := reverseProxy["transport"].(map[string]any)
+		if transport == nil {
+			transport = map[string]any{"protocol": "http"}
+		}
+		transport["versions"] = []any{"h2c", "2"}
+		reverseProxy["transport"] = transport
+	}
+
+	// v2.9.74: upstream_http_versions — explicit HTTP version list for upstream transport.
+	// Only applied when ForceHTTP1 and H2CEnabled are both false; those two flags
+	// take priority if set alongside this field.
+	if p.UpstreamHTTPVersions != "" && !p.ForceHTTP1 && !p.H2CEnabled {
+		transport, _ := reverseProxy["transport"].(map[string]any)
+		if transport == nil {
+			transport = map[string]any{"protocol": "http"}
+		}
+		var versions []any
+		for _, v := range strings.Split(p.UpstreamHTTPVersions, ",") {
+			v = strings.TrimSpace(v)
+			if v != "" {
+				versions = append(versions, v)
+			}
+		}
+		if len(versions) > 0 {
+			transport["versions"] = versions
+		}
+		reverseProxy["transport"] = transport
+	}
+	// v2.9.5: PROXY protocol — tell Caddy to prepend a PROXY protocol header
+	// on the upstream TCP connection so the backend sees the real client IP.
+	if p.ProxyProtocol == "v1" || p.ProxyProtocol == "v2" {
+		transport, _ := reverseProxy["transport"].(map[string]any)
+		if transport == nil {
+			transport = map[string]any{"protocol": "http"}
+		}
+		transport["proxy_protocol"] = p.ProxyProtocol
+		reverseProxy["transport"] = transport
+	}
+
 	if p.WebsocketSupport {
 		reverseProxy["headers"] = map[string]any{
 			"request": map[string]any{
@@ -218,9 +881,305 @@ func BuildProxyRoute(p models.ProxyHost, advancedHandlers []any) map[string]any 
 		}
 	}
 
+	// v2.9.7: upstream Host header override — lets the operator send a different
+	// Host to the backend than the one the client used (e.g. for SaaS/CDN SNI routing).
+	if p.UpstreamHostOverride != "" {
+		hdrCfg, _ := reverseProxy["headers"].(map[string]any)
+		if hdrCfg == nil {
+			hdrCfg = map[string]any{}
+		}
+		reqHdr, _ := hdrCfg["request"].(map[string]any)
+		if reqHdr == nil {
+			reqHdr = map[string]any{}
+		}
+		setHdr, _ := reqHdr["set"].(map[string]any)
+		if setHdr == nil {
+			setHdr = map[string]any{}
+		}
+		setHdr["Host"] = []any{p.UpstreamHostOverride}
+		reqHdr["set"] = setHdr
+		hdrCfg["request"] = reqHdr
+		reverseProxy["headers"] = hdrCfg
+	}
+
+	// v2.9.18: forward real client IP as X-Real-IP header to the upstream.
+	// Uses {http.request.remote.host} so it's the actual TCP connection IP,
+	// not what's in X-Forwarded-For (which can be spoofed by untrusted clients).
+	if p.ForwardClientIP {
+		hdrCfg, _ := reverseProxy["headers"].(map[string]any)
+		if hdrCfg == nil {
+			hdrCfg = map[string]any{}
+		}
+		reqHdr, _ := hdrCfg["request"].(map[string]any)
+		if reqHdr == nil {
+			reqHdr = map[string]any{}
+		}
+		setHdr, _ := reqHdr["set"].(map[string]any)
+		if setHdr == nil {
+			setHdr = map[string]any{}
+		}
+		setHdr["X-Real-IP"] = []any{"{http.request.remote.host}"}
+		reqHdr["set"] = setHdr
+		hdrCfg["request"] = reqHdr
+		reverseProxy["headers"] = hdrCfg
+	}
+
+	// v2.9.8: request body buffering — buffer the upstream request body before
+	// forwarding. Useful for backends that require Content-Length or don't
+	// support chunked transfer. Value is in KB; Caddy uses bytes.
+	if p.RequestBuffersKB > 0 {
+		reverseProxy["request_buffers"] = p.RequestBuffersKB * 1024
+	}
+
+	// v2.9.6: flush_immediate — set flush_interval to -1 so that streaming
+	// responses (SSE, chunked transfer) are forwarded immediately to the client
+	// rather than being buffered by Caddy.
+	if p.FlushImmediate {
+		reverseProxy["flush_interval"] = -1
+	}
+	// v2.9.116: upstream_flush_interval_ms — explicit flush_interval override in ms.
+	// Takes precedence over FlushImmediate when non-zero. Negative values are allowed (-1 = immediate).
+	if p.UpstreamFlushIntervalMS != 0 {
+		reverseProxy["flush_interval"] = p.UpstreamFlushIntervalMS * int(time.Millisecond)
+	}
+
+	// v2.9.6: buffer_responses — buffer the full upstream response body before
+	// forwarding it to the client. Useful when the upstream is slow and you want
+	// to free the upstream connection quickly.
+	if p.BufferResponses {
+		reverseProxy["buffer_responses"] = true
+	}
+	// v2.9.114: max_buffer_size_kb — cap the amount of data Caddy will buffer when
+	// buffer_responses is enabled. 0 means unlimited (Caddy default).
+	if p.MaxBufferSizeKB > 0 {
+		reverseProxy["max_buffer_size"] = p.MaxBufferSizeKB * 1024
+	}
+	// v2.9.49: response_buffers_kb — granular per-connection response streaming buffer.
+	// Distinct from buffer_responses: this controls streaming chunk size, not full buffering.
+	if p.ResponseBuffersKB > 0 {
+		reverseProxy["response_buffers"] = p.ResponseBuffersKB * 1024
+	}
+
+	// v2.9.6: per-host trusted proxies — override which upstream IP ranges are
+	// trusted to supply X-Forwarded-For / X-Real-IP headers.
+	if p.TrustedProxies != "" {
+		if tpRanges := parseCIDRList(p.TrustedProxies); len(tpRanges) > 0 {
+			reverseProxy["trusted_proxies"] = map[string]any{
+				"source": "static",
+				"ranges": tpRanges,
+			}
+		}
+	}
+
 	handlers := []any{}
+	// v2.9.34: www redirect — inject a subroute that redirects between the
+	// www and bare forms of each domain before any other handler fires.
+	if p.WWWRedirect != "" {
+		var redirectRoutes []any
+		for _, d := range domains {
+			d = strings.TrimSpace(d)
+			if d == "" {
+				continue
+			}
+			var fromDomain, toDomain string
+			switch p.WWWRedirect {
+			case "to_www":
+				if !strings.HasPrefix(d, "www.") {
+					fromDomain = d
+					toDomain = "www." + d
+				}
+			case "to_bare":
+				if strings.HasPrefix(d, "www.") {
+					fromDomain = d
+					toDomain = strings.TrimPrefix(d, "www.")
+				}
+			}
+			if fromDomain != "" {
+				redirectRoutes = append(redirectRoutes, map[string]any{
+					"match": []any{map[string]any{"host": []any{fromDomain}}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 301,
+						"headers": map[string]any{
+							"Location": []any{"{http.request.scheme}://" + toDomain + "{http.request.uri}"},
+						},
+					}},
+					"terminal": true,
+				})
+			}
+		}
+		if len(redirectRoutes) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler": "subroute",
+				"routes":  redirectRoutes,
+			})
+		}
+	}
+	// v2.9.61: trailing_slash_redirect — auto-redirect for trailing slash normalisation.
+	if p.TrailingSlashRedirect == "add" {
+		// Redirect /path → /path/ when path has no extension and no trailing slash.
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{map[string]any{
+						"path_regexp": map[string]any{
+							"pattern": `^(/[^.]*[^/])$`,
+						},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 301,
+						"headers": map[string]any{
+							"Location": []any{"{http.request.uri.path}/{http.request.uri.query}"},
+						},
+					}},
+					"terminal": true,
+				},
+			},
+		})
+	} else if p.TrailingSlashRedirect == "remove" {
+		// Redirect /path/ → /path when path ends with / but is not the root.
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{map[string]any{
+						"path_regexp": map[string]any{
+							"pattern": `^(/.+)/$`,
+						},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 301,
+						"headers": map[string]any{
+							"Location": []any{"{http.regexp.capture.1}"},
+						},
+					}},
+					"terminal": true,
+				},
+			},
+		})
+	}
 	if p.BlockCommonExploits {
 		handlers = append(handlers, ExploitBlockerSubroute())
+	}
+	// v2.9.7: dotfile blocking — return 403 for any request whose path contains
+	// a segment beginning with "." (e.g. /.env, /.git/config, /.htaccess).
+	if p.DenyDotfiles {
+		handlers = append(handlers, denyDotfilesSubroute())
+	}
+	// v2.9.10: block requests with no User-Agent header.
+	if p.BlockEmptyUserAgent {
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{map[string]any{
+						"not": []any{map[string]any{
+							"header_regexp": map[string]any{
+								"User-Agent": map[string]any{"pattern": "."},
+							},
+						}},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 403,
+					}},
+					"terminal": true,
+				},
+			},
+		})
+	}
+	// v2.9.10: API key header authentication — reject requests that don't carry
+	// the expected header value. The key is stored in plaintext in the DB.
+	if p.APIKeyHeader != "" && p.APIKeyValue != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{map[string]any{
+						"not": []any{map[string]any{
+							"header": map[string]any{
+								p.APIKeyHeader: []any{p.APIKeyValue},
+							},
+						}},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 401,
+						"body":        "Unauthorized",
+					}},
+					"terminal": true,
+				},
+			},
+		})
+	}
+	// v2.9.25: blocked_methods — reject specific HTTP methods with 405 before anything else.
+	if p.BlockedMethods != "" {
+		var methods []any
+		for _, m := range strings.Split(p.BlockedMethods, ",") {
+			m = strings.TrimSpace(strings.ToUpper(m))
+			if m != "" {
+				methods = append(methods, m)
+			}
+		}
+		if len(methods) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler": "subroute",
+				"routes": []any{
+					map[string]any{
+						"match":    []any{map[string]any{"method": methods}},
+						"handle":   []any{map[string]any{"handler": "static_response", "status_code": 405}},
+						"terminal": true,
+					},
+				},
+			})
+		}
+	}
+	// v2.9.41: allowed_methods — reject methods NOT in the allowlist with 405.
+	// Runs after blocked_methods so an explicit deny always wins.
+	if p.AllowedMethods != "" {
+		var allowed []any
+		for _, m := range strings.Split(p.AllowedMethods, ",") {
+			m = strings.TrimSpace(strings.ToUpper(m))
+			if m != "" {
+				allowed = append(allowed, m)
+			}
+		}
+		if len(allowed) > 0 {
+			// Build a "not" matcher: match any method NOT in the allowed list → 405.
+			handlers = append(handlers, map[string]any{
+				"handler": "subroute",
+				"routes": []any{
+					map[string]any{
+						"match": []any{map[string]any{"not": []any{map[string]any{"method": allowed}}}},
+						"handle": []any{map[string]any{
+							"handler":     "static_response",
+							"status_code": 405,
+							"headers":     map[string]any{"Allow": []any{strings.Join(methodStrings(allowed), ", ")}},
+						}},
+						"terminal": true,
+					},
+				},
+			})
+		}
+	}
+	// v2.9.5: IP blocklist — deny requests from specific CIDR ranges before
+	// the allowlist check so blocklisted IPs are always rejected.
+	if p.IPBlocklist != "" {
+		if blockRanges := parseCIDRList(p.IPBlocklist); len(blockRanges) > 0 {
+			handlers = append(handlers, ipBlocklistSubroute(blockRanges))
+		}
+	}
+	// v2.9.88: block_private_ips — reject requests from RFC 1918 / loopback ranges.
+	if p.BlockPrivateIPs {
+		privateRanges := []string{
+			"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
+			"127.0.0.0/8", "169.254.0.0/16", "100.64.0.0/10",
+			"::1/128", "fc00::/7", "fe80::/10",
+		}
+		handlers = append(handlers, ipBlocklistSubroute(privateRanges))
 	}
 	// Feature C: prepend IP allowlist subroute if access_list is set.
 	if p.AccessList != "" {
@@ -229,36 +1188,1880 @@ func BuildProxyRoute(p models.ProxyHost, advancedHandlers []any) map[string]any 
 			handlers = append(handlers, ipAllowlistSubroute(cidrList))
 		}
 	}
+	// v2.9.155: block_query_params — deny requests containing any of the listed query parameter names (403).
+	if p.BlockQueryParams != "" {
+		for _, param := range strings.Split(p.BlockQueryParams, ",") {
+			param = strings.TrimSpace(param)
+			if param == "" {
+				continue
+			}
+			handlers = append(handlers, map[string]any{
+				"handler": "subroute",
+				"routes": []any{map[string]any{
+					"match": []any{map[string]any{
+						"query": map[string]any{param: []any{"*"}},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 403,
+						"body":        "Forbidden\n",
+					}},
+					"terminal": true,
+				}},
+			})
+		}
+	}
+	// v2.9.146: deny_path_regexp — reject requests whose full path matches a custom regex (403).
+	if p.DenyPathRegexp != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{map[string]any{
+				"match": []any{map[string]any{
+					"path_regexp": map[string]any{"pattern": p.DenyPathRegexp},
+				}},
+				"handle": []any{map[string]any{
+					"handler":     "static_response",
+					"status_code": 403,
+					"body":        "Forbidden\n",
+				}},
+				"terminal": true,
+			}},
+		})
+	}
+	// v2.9.101: deny_extensions — block requests whose path ends with any listed extension (403).
+	if p.DenyExtensions != "" {
+		var exts []string
+		for _, ext := range strings.Split(p.DenyExtensions, ",") {
+			ext = strings.TrimSpace(ext)
+			if ext == "" {
+				continue
+			}
+			if !strings.HasPrefix(ext, ".") {
+				ext = "." + ext
+			}
+			exts = append(exts, regexp.QuoteMeta(ext))
+		}
+		if len(exts) > 0 {
+			pattern := "(?i)(" + strings.Join(exts, "|") + ")$"
+			handlers = append(handlers, map[string]any{
+				"handler": "subroute",
+				"routes": []any{map[string]any{
+					"match": []any{map[string]any{
+						"path_regexp": map[string]any{"pattern": pattern},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 403,
+						"body":        "Forbidden\n",
+					}},
+					"terminal": true,
+				}},
+			})
+		}
+	}
 	// v2.9.0: response compression — gzip/zstd encode handler. Must precede
 	// the reverse_proxy handler so it can wrap the ResponseWriter.
+	// v2.9.18: minimum_length skips compression for small responses.
 	if p.CompressionEnabled {
-		handlers = append(handlers, map[string]any{
+		// v2.9.37: per-algorithm config objects allow setting compression level.
+		gzipCfg := map[string]any{}
+		zstdCfg := map[string]any{}
+		if p.CompressionLevel > 0 {
+			gzipCfg["level"] = p.CompressionLevel
+			// zstd levels are different from gzip (1-22); map gzip 1-9 proportionally.
+			zstdCfg["level"] = p.CompressionLevel
+		}
+		encodings := map[string]any{"gzip": gzipCfg, "zstd": zstdCfg}
+		// v2.9.89: enable_brotli — add brotli (br) encoding to the handler.
+		if p.EnableBrotli {
+			encodings["br"] = map[string]any{}
+		}
+		preferOrder := []any{"zstd", "gzip"}
+		if p.CompressionPreferGzip {
+			preferOrder = []any{"gzip", "zstd"}
+		}
+		if p.EnableBrotli {
+			preferOrder = append([]any{"br"}, preferOrder...)
+		}
+		encHandler := map[string]any{
 			"handler":   "encode",
-			"encodings": map[string]any{"gzip": map[string]any{}, "zstd": map[string]any{}},
-			"prefer":    []any{"zstd", "gzip"},
-		})
+			"encodings": encodings,
+			"prefer":    preferOrder,
+		}
+		if p.CompressionMinSizeKB > 0 {
+			encHandler["minimum_length"] = p.CompressionMinSizeKB * 1024
+		}
+		// v2.9.138: compression_exclude_regexp — skip compression for paths matching this regexp.
+		// Wrap the encode handler in a subroute that fires only for non-matching paths.
+		if p.CompressionExcludeRegexp != "" {
+			handlers = append(handlers, map[string]any{
+				"handler": "subroute",
+				"routes": []any{map[string]any{
+					"match": []any{map[string]any{
+						"not": []any{map[string]any{
+							"path_regexp": map[string]any{"pattern": p.CompressionExcludeRegexp},
+						}},
+					}},
+					"handle": []any{encHandler},
+				}},
+			})
+		} else {
+			handlers = append(handlers, encHandler)
+		}
 	}
 	// v2.9.0: security response headers bundle. Added as a headers handler
 	// before reverse_proxy so the headers appear on every upstream response.
 	if p.SecurityHeadersEnabled {
+		hstsDur := 31536000 // default: 1 year
+		if p.HSTSMaxAgeSec > 0 {
+			hstsDur = p.HSTSMaxAgeSec
+		}
+		hsts := fmt.Sprintf("max-age=%d", hstsDur)
+		if p.HSTSIncludeSubdomains {
+			hsts += "; includeSubDomains"
+		}
+		if p.HSTSPreload {
+			hsts += "; preload"
+		}
+		xfo := "SAMEORIGIN"
+		if p.XFrameOptions != "" {
+			xfo = p.XFrameOptions
+		}
+		rp := "strict-origin-when-cross-origin"
+		if p.ReferrerPolicy != "" {
+			rp = p.ReferrerPolicy
+		}
+		secHdrs := map[string]any{
+			"Strict-Transport-Security": []any{hsts},
+			"X-Frame-Options":           []any{xfo},
+			"X-Content-Type-Options":    []any{"nosniff"},
+			"Referrer-Policy":           []any{rp},
+			"X-XSS-Protection":          []any{"1; mode=block"},
+		}
+		// v2.9.11: Permissions-Policy — modern replacement for Feature-Policy.
+		if p.PermissionsPolicy != "" {
+			secHdrs["Permissions-Policy"] = []any{p.PermissionsPolicy}
+		}
+		handlers = append(handlers, map[string]any{
+			"handler":  "headers",
+			"response": map[string]any{"set": secHdrs},
+		})
+	} else if p.PermissionsPolicy != "" {
+		// Even without the full security bundle, still inject Permissions-Policy alone.
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{"Permissions-Policy": []any{p.PermissionsPolicy}},
+			},
+		})
+	}
+	// v2.9.5: Content-Security-Policy header — injected independently of
+	// SecurityHeadersEnabled so it can be set without enabling the full bundle.
+	if p.CSPHeader != "" {
 		handlers = append(handlers, map[string]any{
 			"handler": "headers",
 			"response": map[string]any{
 				"set": map[string]any{
-					"Strict-Transport-Security": []any{"max-age=31536000; includeSubDomains"},
-					"X-Frame-Options":           []any{"SAMEORIGIN"},
-					"X-Content-Type-Options":    []any{"nosniff"},
-					"Referrer-Policy":           []any{"strict-origin-when-cross-origin"},
-					"X-XSS-Protection":          []any{"1; mode=block"},
+					"Content-Security-Policy": []any{p.CSPHeader},
 				},
 			},
 		})
 	}
+	// v2.9.14: Content-Security-Policy-Report-Only — report violations without
+	// blocking, useful for testing a new policy before enforcing it.
+	if p.CSPReportOnly != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Content-Security-Policy-Report-Only": []any{p.CSPReportOnly},
+				},
+			},
+		})
+	}
+	// v2.9.1: custom request headers — added to/deleted from the upstream request.
+	// v2.9.35: strip_req_headers merged in as additional deletes.
+	if reqHeaders := p.CustomReqHeaderMap(); len(reqHeaders) > 0 || p.StripReqHeaders != "" {
+		setReq := map[string]any{}
+		deleteReq := []any{}
+		for k, v := range reqHeaders {
+			if v == "" {
+				deleteReq = append(deleteReq, k)
+			} else {
+				setReq[k] = []any{v}
+			}
+		}
+		for _, h := range p.StripReqHeaderList() {
+			deleteReq = append(deleteReq, h)
+		}
+		reqOp := map[string]any{}
+		if len(setReq) > 0 {
+			reqOp["set"] = setReq
+		}
+		if len(deleteReq) > 0 {
+			reqOp["delete"] = deleteReq
+		}
+		if len(reqOp) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler": "headers",
+				"request": reqOp,
+			})
+		}
+	}
+	// v2.9.1: custom response headers — added to/deleted from the response.
+	if respHeaders := p.CustomRespHeaderMap(); len(respHeaders) > 0 {
+		setResp := map[string]any{}
+		deleteResp := []any{}
+		for k, v := range respHeaders {
+			if v == "" {
+				deleteResp = append(deleteResp, k)
+			} else {
+				setResp[k] = []any{v}
+			}
+		}
+		respOp := map[string]any{}
+		if len(setResp) > 0 {
+			respOp["set"] = setResp
+		}
+		if len(deleteResp) > 0 {
+			respOp["delete"] = deleteResp
+		}
+		if len(respOp) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler":  "headers",
+				"response": respOp,
+			})
+		}
+	}
+	// v2.9.127: req_header_rename — rename request headers before forwarding ("OldName: NewName" per line).
+	// Implemented as: delete old name, set new name = {http.request.header.OldName}.
+	if p.ReqHeaderRename != "" {
+		type renameRule struct{ from, to string }
+		var rules []renameRule
+		for _, line := range strings.Split(p.ReqHeaderRename, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			if idx := strings.IndexByte(line, ':'); idx > 0 {
+				from := strings.TrimSpace(line[:idx])
+				to := strings.TrimSpace(line[idx+1:])
+				if from != "" && to != "" {
+					rules = append(rules, renameRule{from: from, to: to})
+				}
+			}
+		}
+		if len(rules) > 0 {
+			setMap := map[string]any{}
+			deleteList := []any{}
+			for _, r := range rules {
+				setMap[r.to] = []any{"{http.request.header." + r.from + "}"}
+				deleteList = append(deleteList, r.from)
+			}
+			handlers = append(handlers, map[string]any{
+				"handler": "headers",
+				"request": map[string]any{
+					"set":    setMap,
+					"delete": deleteList,
+				},
+			})
+		}
+	}
+	// v2.9.77: http_basic_auth_upstream — inject Authorization: Basic header for upstream auth.
+	if p.HTTPBasicAuthUpstream != "" {
+		encoded := base64.StdEncoding.EncodeToString([]byte(p.HTTPBasicAuthUpstream))
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"Authorization": []any{"Basic " + encoded},
+				},
+			},
+		})
+	}
+	// v2.9.72: req_header_replace — regex-based value replacement on request headers.
+	if p.ReqHeaderReplace != "" {
+		if rules := parseHeaderReplaceRules(p.ReqHeaderReplace); len(rules) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler": "headers",
+				"request": map[string]any{"replace": rules},
+			})
+		}
+	}
+	// v2.9.73: resp_header_replace — regex-based value replacement on response headers.
+	if p.RespHeaderReplace != "" {
+		if rules := parseHeaderReplaceRules(p.RespHeaderReplace); len(rules) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler":  "headers",
+				"response": map[string]any{"replace": rules},
+			})
+		}
+	}
+	// v2.9.90: vary_header — set Vary response header for CDN/caching control.
+	if p.VaryHeader != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Vary": []any{p.VaryHeader},
+				},
+			},
+		})
+	}
+	// v2.9.91: strip_etag — delete ETag response header from upstream responses.
+	if p.StripETag {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"delete": []any{"ETag"},
+			},
+		})
+	}
+	// v2.9.161: add_server_timing_header — inject standard Server-Timing response header with upstream duration.
+	if p.AddServerTimingHeader {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Server-Timing": []any{"upstream;dur={http.reverse_proxy.upstream.duration}"},
+				},
+			},
+		})
+	}
+	// v2.9.105: add_upstream_timing_header — inject X-Upstream-Time response header with upstream latency.
+	if p.AddUpstreamTimingHeader {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"X-Upstream-Time": []any{"{http.reverse_proxy.upstream.duration}"},
+				},
+			},
+		})
+	}
+	// v2.9.126: add_via_header — add Via response header identifying this proxy (1.1 caddy).
+	if p.AddViaHeader {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"add": map[string]any{
+					"Via": []any{"1.1 caddy"},
+				},
+			},
+		})
+	}
+	// v2.9.132: add_timing_allow_origin — set Timing-Allow-Origin header to enable Resource Timing API.
+	if p.AddTimingAllowOrigin != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Timing-Allow-Origin": []any{p.AddTimingAllowOrigin},
+				},
+			},
+		})
+	}
+	// v2.9.134: cross_origin_opener_policy — isolate browsing context from cross-origin documents.
+	if p.CrossOriginOpenerPolicy != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Cross-Origin-Opener-Policy": []any{p.CrossOriginOpenerPolicy},
+				},
+			},
+		})
+	}
+	// v2.9.135: cross_origin_resource_policy — control which origins can include this resource.
+	if p.CrossOriginResourcePolicy != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Cross-Origin-Resource-Policy": []any{p.CrossOriginResourcePolicy},
+				},
+			},
+		})
+	}
+	// v2.9.136: cross_origin_embedder_policy — require CORP for embedded sub-resources.
+	if p.CrossOriginEmbedderPolicy != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Cross-Origin-Embedder-Policy": []any{p.CrossOriginEmbedderPolicy},
+				},
+			},
+		})
+	}
+	// v2.9.106: strip_server_header — delete Server response header from upstream replies.
+	if p.StripServerHeader {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"delete": []any{"Server"},
+			},
+		})
+	}
+	// v2.9.162: add_clear_site_data — set Clear-Site-Data response header (e.g. "cache","cookies","storage").
+	if p.AddClearSiteData != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Clear-Site-Data": []any{p.AddClearSiteData},
+				},
+			},
+		})
+	}
+	// v2.9.163: add_x_dns_prefetch_control — set X-DNS-Prefetch-Control: off to prevent DNS prefetching.
+	if p.AddXDNSPrefetchControl {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"X-DNS-Prefetch-Control": []any{"off"},
+				},
+			},
+		})
+	}
+	// v2.9.164: add_accept_ranges — set Accept-Ranges: bytes to signal byte-range support.
+	if p.AddAcceptRanges {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Accept-Ranges": []any{"bytes"},
+				},
+			},
+		})
+	}
+	// v2.9.165: add_content_disposition — set Content-Disposition response header.
+	if p.AddContentDisposition != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Content-Disposition": []any{p.AddContentDisposition},
+				},
+			},
+		})
+	}
+	// v2.9.167: add_x_permitted_cross_domain_policies — set X-Permitted-Cross-Domain-Policies response header.
+	if p.AddXPermittedCrossDomainPolicies != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"X-Permitted-Cross-Domain-Policies": []any{p.AddXPermittedCrossDomainPolicies},
+				},
+			},
+		})
+	}
+	// v2.9.168: strip_response_headers — delete comma-separated list of response headers from upstream replies.
+	if p.StripResponseHeaders != "" {
+		delList := []any{}
+		for _, h := range strings.Split(p.StripResponseHeaders, ",") {
+			h = strings.TrimSpace(h)
+			if h != "" {
+				delList = append(delList, h)
+			}
+		}
+		if len(delList) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler": "headers",
+				"response": map[string]any{
+					"delete": delList,
+				},
+			})
+		}
+	}
+	// v2.9.169: add_report_to — set Report-To response header (JSON endpoint group for CSP/NEL reporting).
+	if p.AddReportTo != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Report-To": []any{p.AddReportTo},
+				},
+			},
+		})
+	}
+	// v2.9.170: add_nel_header — set NEL (Network Error Logging) response header.
+	if p.AddNELHeader != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Nel": []any{p.AddNELHeader},
+				},
+			},
+		})
+	}
+	// v2.9.171: block_http_methods — reject listed HTTP methods with 405 Method Not Allowed.
+	if p.BlockHTTPMethods != "" {
+		for _, method := range strings.Split(p.BlockHTTPMethods, ",") {
+			method = strings.TrimSpace(strings.ToUpper(method))
+			if method == "" {
+				continue
+			}
+			handlers = append(handlers, map[string]any{
+				"handler": "subroute",
+				"routes": []any{
+					map[string]any{
+						"match": []any{
+							map[string]any{"method": []any{method}},
+						},
+						"handle": []any{
+							map[string]any{
+								"handler":     "static_response",
+								"status_code": 405,
+								"headers": map[string]any{
+									"Allow": []any{"GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS"},
+								},
+							},
+						},
+					},
+				},
+			})
+		}
+	}
+	// v2.9.172: add_service_worker_allowed — set Service-Worker-Allowed response header to expand SW scope.
+	if p.AddServiceWorkerAllowed != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Service-Worker-Allowed": []any{p.AddServiceWorkerAllowed},
+				},
+			},
+		})
+	}
+	// v2.9.173: add_accept_ch — set Accept-CH response header to declare supported client hints.
+	if p.AddAcceptCH != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Accept-Ch": []any{p.AddAcceptCH},
+				},
+			},
+		})
+	}
+	// v2.9.174: add_alt_svc — set Alt-Svc response header to advertise alternative services.
+	if p.AddAltSvc != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Alt-Svc": []any{p.AddAltSvc},
+				},
+			},
+		})
+	}
+	// v2.9.175: add_content_language — set Content-Language response header.
+	if p.AddContentLanguage != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Content-Language": []any{p.AddContentLanguage},
+				},
+			},
+		})
+	}
+	// v2.9.176: add_critical_ch — set Critical-CH response header (marks required client hints).
+	if p.AddCriticalCH != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Critical-Ch": []any{p.AddCriticalCH},
+				},
+			},
+		})
+	}
+	// v2.9.177: add_x_download_options — set X-Download-Options: noopen to prevent IE auto-open.
+	if p.AddXDownloadOptions {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"X-Download-Options": []any{"noopen"},
+				},
+			},
+		})
+	}
+	// v2.9.178: deny_user_agent_regexp — block requests whose User-Agent matches the regexp with 403.
+	if p.DenyUserAgentRegexp != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{
+						map[string]any{
+							"header_regexp": map[string]any{
+								"User-Agent": map[string]any{
+									"pattern": p.DenyUserAgentRegexp,
+								},
+							},
+						},
+					},
+					"handle": []any{
+						map[string]any{
+							"handler":     "static_response",
+							"status_code": 403,
+						},
+					},
+				},
+			},
+		})
+	}
+	// v2.9.200: add_x_no_archive — set X-No-Archive: yes response header to block archive caching.
+	if p.AddXNoArchive {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"X-No-Archive": []any{"yes"},
+				},
+			},
+		})
+	}
+	// v2.9.201: add_x_request_hostname — forward X-Request-Hostname request header to upstream.
+	if p.AddXRequestHostname {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Request-Hostname": []any{"{http.request.hostname}"},
+				},
+			},
+		})
+	}
+	// v2.9.202: add_x_xss_protection_disabled — set X-XSS-Protection: 0 response header (disable legacy XSS filter).
+	if p.AddXXSSProtectionDisabled {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"X-Xss-Protection": []any{"0"},
+				},
+			},
+		})
+	}
+	// v2.9.197: add_x_request_referer — forward X-Request-Referer request header (echoes Referer) to upstream.
+	if p.AddXRequestReferer {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Request-Referer": []any{"{http.request.header.Referer}"},
+				},
+			},
+		})
+	}
+	// v2.9.198: add_x_request_origin — forward X-Request-Origin request header (echoes Origin) to upstream.
+	if p.AddXRequestOrigin {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Request-Origin": []any{"{http.request.header.Origin}"},
+				},
+			},
+		})
+	}
+	// v2.9.199: add_x_forwarded_uri — forward X-Forwarded-URI request header (full request URI) to upstream.
+	if p.AddXForwardedURI {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Forwarded-Uri": []any{"{http.request.uri}"},
+				},
+			},
+		})
+	}
+	// v2.9.194: add_x_forwarded_email — set static X-Forwarded-Email request header on upstream calls.
+	if p.AddXForwardedEmail != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Forwarded-Email": []any{p.AddXForwardedEmail},
+				},
+			},
+		})
+	}
+	// v2.9.195: add_x_forwarded_roles — set static X-Forwarded-Roles request header on upstream calls.
+	if p.AddXForwardedRoles != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Forwarded-Roles": []any{p.AddXForwardedRoles},
+				},
+			},
+		})
+	}
+	// v2.9.196: block_query_param_regexp — return 403 when the request's raw query string matches the regexp.
+	if p.BlockQueryParamRegexp != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{
+						map[string]any{
+							"expression": fmt.Sprintf("{http.request.uri.query} matches '%s'", strings.ReplaceAll(p.BlockQueryParamRegexp, "'", "\\'")),
+						},
+					},
+					"handle": []any{
+						map[string]any{
+							"handler":     "static_response",
+							"status_code": 403,
+						},
+					},
+				},
+			},
+		})
+	}
+	// v2.9.191: add_x_real_scheme — forward X-Real-Scheme request header (http or https) to upstream.
+	if p.AddXRealScheme {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Real-Scheme": []any{"{http.request.scheme}"},
+				},
+			},
+		})
+	}
+	// v2.9.192: add_origin_agent_cluster — set Origin-Agent-Cluster: ?1 response header.
+	if p.AddOriginAgentCluster {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Origin-Agent-Cluster": []any{"?1"},
+				},
+			},
+		})
+	}
+	// v2.9.193: add_x_forwarded_groups — set static X-Forwarded-Groups request header on upstream calls.
+	if p.AddXForwardedGroups != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Forwarded-Groups": []any{p.AddXForwardedGroups},
+				},
+			},
+		})
+	}
+	// v2.9.188: add_x_request_method — forward X-Request-Method request header (echoes HTTP method) to upstream.
+	if p.AddXRequestMethod {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Request-Method": []any{"{http.request.method}"},
+				},
+			},
+		})
+	}
+	// v2.9.189: add_x_request_query — forward X-Request-Query request header (echoes query string) to upstream.
+	if p.AddXRequestQuery {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Request-Query": []any{"{http.request.uri.query}"},
+				},
+			},
+		})
+	}
+	// v2.9.190: add_x_forwarded_user — set static X-Forwarded-User request header on upstream calls.
+	if p.AddXForwardedUser != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Forwarded-User": []any{p.AddXForwardedUser},
+				},
+			},
+		})
+	}
+	// v2.9.185: add_age_zero — set Age: 0 response header to signal a fresh response (CDN bypass).
+	if p.AddAgeZero {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Age": []any{"0"},
+				},
+			},
+		})
+	}
+	// v2.9.186: add_surrogate_control — set Surrogate-Control response header (CDN-only cache directive).
+	if p.AddSurrogateControl != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Surrogate-Control": []any{p.AddSurrogateControl},
+				},
+			},
+		})
+	}
+	// v2.9.187: add_warning_header — set Warning response header (RFC 7234 warning codes).
+	if p.AddWarningHeader != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Warning": []any{p.AddWarningHeader},
+				},
+			},
+		})
+	}
+	// v2.9.182: add_x_clacks_overhead — set X-Clacks-Overhead response header (custom value).
+	if p.AddXClacksOverhead != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"X-Clacks-Overhead": []any{p.AddXClacksOverhead},
+				},
+			},
+		})
+	}
+	// v2.9.183: add_x_ua_compatible — set X-UA-Compatible response header (legacy IE rendering).
+	if p.AddXUACompatible != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"X-Ua-Compatible": []any{p.AddXUACompatible},
+				},
+			},
+		})
+	}
+	// v2.9.179: add_pragma_no_cache — set Pragma: no-cache response header (HTTP/1.0 cache directive).
+	if p.AddPragmaNoCache {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Pragma": []any{"no-cache"},
+				},
+			},
+		})
+	}
+	// v2.9.181: add_x_request_path — inject X-Request-Path request header on upstream calls.
+	if p.AddXRequestPath {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Request-Path": []any{"{http.request.uri.path}"},
+				},
+			},
+		})
+	}
+	// v2.9.156: add_document_policy — set Document-Policy response header for web platform feature controls.
+	if p.AddDocumentPolicy != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Document-Policy": []any{p.AddDocumentPolicy},
+				},
+			},
+		})
+	}
+	// v2.9.154: add_x_powered_by — set a custom X-Powered-By response header.
+	if p.AddXPoweredBy != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"X-Powered-By": []any{p.AddXPoweredBy},
+				},
+			},
+		})
+	}
+	// v2.9.131: strip_x_powered_by — delete X-Powered-By response header (hides technology stack).
+	if p.StripXPoweredBy {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"delete": []any{"X-Powered-By"},
+			},
+		})
+	}
+	// v2.9.103: add_resp_cookies — append Set-Cookie headers to every response.
+	if p.AddRespCookies != "" {
+		cookies := []any{}
+		for _, line := range strings.Split(p.AddRespCookies, "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" && !strings.HasPrefix(line, "#") {
+				cookies = append(cookies, line)
+			}
+		}
+		if len(cookies) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler": "headers",
+				"response": map[string]any{
+					"add": map[string]any{
+						"Set-Cookie": cookies,
+					},
+				},
+			})
+		}
+	}
+	// v2.9.80: server_header_value — override (or suppress) the Server response header.
+	if p.ServerHeaderValue != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Server": []any{p.ServerHeaderValue},
+				},
+			},
+		})
+	}
+	// v2.9.81: x_robots_tag — X-Robots-Tag response header for search-engine control.
+	if p.XRobotsTag != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"X-Robots-Tag": []any{p.XRobotsTag},
+				},
+			},
+		})
+	}
+	// v2.9.82: add_forwarded_header — inject RFC 7239 Forwarded header on upstream requests.
+	if p.AddForwardedHeader {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"Forwarded": []any{"for={http.request.remote.host};proto={http.request.scheme};host={http.request.host}"},
+				},
+			},
+		})
+	}
+	// v2.9.76: add_canonical_link_header — inject Link: <https://primary/>; rel="canonical".
+	if p.AddCanonicalLinkHeader && len(domains) > 0 {
+		canonical := fmt.Sprintf("<https://%s/>; rel=\"canonical\"", domains[0])
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Link": []any{canonical},
+				},
+			},
+		})
+	}
+	// v2.9.3: CORS headers — preflight (OPTIONS) handling + response headers.
+	// v2.9.8: extended with cors_allow_credentials and cors_expose_headers.
+	// v2.9.19: cors_max_age_sec, cors_allow_methods, cors_allow_headers overrides.
+	if p.CORSEnabled {
+		origins := strings.TrimSpace(p.CORSOrigins)
+		if origins == "" {
+			origins = "*"
+		}
+		corsAllowMethods := "GET, POST, PUT, DELETE, PATCH, OPTIONS"
+		if p.CORSAllowMethods != "" {
+			corsAllowMethods = p.CORSAllowMethods
+		}
+		corsAllowHeaders := "Content-Type, Authorization, X-Requested-With"
+		if p.CORSAllowHeaders != "" {
+			corsAllowHeaders = p.CORSAllowHeaders
+		}
+		corsMaxAge := "86400"
+		if p.CORSMaxAgeSec > 0 {
+			corsMaxAge = fmt.Sprintf("%d", p.CORSMaxAgeSec)
+		}
+		preflightHdrs := map[string]any{
+			"Access-Control-Allow-Origin":  []any{origins},
+			"Access-Control-Allow-Methods": []any{corsAllowMethods},
+			"Access-Control-Allow-Headers": []any{corsAllowHeaders},
+			"Access-Control-Max-Age":       []any{corsMaxAge},
+		}
+		respHdrs := map[string]any{
+			"Access-Control-Allow-Origin":  []any{origins},
+			"Access-Control-Allow-Methods": []any{corsAllowMethods},
+			"Access-Control-Allow-Headers": []any{corsAllowHeaders},
+		}
+		if p.CORSAllowCredentials {
+			preflightHdrs["Access-Control-Allow-Credentials"] = []any{"true"}
+			respHdrs["Access-Control-Allow-Credentials"] = []any{"true"}
+		}
+		if p.CORSExposeHeaders != "" {
+			respHdrs["Access-Control-Expose-Headers"] = []any{p.CORSExposeHeaders}
+		}
+		// v2.9.66: cors_allow_private_network — Chrome Private Network Access CORS extension.
+		if p.CORSAllowPrivateNetwork {
+			preflightHdrs["Access-Control-Allow-Private-Network"] = []any{"true"}
+		}
+		// Handle OPTIONS preflight: respond immediately with 204.
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{map[string]any{"method": []any{"OPTIONS"}}},
+					"handle": []any{
+						map[string]any{
+							"handler":  "headers",
+							"response": map[string]any{"set": preflightHdrs},
+						},
+						map[string]any{"handler": "static_response", "status_code": 204},
+					},
+					"terminal": true,
+				},
+			},
+		})
+		// For non-OPTIONS requests: add CORS headers to the response.
+		handlers = append(handlers, map[string]any{
+			"handler":  "headers",
+			"response": map[string]any{"set": respHdrs},
+		})
+	}
+	// v2.9.152: add_cors_vary_header — add Vary: Origin for correct CDN caching of CORS responses.
+	if p.AddCORSVaryHeader {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"add": map[string]any{
+					"Vary": []any{"Origin"},
+				},
+			},
+		})
+	}
+	// v2.9.2: URL rewrite rules — each rule becomes a Caddy `rewrite` handler.
+	// strip_prefix: chop a leading path segment via regexp.
+	// add_prefix: prepend a path prefix via static_response placeholder.
+	// regex: apply a regexp substitution to the path.
+	for _, rule := range p.URLRewriteList() {
+		from := strings.TrimSpace(rule.From)
+		to := strings.TrimSpace(rule.To)
+		if from == "" {
+			continue
+		}
+		switch rule.Type {
+		case "strip_prefix":
+			// Rewrite /prefix/rest → /rest
+			handlers = append(handlers, map[string]any{
+				"handler":            "rewrite",
+				"strip_path_prefix": from,
+			})
+		case "add_prefix":
+			// Rewrite /path → /prefix/path
+			handlers = append(handlers, map[string]any{
+				"handler": "rewrite",
+				"uri":     from + "{http.request.uri}",
+			})
+		case "regex":
+			if to == "" {
+				to = "/"
+			}
+			handlers = append(handlers, map[string]any{
+				"handler": "rewrite",
+				"uri": map[string]any{
+					"path": map[string]any{
+						"find":    from,
+						"replace": to,
+					},
+				},
+			})
+		}
+	}
+	// v2.9.67: robots_txt_disallow_all — serve "User-agent: *\nDisallow: /" for all bots.
+	if p.RobotsTxtDisallowAll {
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{map[string]any{
+						"path":   []any{"/robots.txt"},
+						"method": []any{"GET", "HEAD"},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 200,
+						"headers":     map[string]any{"Content-Type": []any{"text/plain; charset=utf-8"}},
+						"body":        "User-agent: *\nDisallow: /",
+					}},
+					"terminal": true,
+				},
+			},
+		})
+	}
+	// v2.9.5: custom robots.txt — intercept GET/HEAD /robots.txt and serve
+	// the configured body before the request reaches the upstream.
+	if p.RobotsTxt != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{map[string]any{
+						"path":   []any{"/robots.txt"},
+						"method": []any{"GET", "HEAD"},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 200,
+						"headers":     map[string]any{"Content-Type": []any{"text/plain; charset=utf-8"}},
+						"body":        p.RobotsTxt,
+					}},
+					"terminal": true,
+				},
+			},
+		})
+	}
+	// v2.9.79: security_txt_body — serve custom security.txt at /.well-known/security.txt.
+	if p.SecurityTxtBody != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{map[string]any{
+						"path":   []any{"/.well-known/security.txt"},
+						"method": []any{"GET", "HEAD"},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 200,
+						"headers":     map[string]any{"Content-Type": []any{"text/plain; charset=utf-8"}},
+						"body":        p.SecurityTxtBody,
+					}},
+					"terminal": true,
+				},
+			},
+		})
+	}
+	// v2.9.92: http2_push_paths — push static resources via HTTP/2 server push.
+	if p.HTTP2PushPaths != "" {
+		var resources []any
+		for _, path := range strings.Split(p.HTTP2PushPaths, "\n") {
+			path = strings.TrimSpace(path)
+			if path != "" && !strings.HasPrefix(path, "#") {
+				resources = append(resources, map[string]any{"path": path})
+			}
+		}
+		if len(resources) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler":   "push",
+				"resources": resources,
+			})
+		}
+	}
+	// v2.9.93: deny_content_types — reject requests whose Content-Type matches a blocked prefix (415).
+	if p.DenyContentTypes != "" {
+		var typePatterns []any
+		for _, ct := range strings.Split(p.DenyContentTypes, ",") {
+			ct = strings.TrimSpace(ct)
+			if ct != "" {
+				typePatterns = append(typePatterns, ct+"*")
+			}
+		}
+		if len(typePatterns) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler": "subroute",
+				"routes": []any{
+					map[string]any{
+						"match": []any{map[string]any{
+							"header": map[string]any{
+								"Content-Type": typePatterns,
+							},
+						}},
+						"handle": []any{map[string]any{
+							"handler":     "static_response",
+							"status_code": 415,
+							"body":        "Unsupported Media Type.\n",
+						}},
+						"terminal": true,
+					},
+				},
+			})
+		}
+	}
+	// v2.9.3: request body size limit (Caddy request_body handler).
+	// v2.9.29: also sets read_timeout when RequestBodyReadTimeoutSec > 0.
+	if p.MaxRequestBodyMB > 0 || p.RequestBodyReadTimeoutSec > 0 {
+		rbHandler := map[string]any{"handler": "request_body"}
+		if p.MaxRequestBodyMB > 0 {
+			rbHandler["max_size"] = int64(p.MaxRequestBodyMB) * 1024 * 1024
+		}
+		if p.RequestBodyReadTimeoutSec > 0 {
+			rbHandler["read_timeout"] = fmt.Sprintf("%ds", p.RequestBodyReadTimeoutSec)
+		}
+		handlers = append(handlers, rbHandler)
+	}
+	// v2.9.3: maintenance mode — serve 503 with a simple HTML body instead
+	// of forwarding to the upstream. Also honoured during a scheduled window.
+	if p.MaintenanceMode || p.InScheduledMaintenanceWindow() {
+		maintenanceBody := `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Maintenance</title><style>*{box-sizing:border-box}body{font-family:system-ui,sans-serif;background:#f8fafc;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}.card{background:#fff;border-radius:16px;padding:40px 48px;text-align:center;box-shadow:0 4px 32px rgba(0,0,0,.08);max-width:480px}h1{font-size:1.5rem;color:#1e293b;margin:16px 0 8px}p{color:#64748b;font-size:.95rem;line-height:1.6;margin:0}</style></head><body><div class="card"><svg width="48" height="48" fill="none" stroke="#f59e0b" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 010-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 01-1.44-4.282m3.102.069a18.03 18.03 0 01-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 018.835 2.535M10.34 6.66a23.847 23.847 0 008.835-2.535m0 0A23.74 23.74 0 0018.795 3m.38 1.125a23.91 23.91 0 011.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 001.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 010 3.46"/></svg><h1>Down for Maintenance</h1><p>` + htmlEscape(msgOrDefault(p.MaintenanceMsg, "We're making improvements and will be back shortly. Thank you for your patience.")) + `</p></div></body></html>`
+		maintHeaders := map[string]any{
+			"Content-Type": []any{"text/html; charset=utf-8"},
+			"Retry-After":  []any{func() string { if p.MaintenanceRetryAfterSec > 0 { return strconv.Itoa(p.MaintenanceRetryAfterSec) }; return "3600" }()},
+		}
+		// v2.9.100: maintenance_custom_headers — extra "Name: Value" headers on the 503 response.
+		if p.MaintenanceCustomHeaders != "" {
+			for _, line := range strings.Split(p.MaintenanceCustomHeaders, "\n") {
+				line = strings.TrimSpace(line)
+				if line == "" || strings.HasPrefix(line, "#") {
+					continue
+				}
+				if idx := strings.IndexByte(line, ':'); idx > 0 {
+					name := strings.TrimSpace(line[:idx])
+					val := strings.TrimSpace(line[idx+1:])
+					if name != "" {
+						maintHeaders[name] = []any{val}
+					}
+				}
+			}
+		}
+		var maintHandler map[string]any
+		// v2.9.157: maintenance_redirect_url — redirect to external page instead of inline 503.
+		if p.MaintenanceRedirectURL != "" {
+			maintHandler = map[string]any{
+				"handler":     "static_response",
+				"status_code": 302,
+				"headers": map[string]any{
+					"Location": []any{p.MaintenanceRedirectURL},
+				},
+			}
+		} else {
+			maintHandler = map[string]any{
+				"handler":     "static_response",
+				"status_code": maintenanceStatusCode(p.MaintenanceStatusCode),
+				"headers":     maintHeaders,
+				"body":        maintenanceBody,
+			}
+		}
+		// v2.9.118: maintenance_allowed_ips — IPs/CIDRs that bypass maintenance and reach the upstream.
+		if p.MaintenanceAllowedIPs != "" {
+			var allowedRanges []any
+			for _, cidr := range strings.Split(p.MaintenanceAllowedIPs, ",") {
+				cidr = strings.TrimSpace(cidr)
+				if cidr != "" {
+					allowedRanges = append(allowedRanges, cidr)
+				}
+			}
+			if len(allowedRanges) > 0 {
+				handlers = append(handlers, map[string]any{
+					"handler": "subroute",
+					"routes": []any{map[string]any{
+						"match": []any{map[string]any{
+							"not": []any{map[string]any{
+								"remote_ip": map[string]any{"ranges": allowedRanges},
+							}},
+						}},
+						"handle":   []any{maintHandler},
+						"terminal": true,
+					}},
+				})
+			} else {
+				handlers = append(handlers, maintHandler)
+			}
+		} else {
+			handlers = append(handlers, maintHandler)
+		}
+		// Still append advancedHandlers so custom error_pages/rate_limit work,
+		// but skip the reverse_proxy by returning early from handler chain.
+		// (Caddy will short-circuit after static_response.)
+	}
+	// Feature A: Inject X-Request-Id (or custom header) for distributed tracing.
+	if p.AddRequestID {
+		ridHeader := p.RequestIDHeaderName
+		if ridHeader == "" {
+			ridHeader = "X-Request-Id"
+		}
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					ridHeader: []any{"{http.request.uuid}"},
+				},
+			},
+		})
+		// v2.9.147: add_request_id_to_response — echo the request trace ID in the response header.
+		if p.AddRequestIDToResponse {
+			handlers = append(handlers, map[string]any{
+				"handler": "headers",
+				"response": map[string]any{
+					"set": map[string]any{
+						ridHeader: []any{"{http.request.header." + ridHeader + "}"},
+					},
+				},
+			})
+		}
+	}
+	// v2.9.102: inject_request_timestamp — add X-Request-Timestamp header with the UNIX epoch.
+	if p.InjectRequestTimestamp {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Request-Timestamp": []any{"{time.now.unix}"},
+				},
+			},
+		})
+	}
+	// v2.9.140: add_x_request_start — inject X-Request-Start with millisecond epoch for APM tools.
+	if p.AddXRequestStart {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Request-Start": []any{"t={time.now.unix_ms}"},
+				},
+			},
+		})
+	}
+	// v2.9.104: strip_accept_encoding — delete Accept-Encoding before forwarding to prevent upstream compression.
+	if p.StripAcceptEncoding {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"delete": []any{"Accept-Encoding"},
+			},
+		})
+	}
+	// v2.9.129: force_upstream_encoding — override Accept-Encoding sent to upstream (e.g. "gzip","identity","br").
+	if p.ForceUpstreamEncoding != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"Accept-Encoding": []any{p.ForceUpstreamEncoding},
+				},
+			},
+		})
+	}
+	// v2.9.109: strip_authorization_header — delete Authorization before forwarding (for proxy-level auth replacement).
+	if p.StripAuthorizationHeader {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"delete": []any{"Authorization"},
+			},
+		})
+	}
+	// v2.9.110: real_ip_from_header — copy real client IP from a custom header into X-Real-IP.
+	if p.RealIPFromHeader != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Real-IP": []any{"{http.request.header." + p.RealIPFromHeader + "}"},
+				},
+			},
+		})
+	}
+	// v2.9.112: add_x_forwarded_port — add X-Forwarded-Port with the incoming request port.
+	if p.AddXForwardedPort {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Forwarded-Port": []any{"{http.request.port}"},
+				},
+			},
+		})
+	}
+	// v2.9.117: add_x_forwarded_host — inject X-Forwarded-Host with the original Host value.
+	if p.AddXForwardedHost {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Forwarded-Host": []any{"{http.request.host}"},
+				},
+			},
+		})
+	}
+	// v2.9.143: add_x_forwarded_scheme — inject X-Forwarded-Scheme with the client-facing scheme.
+	if p.AddXForwardedScheme {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Forwarded-Scheme": []any{"{http.request.scheme}"},
+				},
+			},
+		})
+	}
+	// v2.9.159: add_origin_header — inject Origin request header for upstream APIs that require it.
+	if p.AddOriginHeader != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"Origin": []any{p.AddOriginHeader},
+				},
+			},
+		})
+	}
+	// v2.9.149: add_x_real_ip — inject X-Real-IP with the direct client IP.
+	if p.AddXRealIP {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"set": map[string]any{
+					"X-Real-IP": []any{"{http.request.remote.host}"},
+				},
+			},
+		})
+	}
+	// v2.9.150: strip_incoming_x_forwarded_for — delete X-Forwarded-For to prevent IP spoofing.
+	if p.StripIncomingXForwardedFor {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"request": map[string]any{
+				"delete": []any{"X-Forwarded-For"},
+			},
+		})
+	}
+	// Feature B: Strip configured response headers from upstream replies.
+	if toStrip := p.StripRespHeaderList(); len(toStrip) > 0 {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"delete": toStrip,
+			},
+		})
+	}
+	// Feature C: Block requests from listed user-agent patterns (case-insensitive regex OR).
+	if p.BlockedAgents != "" {
+		var patterns []string
+		for _, a := range strings.Split(p.BlockedAgents, ",") {
+			a = strings.TrimSpace(a)
+			if a != "" {
+				patterns = append(patterns, regexp.QuoteMeta(a))
+			}
+		}
+		if len(patterns) > 0 {
+			combined := strings.Join(patterns, "|")
+			handlers = append(handlers, map[string]any{
+				"handler": "subroute",
+				"routes": []any{
+					map[string]any{
+						"match": []any{map[string]any{
+							"header_regexp": map[string]any{
+								"User-Agent": "(?i)(" + combined + ")",
+							},
+						}},
+						"handle": []any{map[string]any{
+							"handler":     "static_response",
+							"status_code": 403,
+							"body":        "Access denied.\n",
+						}},
+						"terminal": true,
+					},
+				},
+			})
+		}
+	}
+	// v2.9.78: block_ua_regexp — block requests whose User-Agent matches the Go regexp (403).
+	if p.BlockUARegexp != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{map[string]any{
+						"header_regexp": map[string]any{
+							"User-Agent": p.BlockUARegexp,
+						},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 403,
+						"body":        "Access denied.\n",
+					}},
+					"terminal": true,
+				},
+			},
+		})
+	}
+	// v2.9.107: block_referer_regexp — block requests whose Referer header matches the Go regexp (hotlink protection).
+	if p.BlockRefererRegexp != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{
+				map[string]any{
+					"match": []any{map[string]any{
+						"header_regexp": map[string]any{
+							"Referer": p.BlockRefererRegexp,
+						},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 403,
+						"body":        "Access denied.\n",
+					}},
+					"terminal": true,
+				},
+			},
+		})
+	}
+	// v2.9.137: deny_request_content_type — block requests whose Content-Type matches a configured MIME type.
+	if p.DenyRequestContentType != "" {
+		var typePatterns []string
+		for _, ct := range strings.Split(p.DenyRequestContentType, ",") {
+			ct = strings.TrimSpace(ct)
+			if ct != "" {
+				typePatterns = append(typePatterns, regexp.QuoteMeta(ct))
+			}
+		}
+		if len(typePatterns) > 0 {
+			combined := "(?i)(" + strings.Join(typePatterns, "|") + ")"
+			handlers = append(handlers, map[string]any{
+				"handler": "subroute",
+				"routes": []any{map[string]any{
+					"match": []any{map[string]any{
+						"header_regexp": map[string]any{"Content-Type": combined},
+					}},
+					"handle": []any{map[string]any{
+						"handler":     "static_response",
+						"status_code": 415,
+						"body":        "Unsupported Media Type\n",
+					}},
+					"terminal": true,
+				}},
+			})
+		}
+	}
+	// v2.9.121: deny_referer_empty — block requests that carry no Referer header (prevents direct hotlinking).
+	if p.DenyRefererEmpty {
+		handlers = append(handlers, map[string]any{
+			"handler": "subroute",
+			"routes": []any{map[string]any{
+				"match": []any{map[string]any{
+					"not": []any{map[string]any{
+						"header": map[string]any{"Referer": []any{"*"}},
+					}},
+				}},
+				"handle": []any{map[string]any{
+					"handler":     "static_response",
+					"status_code": 403,
+					"body":        "Access denied.\n",
+				}},
+				"terminal": true,
+			}},
+		})
+	}
+	// v2.9.108: add_content_type_nosniff — add X-Content-Type-Options: nosniff response header.
+	if p.AddContentTypeNosniff {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"X-Content-Type-Options": []any{"nosniff"},
+				},
+			},
+		})
+	}
+	// Inject or override Cache-Control response header.
+	if p.ResponseCacheControl != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Cache-Control": []any{p.ResponseCacheControl},
+				},
+			},
+		})
+	}
+	// v2.9.128: add_expect_ct_header — add Expect-CT: enforce response header for certificate transparency.
+	if p.AddExpectCTHeader {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Expect-CT": []any{"enforce"},
+				},
+			},
+		})
+	}
+	// v2.9.139: add_cache_control_public — add Cache-Control: public response header for CDN caching.
+	if p.AddCacheControlPublic {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Cache-Control": []any{"public"},
+				},
+			},
+		})
+	}
+	// v2.9.120: add_cache_control_no_store — force Cache-Control: no-store on all responses.
+	if p.AddCacheControlNoStore {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Cache-Control": []any{"no-store"},
+				},
+			},
+		})
+	}
+	// v2.9.144: response_cache_ttl_sec — set Cache-Control: max-age=N on responses.
+	if p.ResponseCacheTTLSec > 0 {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Cache-Control": []any{fmt.Sprintf("max-age=%d", p.ResponseCacheTTLSec)},
+				},
+			},
+		})
+	}
+	// v2.9.145: add_link_preload — set Link response header for HTTP/2 preload hints.
+	if p.AddLinkPreload != "" {
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Link": []any{p.AddLinkPreload},
+				},
+			},
+		})
+	}
+	// v2.9.11: error_redirect_url takes priority over error_page_html — redirect
+	// the client to a custom URL instead of serving the error inline.
+	if p.ErrorRedirectURL != "" {
+		reverseProxy["handle_response"] = []any{
+			map[string]any{
+				"match": map[string]any{"status_code": []any{4, 5}},
+				"handle": []any{
+					map[string]any{
+						"handler":     "static_response",
+						"status_code": 302,
+						"headers":     map[string]any{"Location": []any{p.ErrorRedirectURL}},
+					},
+				},
+			},
+		}
+	} else if p.ErrorPageHTML != "" {
+		// v2.9.58: error_page_codes — if set, only intercept these specific codes.
+		var epMatch map[string]any
+		if p.ErrorPageCodes != "" {
+			var codes []any
+			for _, cs := range strings.Split(p.ErrorPageCodes, ",") {
+				cs = strings.TrimSpace(cs)
+				if code, err := strconv.Atoi(cs); err == nil && code >= 100 && code <= 599 {
+					codes = append(codes, code)
+				}
+			}
+			if len(codes) > 0 {
+				epMatch = map[string]any{"status_code": codes}
+			}
+		}
+		if epMatch == nil {
+			epMatch = map[string]any{"status_code": []any{4, 5}}
+		}
+		reverseProxy["handle_response"] = []any{
+			map[string]any{
+				"match": epMatch,
+				"handle": []any{
+					map[string]any{
+						"handler":     "static_response",
+						"status_code": "{http.reverse_proxy.status_code}",
+						"headers":     map[string]any{"Content-Type": []any{"text/html; charset=utf-8"}},
+						"body":        p.ErrorPageHTML,
+					},
+				},
+			},
+		}
+	}
 	handlers = append(handlers, advancedHandlers...)
+
+	// v2.9.28: query string control — strip or selectively delete query params before forwarding.
+	if p.StripQueryString {
+		// Drop the entire query string by rewriting the URI to the path only.
+		handlers = append(handlers, map[string]any{
+			"handler": "rewrite",
+			"uri":     "{http.request.uri.path}",
+		})
+	} else if p.DeleteQueryParams != "" {
+		// Delete specific query parameters (e.g. tracking IDs) while keeping the rest.
+		var delParams []any
+		for _, q := range strings.Split(p.DeleteQueryParams, ",") {
+			q = strings.TrimSpace(q)
+			if q != "" {
+				delParams = append(delParams, q)
+			}
+		}
+		if len(delParams) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler": "rewrite",
+				"query": map[string]any{
+					"delete": delParams,
+				},
+			})
+		}
+	}
+
+	// v2.9.27: forward_auth — delegate authentication to an external service.
+	// If the auth service returns non-2xx the response is sent to the client
+	// directly (typically 401/403). On 2xx, configured headers are copied to
+	// the upstream request and the proxy continues normally.
+	if p.ForwardAuthURL != "" {
+		faHandler := map[string]any{
+			"handler": "forward_auth",
+			"uri":     p.ForwardAuthURL,
+		}
+		// v2.9.52: forward_auth_method — HTTP method for the auth subrequest (default GET).
+		if p.ForwardAuthMethod != "" && p.ForwardAuthMethod != "GET" {
+			faHandler["method"] = strings.ToUpper(p.ForwardAuthMethod)
+		}
+		// v2.9.54: forward_auth_headers_prefix — prefix applied to all copied headers.
+		if p.ForwardAuthHeadersPrefix != "" {
+			faHandler["headers_prefix"] = p.ForwardAuthHeadersPrefix
+		}
+		if p.ForwardAuthCopyHeaders != "" {
+			var hdrs []any
+			for _, h := range strings.Split(p.ForwardAuthCopyHeaders, ",") {
+				h = strings.TrimSpace(h)
+				if h != "" {
+					hdrs = append(hdrs, h)
+				}
+			}
+			if len(hdrs) > 0 {
+				faHandler["copy_headers"] = hdrs
+			}
+		}
+		// v2.9.184: forward_auth_skip_paths — wrap forward_auth in a subroute that skips
+		// listed path prefixes, so health/metrics/etc. bypass the auth subrequest.
+		if p.ForwardAuthSkipPaths != "" {
+			var skipPaths []any
+			for _, sp := range strings.Split(p.ForwardAuthSkipPaths, ",") {
+				sp = strings.TrimSpace(sp)
+				if sp == "" {
+					continue
+				}
+				if !strings.HasSuffix(sp, "*") {
+					sp = sp + "*"
+				}
+				skipPaths = append(skipPaths, sp)
+			}
+			if len(skipPaths) > 0 {
+				handlers = append(handlers, map[string]any{
+					"handler": "subroute",
+					"routes": []any{
+						map[string]any{
+							"match": []any{
+								map[string]any{
+									"not": []any{
+										map[string]any{"path": skipPaths},
+									},
+								},
+							},
+							"handle": []any{faHandler},
+						},
+					},
+				})
+			} else {
+				handlers = append(handlers, faHandler)
+			}
+		} else {
+			handlers = append(handlers, faHandler)
+		}
+	}
+
+	// v2.9.53: grpc_web_enabled — transcode gRPC-Web requests to standard gRPC for the upstream.
+	// Must be placed immediately before the reverse_proxy handler so it intercepts gRPC-Web
+	// Content-Type frames before the proxy forwards them.
+	if p.GRPCWebEnabled {
+		handlers = append(handlers, map[string]any{"handler": "grpc_web"})
+	}
+
+	// v2.9.16: strip path prefix before forwarding to upstream.
+	if p.StripPathPrefix && p.PathMatcher != "" {
+		prefix := strings.TrimRight(p.PathMatcher, "/*")
+		if prefix != "" {
+			handlers = append(handlers, map[string]any{
+				"handler":           "rewrite",
+				"strip_path_prefix": prefix,
+			})
+		}
+	}
+	// v2.9.36: upstream_path_prefix — prepend a static prefix to every upstream
+	// request URI (e.g. public / → upstream /v2/). Applied after path-prefix
+	// stripping so both options can be combined.
+	if p.UpstreamPathPrefix != "" {
+		pfx := "/" + strings.TrimLeft(p.UpstreamPathPrefix, "/")
+		handlers = append(handlers, map[string]any{
+			"handler": "rewrite",
+			"uri":     pfx + "{http.request.uri}",
+		})
+	}
+	// v2.9.56: strip_path_suffix — remove a static suffix from the request path before proxying.
+	if p.StripPathSuffix != "" {
+		handlers = append(handlers, map[string]any{
+			"handler":           "rewrite",
+			"strip_path_suffix": p.StripPathSuffix,
+		})
+	}
+	// v2.9.57: add_req_query_params — append key=value pairs to the upstream query string.
+	if p.AddReqQueryParams != "" {
+		addQuery := map[string][]string{}
+		for _, pair := range strings.FieldsFunc(p.AddReqQueryParams, func(r rune) bool {
+			return r == ',' || r == '\n'
+		}) {
+			pair = strings.TrimSpace(pair)
+			if pair == "" {
+				continue
+			}
+			parts := strings.SplitN(pair, "=", 2)
+			key := strings.TrimSpace(parts[0])
+			val := ""
+			if len(parts) == 2 {
+				val = strings.TrimSpace(parts[1])
+			}
+			if key != "" {
+				addQuery[key] = append(addQuery[key], val)
+			}
+		}
+		if len(addQuery) > 0 {
+			qAny := map[string]any{}
+			for k, vs := range addQuery {
+				qAny[k] = vs
+			}
+			handlers = append(handlers, map[string]any{
+				"handler": "rewrite",
+				"query":   map[string]any{"add": qAny},
+			})
+		}
+	}
 	handlers = append(handlers, reverseProxy)
 
+	// v2.9.16: path-based routing — narrow the match to a specific path prefix.
+	// v2.9.65: path_matcher_type controls how PathMatcher is applied.
+	matchObj := map[string]any{"host": asIfaceStrings(domains)}
+	if p.PathMatcher != "" {
+		switch p.PathMatcherType {
+		case "exact":
+			// Exact path match — only match this literal path (no wildcard).
+			matchObj["path"] = []any{p.PathMatcher}
+		case "regexp":
+			// Regular expression match against the path.
+			matchObj["path_regexp"] = map[string]any{"pattern": p.PathMatcher}
+		default:
+			// '' or "prefix" — legacy prefix matching behaviour.
+			prefix := strings.TrimRight(p.PathMatcher, "/*")
+			if prefix != "" {
+				matchObj["path"] = []any{prefix, prefix + "/*"}
+			}
+		}
+	}
 	return map[string]any{
-		"match":    []any{map[string]any{"host": asIfaceStrings(domains)}},
+		"match":    []any{matchObj},
 		"handle":   handlers,
 		"terminal": true,
 	}
@@ -300,7 +3103,30 @@ func ipAllowlistSubroute(cidrList []string) map[string]any {
 	}
 }
 
+// ipBlocklistSubroute returns a Caddy subroute handler that responds 403 to
+// any request whose remote IP matches one of the listed CIDR ranges.
+func ipBlocklistSubroute(cidrList []string) map[string]any {
+	ranges := make([]any, len(cidrList))
+	for i, c := range cidrList {
+		ranges[i] = c
+	}
+	return map[string]any{
+		"handler": "subroute",
+		"routes": []any{
+			map[string]any{
+				"match": []any{map[string]any{
+					"remote_ip": map[string]any{"ranges": ranges},
+				}},
+				"handle":   []any{map[string]any{"handler": "static_response", "status_code": 403}},
+				"terminal": true,
+			},
+		},
+	}
+}
+
 // BuildRedirectRoute constructs a single route for a redirection host.
+// v2.9.13: prepends IP allowlist subroute and/or maintenance-mode handler
+// before the redirect static_response when those features are enabled.
 func BuildRedirectRoute(r models.RedirectionHost) map[string]any {
 	domains := r.DomainList()
 	scheme := r.ForwardScheme
@@ -319,17 +3145,119 @@ func BuildRedirectRoute(r models.RedirectionHost) map[string]any {
 	if statusCode == 0 {
 		statusCode = 301
 	}
-	return map[string]any{
-		"match": []any{map[string]any{"host": asIfaceStrings(domains)}},
-		"handle": []any{
-			map[string]any{
-				"handler": "static_response",
-				"headers": map[string]any{
-					"Location": []any{location},
+
+	var handlers []any
+
+	// v2.9.26: advanced_config — raw JSON array of handlers injected before security checks.
+	if strings.TrimSpace(r.AdvancedConfig) != "" {
+		var adv []any
+		if err := json.Unmarshal([]byte(r.AdvancedConfig), &adv); err == nil {
+			handlers = append(handlers, adv...)
+		}
+	}
+
+	// v2.9.21: IP blocklist — deny matching IPs with 403 before the redirect fires.
+	if r.IPBlocklist != "" {
+		if blockRanges := parseCIDRList(r.IPBlocklist); len(blockRanges) > 0 {
+			handlers = append(handlers, ipBlocklistSubroute(blockRanges))
+		}
+	}
+
+	// IP allowlist: deny non-matching IPs before the redirect fires.
+	if r.AccessList != "" {
+		if allowed := parseCIDRList(r.AccessList); len(allowed) > 0 {
+			handlers = append(handlers, map[string]any{
+				"handler": "subroute",
+				"routes": []any{
+					map[string]any{
+						"match": []any{map[string]any{
+							"not": []any{map[string]any{
+								"remote_ip": map[string]any{"ranges": allowed},
+							}},
+						}},
+						"handle":   []any{map[string]any{"handler": "static_response", "status_code": 403}},
+						"terminal": true,
+					},
 				},
-				"status_code": statusCode,
+			})
+		}
+	}
+
+	// Maintenance mode: respond with configured status code and skip the redirect.
+	if r.MaintenanceMode {
+		msg := r.MaintenanceMsg
+		if msg == "" {
+			msg = "Service temporarily unavailable for maintenance."
+		}
+		statusCode := r.MaintenanceStatusCode
+		if statusCode == 0 {
+			statusCode = 503
+		}
+		handlers = append(handlers, map[string]any{
+			"handler":     "static_response",
+			"status_code": statusCode,
+			"body":        msg,
+		})
+		// Return early — don't add redirect handler below.
+		return map[string]any{
+			"match":    []any{map[string]any{"host": asIfaceStrings(domains)}},
+			"handle":   handlers,
+			"terminal": true,
+		}
+	}
+
+	// v2.9.24: HSTS — inject Strict-Transport-Security on redirect responses.
+	if r.HSTSMaxAgeSec > 0 {
+		hsts := fmt.Sprintf("max-age=%d", r.HSTSMaxAgeSec)
+		if r.HSTSIncludeSubdomains {
+			hsts += "; includeSubDomains"
+		}
+		if r.HSTSPreload {
+			hsts += "; preload"
+		}
+		handlers = append(handlers, map[string]any{
+			"handler": "headers",
+			"response": map[string]any{
+				"set": map[string]any{
+					"Strict-Transport-Security": []any{hsts},
+				},
 			},
+		})
+	}
+
+	// v2.9.20: custom response headers injected before the redirect fires.
+	if respHdrs := r.CustomRespHeaderMap(); len(respHdrs) > 0 {
+		setHdrs := map[string]any{}
+		delHdrs := []any{}
+		for k, v := range respHdrs {
+			if v == "" {
+				delHdrs = append(delHdrs, k)
+			} else {
+				setHdrs[k] = []any{v}
+			}
+		}
+		respOp := map[string]any{}
+		if len(setHdrs) > 0 {
+			respOp["set"] = setHdrs
+		}
+		if len(delHdrs) > 0 {
+			respOp["delete"] = delHdrs
+		}
+		handlers = append(handlers, map[string]any{"handler": "headers", "response": respOp})
+	}
+
+	// The actual redirect.
+	handlers = append(handlers, map[string]any{
+		"handler": "static_response",
+		"headers": map[string]any{
+			"Location": []any{location},
 		},
+		"status_code": statusCode,
+	})
+
+	return map[string]any{
+		"match":    []any{map[string]any{"host": asIfaceStrings(domains)}},
+		"handle":   handlers,
 		"terminal": true,
 	}
 }
@@ -352,6 +3280,33 @@ func BuildRoutes(proxies []models.ProxyHost, redirects []models.RedirectionHost)
 		routes = append(routes, BuildRedirectRoute(r))
 	}
 	return routes
+}
+
+// denyDotfilesSubroute returns a subroute that blocks any request whose URI
+// path contains a segment starting with "." (hidden files and directories,
+// e.g. /.env, /.git/config, /foo/.htpasswd). Returns 403 Forbidden.
+func denyDotfilesSubroute() map[string]any {
+	return map[string]any{
+		"handler": "subroute",
+		"routes": []any{
+			map[string]any{
+				"match": []any{
+					map[string]any{
+						"path_regexp": map[string]any{
+							"pattern": `(?i)(?:^|/)\.`,
+						},
+					},
+				},
+				"handle": []any{
+					map[string]any{
+						"handler":     "static_response",
+						"status_code": 403,
+					},
+				},
+				"terminal": true,
+			},
+		},
+	}
 }
 
 // ExploitBlockerSubroute returns a subroute handler that returns 403 for common
@@ -415,10 +3370,79 @@ func BuildTLSConnectionPolicies(proxies []models.ProxyHost) []any {
 	return policies
 }
 
+// methodStrings converts a []any of method strings back to []string for the
+// Allow header in allowed_methods 405 responses.
+func methodStrings(in []any) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 func asIfaceStrings(in []string) []any {
 	out := make([]any, len(in))
 	for i, s := range in {
 		out[i] = s
+	}
+	return out
+}
+
+// maintenanceStatusCode returns a valid maintenance HTTP status code.
+// Valid values are 429, 502, 503 (default), 520.
+func maintenanceStatusCode(code int) int {
+	switch code {
+	case 429, 502, 520:
+		return code
+	default:
+		return 503
+	}
+}
+
+// msgOrDefault returns msg if non-empty, otherwise returns def.
+func msgOrDefault(msg, def string) string {
+	if msg != "" {
+		return msg
+	}
+	return def
+}
+
+// htmlEscape escapes special HTML characters to prevent injection.
+func htmlEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, `"`, "&#34;")
+	return s
+}
+
+// parseHeaderReplaceRules parses newline-separated "Name|regexp|replacement"
+// lines into a Caddy headers handler replace map. Lines that don't have exactly
+// two '|' separators are skipped. Multiple rules for the same header name are
+// merged into a single slice.
+func parseHeaderReplaceRules(raw string) map[string][]any {
+	out := map[string][]any{}
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "|", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		pattern := strings.TrimSpace(parts[1])
+		replacement := parts[2] // preserve trailing spaces in replacement
+		if name == "" || pattern == "" {
+			continue
+		}
+		out[name] = append(out[name], map[string]any{
+			"search_regexp": pattern,
+			"replace":       replacement,
+		})
 	}
 	return out
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -175,6 +175,35 @@ CREATE TABLE IF NOT EXISTS user_groups (
     FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_user_groups_group ON user_groups(group_id);
+
+-- v2.9.1: API tokens for programmatic / headless access.
+-- token_hash is SHA-256(raw_token) stored as lowercase hex.
+-- expires_at NULL means the token never expires.
+CREATE TABLE IF NOT EXISTS api_tokens (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,
+    last_used_at TIMESTAMP,
+    expires_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- v2.9.1: per-proxy-host health check history.
+-- checked_at is a Unix timestamp. ok=1 means the check succeeded (HTTP 2xx).
+-- Keeps last 288 checks per host (24 hours at 5-minute intervals).
+CREATE TABLE IF NOT EXISTS proxy_health (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    proxy_host_id INTEGER NOT NULL,
+    checked_at INTEGER NOT NULL,
+    ok INTEGER NOT NULL DEFAULT 0,
+    status_code INTEGER NOT NULL DEFAULT 0,
+    latency_ms INTEGER NOT NULL DEFAULT 0,
+    error_msg TEXT NOT NULL DEFAULT '',
+    FOREIGN KEY (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_proxy_health_host_ts ON proxy_health(proxy_host_id, checked_at);
 `
 
 func Open(path string) (*sql.DB, error) {
@@ -483,7 +512,1294 @@ func migrate(db *sql.DB) error {
 		}
 	}
 
+	// v2.9.1: per-host custom request/response headers.
+	for _, col := range []struct{ name, def string }{
+		{"custom_req_headers", "TEXT NOT NULL DEFAULT '{}'"},
+		{"custom_resp_headers", "TEXT NOT NULL DEFAULT '{}'"},
+	} {
+		has, err := columnExists(db, "proxy_hosts", col.name)
+		if err != nil {
+			return err
+		}
+		if !has {
+			if _, err := db.Exec(fmt.Sprintf(`ALTER TABLE proxy_hosts ADD COLUMN %s %s`, col.name, col.def)); err != nil {
+				return fmt.Errorf("add %s to proxy_hosts: %w", col.name, err)
+			}
+		}
+	}
+
+	// v2.9.2: URL rewrite rules per proxy host.
+	// Stored as JSON array of {type, from, to} objects.
+	hasURLRewrites, err := columnExists(db, "proxy_hosts", "url_rewrites")
+	if err != nil {
+		return err
+	}
+	if !hasURLRewrites {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN url_rewrites TEXT NOT NULL DEFAULT '[]'`); err != nil {
+			return fmt.Errorf("add url_rewrites: %w", err)
+		}
+	}
+
+	// v2.9.3: maintenance mode per proxy host.
+	hasMaintMode, err := columnExists(db, "proxy_hosts", "maintenance_mode")
+	if err != nil {
+		return err
+	}
+	if !hasMaintMode {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN maintenance_mode INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add maintenance_mode: %w", err)
+		}
+	}
+
+	// v2.9.3: request body size limit in MiB (0 = unlimited).
+	hasMaxBody, err := columnExists(db, "proxy_hosts", "max_request_body_mb")
+	if err != nil {
+		return err
+	}
+	if !hasMaxBody {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN max_request_body_mb INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add max_request_body_mb: %w", err)
+		}
+	}
+
+	// v2.9.3: sticky sessions (cookie-based LB selection policy).
+	hasStickySession, err := columnExists(db, "proxy_hosts", "sticky_sessions")
+	if err != nil {
+		return err
+	}
+	if !hasStickySession {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN sticky_sessions INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add sticky_sessions: %w", err)
+		}
+	}
+
+	// v2.9.3: upstream response timeout in seconds (0 = use Caddy default).
+	if !columnExists2(db, "proxy_hosts", "upstream_timeout_sec") {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_timeout_sec INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add upstream_timeout_sec: %w", err)
+		}
+	}
+
+	// v2.9.3: CORS — enabled flag + allowed origins string.
+	if !columnExists2(db, "proxy_hosts", "cors_enabled") {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN cors_enabled INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add cors_enabled: %w", err)
+		}
+	}
+	if !columnExists2(db, "proxy_hosts", "cors_origins") {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN cors_origins TEXT NOT NULL DEFAULT '*'`); err != nil {
+			return fmt.Errorf("add cors_origins: %w", err)
+		}
+	}
+
+	// v2.9.4: active upstream health check URI and interval.
+	if !columnExists2(db, "proxy_hosts", "health_check_uri") {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_uri TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add health_check_uri: %w", err)
+		}
+	}
+	if !columnExists2(db, "proxy_hosts", "health_check_interval_sec") {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_interval_sec INTEGER NOT NULL DEFAULT 30`); err != nil {
+			return fmt.Errorf("add health_check_interval_sec: %w", err)
+		}
+	}
+	// v2.9.4: keepalive connection pool size (0 = Caddy default).
+	if !columnExists2(db, "proxy_hosts", "keepalive_conns") {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN keepalive_conns INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add keepalive_conns: %w", err)
+		}
+	}
+
+	// v2.9.4: proxy host tags (comma-separated, UI-only metadata).
+	if !columnExists2(db, "proxy_hosts", "tags") {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN tags TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add tags: %w", err)
+		}
+	}
+
+	// v2.9.4: freeform notes per proxy host (UI-only metadata).
+	if !columnExists2(db, "proxy_hosts", "notes") {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN notes TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add notes: %w", err)
+		}
+	}
+
+	// v2.9.5: disable access log collection for this host.
+	if !columnExists2(db, "proxy_hosts", "disable_access_log") {
+		if _, err := db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN disable_access_log INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add disable_access_log: %w", err)
+		}
+	}
+
+	if !columnExists2(db, "proxy_hosts", "maintenance_msg") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN maintenance_msg TEXT NOT NULL DEFAULT ''`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "add_request_id") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_request_id INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "strip_resp_headers") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_resp_headers TEXT NOT NULL DEFAULT ''`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "blocked_agents") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN blocked_agents TEXT NOT NULL DEFAULT ''`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "health_check_method") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_method TEXT NOT NULL DEFAULT 'GET'`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "maintenance_status_code") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN maintenance_status_code INTEGER NOT NULL DEFAULT 503`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "response_cache_control") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN response_cache_control TEXT NOT NULL DEFAULT ''`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "upstream_sni") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_sni TEXT NOT NULL DEFAULT ''`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "hsts_preload") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN hsts_preload INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "max_conns_per_host") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN max_conns_per_host INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "health_check_timeout_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_timeout_sec INTEGER NOT NULL DEFAULT 5`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "upstream_retries") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_retries INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "force_http1") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN force_http1 INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "basicauth_realm") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN basicauth_realm TEXT NOT NULL DEFAULT 'Restricted'`)
+	}
+
+	// api_tokens: add scopes column
+	if !columnExists2(db, "api_tokens", "scopes") {
+		_, _ = db.Exec(`ALTER TABLE api_tokens ADD COLUMN scopes TEXT NOT NULL DEFAULT 'full'`)
+	}
+
+	// TOTP backup codes: single-use recovery codes stored as JSON array of SHA-256 hashes.
+	if !columnExists2(db, "users", "totp_backup_codes") {
+		_, _ = db.Exec(`ALTER TABLE users ADD COLUMN totp_backup_codes TEXT NOT NULL DEFAULT ''`)
+	}
+
+	if !columnExists2(db, "proxy_hosts", "error_page_html") {
+		_, err = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN error_page_html TEXT NOT NULL DEFAULT ''`)
+		if err != nil {
+			return err
+		}
+	}
+
+	// v2.9.5: scheduled maintenance windows — auto-sync Caddy at window boundaries.
+	if !columnExists2(db, "proxy_hosts", "maintenance_window_start") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN maintenance_window_start TEXT NOT NULL DEFAULT ''`)
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN maintenance_window_end TEXT NOT NULL DEFAULT ''`)
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN maintenance_window_days TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.5: per-host IP blocklist — deny specific CIDR ranges with 403.
+	if !columnExists2(db, "proxy_hosts", "ip_blocklist") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN ip_blocklist TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.5: load-balancer selection policy for multi-upstream hosts.
+	if !columnExists2(db, "proxy_hosts", "lb_policy") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_policy TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.5: PROXY protocol version for upstream connections ("" | "v1" | "v2").
+	if !columnExists2(db, "proxy_hosts", "proxy_protocol") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN proxy_protocol TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.5: custom robots.txt content to inject before the reverse proxy.
+	if !columnExists2(db, "proxy_hosts", "robots_txt") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN robots_txt TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.5: tags and notes for redirection hosts — parity with proxy hosts.
+	if !columnExists2(db, "redirection_hosts", "tags") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN tags TEXT NOT NULL DEFAULT ''`)
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN notes TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.5: passive health check configuration for upstream failure detection.
+	if !columnExists2(db, "proxy_hosts", "passive_fail_duration_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN passive_fail_duration_sec INTEGER NOT NULL DEFAULT 0`)
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN passive_max_fails INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.5: HSTS max-age override and Content-Security-Policy header.
+	if !columnExists2(db, "proxy_hosts", "hsts_max_age_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN hsts_max_age_sec INTEGER NOT NULL DEFAULT 0`)
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN csp_header TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.5: H2C (HTTP/2 cleartext) upstream transport for gRPC and similar.
+	if !columnExists2(db, "proxy_hosts", "h2c_enabled") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN h2c_enabled INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.5: custom upstream health-check request headers.
+	if !columnExists2(db, "proxy_hosts", "health_check_headers") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_headers TEXT NOT NULL DEFAULT '{}'`)
+	}
+
+	// v2.9.6: streaming / flush mode, response buffering, per-host trusted proxies.
+	if !columnExists2(db, "proxy_hosts", "flush_immediate") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN flush_immediate INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "proxy_hosts", "buffer_responses") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN buffer_responses INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "proxy_hosts", "trusted_proxies") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN trusted_proxies TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.7: upstream Host header override, response body read timeout, dotfile blocking.
+	if !columnExists2(db, "proxy_hosts", "upstream_host_override") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_host_override TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "read_timeout_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN read_timeout_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "proxy_hosts", "deny_dotfiles") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN deny_dotfiles INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.8: request body buffering; CORS credentials and expose-headers.
+	if !columnExists2(db, "proxy_hosts", "request_buffers_kb") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN request_buffers_kb INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "proxy_hosts", "cors_allow_credentials") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN cors_allow_credentials INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "proxy_hosts", "cors_expose_headers") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN cors_expose_headers TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.9: verify upstream TLS certificate (off by default to preserve
+	// existing skip-verify behaviour); separate dial timeout.
+	if !columnExists2(db, "proxy_hosts", "ssl_verify_upstream") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN ssl_verify_upstream INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "proxy_hosts", "dial_timeout_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN dial_timeout_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.10: API key header authentication; block empty User-Agent.
+	if !columnExists2(db, "proxy_hosts", "api_key_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN api_key_header TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "api_key_value") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN api_key_value TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "block_empty_user_agent") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN block_empty_user_agent INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.11: error redirect URL; granular security header overrides.
+	if !columnExists2(db, "proxy_hosts", "error_redirect_url") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN error_redirect_url TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "permissions_policy") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN permissions_policy TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "x_frame_options") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN x_frame_options TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "referrer_policy") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN referrer_policy TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.13: IP access control, maintenance mode, and maintenance message
+	// for redirection hosts — feature parity with proxy hosts.
+	if !columnExists2(db, "redirection_hosts", "access_list") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN access_list TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "redirection_hosts", "maintenance_mode") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN maintenance_mode INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "redirection_hosts", "maintenance_msg") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN maintenance_msg TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.14: HSTS includeSubDomains toggle — DEFAULT 1 so existing hosts that
+	// already relied on the previously-hardcoded includeSubDomains keep working.
+	if !columnExists2(db, "proxy_hosts", "hsts_include_subdomains") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN hsts_include_subdomains INTEGER NOT NULL DEFAULT 1`)
+	}
+	// v2.9.14: Content-Security-Policy-Report-Only header (report-only mode).
+	if !columnExists2(db, "proxy_hosts", "csp_report_only") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN csp_report_only TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.14: per-host keepalive idle timeout in seconds (0 = use default 90s).
+	if !columnExists2(db, "proxy_hosts", "keepalive_idle_timeout_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN keepalive_idle_timeout_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.15: active health check expected status code and response body regexp.
+	// expect_status 0 = accept any 2xx; >0 = require that exact code.
+	if !columnExists2(db, "proxy_hosts", "health_check_expect_status") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_expect_status INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "proxy_hosts", "health_check_expect_body") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_expect_body TEXT NOT NULL DEFAULT ''`)
+	}
+	// follow_redirects: when 1, Caddy follows HTTP redirects during health probes.
+	if !columnExists2(db, "proxy_hosts", "health_check_follow_redirects") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_follow_redirects INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.16: path-based routing — restrict this proxy host to requests whose
+	// path starts with path_matcher (e.g. "/api"). strip_path_prefix removes
+	// the prefix before forwarding to the upstream when enabled.
+	if !columnExists2(db, "proxy_hosts", "path_matcher") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN path_matcher TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "strip_path_prefix") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_path_prefix INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.17: load-balancer tuning — custom sticky-session cookie name,
+	// try_duration (how long to keep retrying across upstreams before giving up),
+	// and try_interval (delay between retry attempts in milliseconds).
+	if !columnExists2(db, "proxy_hosts", "sticky_cookie_name") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN sticky_cookie_name TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "lb_try_duration_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_try_duration_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "proxy_hosts", "lb_try_interval_ms") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_try_interval_ms INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.18: compression minimum size — skip compressing responses smaller
+	// than this many kilobytes (0 = compress everything, Caddy default).
+	if !columnExists2(db, "proxy_hosts", "compression_min_size_kb") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN compression_min_size_kb INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.18: forward real client IP as X-Real-IP header to upstream.
+	if !columnExists2(db, "proxy_hosts", "forward_client_ip") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN forward_client_ip INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.19: CORS fine-tuning — custom preflight max-age, allowed methods,
+	// and allowed headers. 0 / empty = use the existing defaults.
+	if !columnExists2(db, "proxy_hosts", "cors_max_age_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN cors_max_age_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "proxy_hosts", "cors_allow_methods") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN cors_allow_methods TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "cors_allow_headers") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN cors_allow_headers TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.20: custom response headers on redirection hosts — allows operators
+	// to inject headers (e.g. Cache-Control, X-Robots-Tag) into redirect responses.
+	if !columnExists2(db, "redirection_hosts", "custom_resp_headers") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN custom_resp_headers TEXT NOT NULL DEFAULT '{}'`)
+	}
+
+	// v2.9.21: IP blocklist for redirection hosts — deny specific CIDRs
+	// before the redirect fires (parity with proxy hosts which have ip_blocklist).
+	if !columnExists2(db, "redirection_hosts", "ip_blocklist") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN ip_blocklist TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.22: retry on specific upstream HTTP status codes for proxy hosts.
+	// Complements upstream_retries (connection failures) with status-code-based retry.
+	if !columnExists2(db, "proxy_hosts", "retry_status_codes") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN retry_status_codes TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.22: write_timeout — time allowed to transmit the request body to the upstream.
+	if !columnExists2(db, "proxy_hosts", "write_timeout_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN write_timeout_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.23: upstream TLS minimum version — enforce TLS 1.2 or 1.3 for upstream connections.
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_min_version") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_min_version TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.23: forward_proxy_url — chain outbound requests through an upstream HTTP proxy.
+	if !columnExists2(db, "proxy_hosts", "forward_proxy_url") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN forward_proxy_url TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.24: HSTS for redirection hosts — inject Strict-Transport-Security on redirect
+	// responses so browsers skip HTTP for subsequent visits after the first redirect.
+	if !columnExists2(db, "redirection_hosts", "hsts_max_age_sec") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN hsts_max_age_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "redirection_hosts", "hsts_include_subdomains") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN hsts_include_subdomains INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "redirection_hosts", "hsts_preload") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN hsts_preload INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.25: blocked_methods — comma-separated HTTP methods that return 405 before proxying.
+	// Useful for hardening: TRACE, CONNECT, or custom methods you never want routed.
+	if !columnExists2(db, "proxy_hosts", "blocked_methods") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN blocked_methods TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.26: advanced_config for redirection hosts — raw JSON array of Caddy handlers
+	// injected before the redirect fires. Gives power users full control without
+	// needing the Caddyfile adapter. Format: [{"handler":"...","...":"..."},...].
+	if !columnExists2(db, "redirection_hosts", "advanced_config") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN advanced_config TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.27: forward_auth — delegate authentication to an external service
+	// (e.g. Authelia, Authentik) before proxying. Only forwards if the auth
+	// service returns 2xx; otherwise returns its response (typically 401/403).
+	if !columnExists2(db, "proxy_hosts", "forward_auth_url") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN forward_auth_url TEXT NOT NULL DEFAULT ''`)
+	}
+	// forward_auth_copy_headers: comma-separated response headers from the auth
+	// service that are copied to the proxied upstream request.
+	if !columnExists2(db, "proxy_hosts", "forward_auth_copy_headers") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN forward_auth_copy_headers TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.28: query string control for proxy hosts.
+	// strip_query_string: remove the entire query string before forwarding.
+	if !columnExists2(db, "proxy_hosts", "strip_query_string") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_query_string INTEGER NOT NULL DEFAULT 0`)
+	}
+	// delete_query_params: comma-separated query param names to remove before forwarding
+	// (e.g. "utm_source,utm_medium,fbclid" strips common tracking parameters).
+	if !columnExists2(db, "proxy_hosts", "delete_query_params") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN delete_query_params TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.29: request body read timeout — how long to wait for the client to
+	// finish sending the request body. 0 = no limit. Guards against slow-body attacks.
+	if !columnExists2(db, "proxy_hosts", "request_body_read_timeout_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN request_body_read_timeout_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.29: response_header_timeout_sec — independent control over how long
+	// to wait for the upstream to start sending response headers, separate from
+	// the combined upstream_timeout_sec. 0 = falls back to upstream_timeout_sec.
+	if !columnExists2(db, "proxy_hosts", "response_header_timeout_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN response_header_timeout_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.31: max_conn_duration_sec — maximum lifetime of an upstream connection
+	// before Caddy replaces it. 0 = unlimited. Useful with cloud load balancers
+	// (e.g. AWS ALB) that forcibly close long-lived idle connections.
+	if !columnExists2(db, "proxy_hosts", "max_conn_duration_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN max_conn_duration_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.32: decompress_response — when true, Caddy decompresses upstream
+	// gzip/br responses before forwarding, enabling response-body transforms.
+	if !columnExists2(db, "proxy_hosts", "decompress_response") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN decompress_response INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.33: color label — short color token for visual host grouping in the
+	// list view (e.g. "red", "green", "blue"). No Caddy impact.
+	if !columnExists2(db, "proxy_hosts", "color") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN color TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "redirection_hosts", "color") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN color TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.34: www_redirect — automatically redirect between www and bare
+	// domain variants. Values: '' (disabled) | 'to_www' | 'to_bare'.
+	if !columnExists2(db, "proxy_hosts", "www_redirect") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN www_redirect TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.35: strip_req_headers — comma-separated list of request header names
+	// to delete before forwarding to the upstream. Companion to strip_resp_headers.
+	if !columnExists2(db, "proxy_hosts", "strip_req_headers") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_req_headers TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.36: upstream_path_prefix — static path prefix prepended to every
+	// upstream request URI. Useful when the upstream app is mounted under a
+	// subpath different from the public URL (e.g. proxy / → upstream /v2).
+	if !columnExists2(db, "proxy_hosts", "upstream_path_prefix") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_path_prefix TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.37: compression_level — gzip compression level (0 = default, 1-9).
+	// Higher levels compress more but use more CPU. zstd level: 0 = default, 1-22.
+	if !columnExists2(db, "proxy_hosts", "compression_level") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN compression_level INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.37: compression_prefer_gzip — prefer gzip over zstd for broader
+	// client compatibility (e.g. older Safari or caching proxies that don't
+	// support zstd).
+	if !columnExists2(db, "proxy_hosts", "compression_prefer_gzip") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN compression_prefer_gzip INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.38: maintenance_status_code for redirection hosts — parity with
+	// proxy hosts. Defaults to 503; admin can use 429, 502, or 520.
+	if !columnExists2(db, "redirection_hosts", "maintenance_status_code") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN maintenance_status_code INTEGER NOT NULL DEFAULT 503`)
+	}
+
+	// v2.9.39: sort_order — integer weight for manual ordering in the list
+	// view. Lower values appear first. Default 0 keeps existing ordering.
+	if !columnExists2(db, "proxy_hosts", "sort_order") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "redirection_hosts", "sort_order") {
+		_, _ = db.Exec(`ALTER TABLE redirection_hosts ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.41: allowed_methods — HTTP method allowlist (empty = allow all; complement to blocked_methods denylist)
+	if !columnExists2(db, "proxy_hosts", "allowed_methods") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN allowed_methods TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.42: upstream_max_resp_header_kb — cap on response header bytes from upstream (0 = Caddy default)
+	if !columnExists2(db, "proxy_hosts", "upstream_max_resp_header_kb") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_max_resp_header_kb INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.43: health_check_port — separate port for active health probes (0 = same port as traffic)
+	if !columnExists2(db, "proxy_hosts", "health_check_port") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_port INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.44: request_id_header_name — custom header for injected request IDs ('' = X-Request-Id)
+	if !columnExists2(db, "proxy_hosts", "request_id_header_name") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN request_id_header_name TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.45: lb_cookie_path — cookie path scope for sticky-session load balancing
+	if !columnExists2(db, "proxy_hosts", "lb_cookie_path") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_cookie_path TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.46: passive_unhealthy_latency_ms — mark upstream unhealthy above this response latency
+	if !columnExists2(db, "proxy_hosts", "passive_unhealthy_latency_ms") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN passive_unhealthy_latency_ms INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.47: tls_handshake_timeout_sec — TLS handshake timeout for upstream connections (0 = Caddy default)
+	if !columnExists2(db, "proxy_hosts", "tls_handshake_timeout_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN tls_handshake_timeout_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.48: expect_continue_timeout_sec — wait for 100-Continue from upstream (0 = disabled)
+	if !columnExists2(db, "proxy_hosts", "expect_continue_timeout_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN expect_continue_timeout_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.49: response_buffers_kb — per-connection response streaming buffer size (0 = Caddy default)
+	if !columnExists2(db, "proxy_hosts", "response_buffers_kb") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN response_buffers_kb INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.50: upstream_max_idle_conns — total idle upstream connections across all hosts (0 = Caddy default)
+	if !columnExists2(db, "proxy_hosts", "upstream_max_idle_conns") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_max_idle_conns INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.51: upstream_keep_alive_probe_sec — keepalive probe interval in seconds (0 = no probing)
+	if !columnExists2(db, "proxy_hosts", "upstream_keep_alive_probe_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_keep_alive_probe_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.52: forward_auth_method — HTTP method for the ForwardAuth subrequest ('' = GET default)
+	if !columnExists2(db, "proxy_hosts", "forward_auth_method") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN forward_auth_method TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.53: grpc_web_enabled — enable gRPC-Web protocol transcoding for browser clients
+	if !columnExists2(db, "proxy_hosts", "grpc_web_enabled") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN grpc_web_enabled INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.54: forward_auth_headers_prefix — prefix for headers copied from ForwardAuth response
+	if !columnExists2(db, "proxy_hosts", "forward_auth_headers_prefix") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN forward_auth_headers_prefix TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.55: health_check_max_size_kb — max response body size read during active health checks
+	if !columnExists2(db, "proxy_hosts", "health_check_max_size_kb") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_max_size_kb INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.56: strip_path_suffix — strip a static suffix from the request path before forwarding
+	if !columnExists2(db, "proxy_hosts", "strip_path_suffix") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_path_suffix TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.57: add_req_query_params — key=value pairs appended to upstream query string
+	if !columnExists2(db, "proxy_hosts", "add_req_query_params") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_req_query_params TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.58: error_page_codes — comma-separated HTTP status codes that trigger the custom error page
+	if !columnExists2(db, "proxy_hosts", "error_page_codes") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN error_page_codes TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.59: upstream_tls_ca_pem_file — path to CA bundle for upstream TLS cert verification
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_ca_pem_file") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_ca_pem_file TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.60: keepalive_disabled — completely disable upstream keepalive (e.g. for NTLM auth upstreams)
+	if !columnExists2(db, "proxy_hosts", "keepalive_disabled") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN keepalive_disabled INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.61: trailing_slash_redirect — "" | "add" | "remove" — auto-redirect for trailing slash normalisation
+	if !columnExists2(db, "proxy_hosts", "trailing_slash_redirect") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN trailing_slash_redirect TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.62: dial_fallback_delay_ms — time before falling back to next upstream after dial failure (0 = Caddy default)
+	if !columnExists2(db, "proxy_hosts", "dial_fallback_delay_ms") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN dial_fallback_delay_ms INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.63: upstream_network — TCP network type for upstream dial ("" | "tcp4" | "tcp6")
+	if !columnExists2(db, "proxy_hosts", "upstream_network") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_network TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.64: dns_resolver — custom DNS resolver for upstream name resolution ('' = system default)
+	if !columnExists2(db, "proxy_hosts", "dns_resolver") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN dns_resolver TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.65: path_matcher_type — how PathMatcher is applied ('' = prefix | "exact" | "regexp")
+	if !columnExists2(db, "proxy_hosts", "path_matcher_type") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN path_matcher_type TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.66: cors_allow_private_network — add Access-Control-Allow-Private-Network: true header
+	if !columnExists2(db, "proxy_hosts", "cors_allow_private_network") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN cors_allow_private_network INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.67: robots_txt_disallow_all — serve "Disallow: /" robots.txt without custom HTML body
+	if !columnExists2(db, "proxy_hosts", "robots_txt_disallow_all") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN robots_txt_disallow_all INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.68: maintenance_retry_after_sec — Retry-After header value on maintenance 503 (0 = default 3600)
+	if !columnExists2(db, "proxy_hosts", "maintenance_retry_after_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN maintenance_retry_after_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.69: upstream_resolve_timeout_sec — DNS resolver timeout in seconds (0 = Caddy default)
+	if !columnExists2(db, "proxy_hosts", "upstream_resolve_timeout_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_resolve_timeout_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.70: upstream_read_buffer_size_kb — transport read buffer in KB (0 = Caddy default 32KB)
+	if !columnExists2(db, "proxy_hosts", "upstream_read_buffer_size_kb") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_read_buffer_size_kb INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.71: upstream_write_buffer_size_kb — transport write buffer in KB (0 = Caddy default)
+	if !columnExists2(db, "proxy_hosts", "upstream_write_buffer_size_kb") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_write_buffer_size_kb INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.72: req_header_replace — newline-separated "Name|regexp|replacement" rules for request header values
+	if !columnExists2(db, "proxy_hosts", "req_header_replace") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN req_header_replace TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.73: resp_header_replace — newline-separated "Name|regexp|replacement" rules for response header values
+	if !columnExists2(db, "proxy_hosts", "resp_header_replace") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN resp_header_replace TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.74: upstream_http_versions — comma-separated HTTP versions for upstream transport ('' = Caddy default)
+	if !columnExists2(db, "proxy_hosts", "upstream_http_versions") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_http_versions TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.75: health_check_body — request body to send with active health check probes
+	if !columnExists2(db, "proxy_hosts", "health_check_body") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_body TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.76: add_canonical_link_header — inject Link: <canonical-url>; rel="canonical" response header
+	if !columnExists2(db, "proxy_hosts", "add_canonical_link_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_canonical_link_header INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.77: http_basic_auth_upstream — "user:pass" credentials injected as Authorization: Basic to upstream
+	if !columnExists2(db, "proxy_hosts", "http_basic_auth_upstream") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN http_basic_auth_upstream TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.78: block_ua_regexp — Go regexp; requests whose User-Agent matches get a 403 response
+	if !columnExists2(db, "proxy_hosts", "block_ua_regexp") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN block_ua_regexp TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.79: security_txt_body — serve custom security.txt at /.well-known/security.txt
+	if !columnExists2(db, "proxy_hosts", "security_txt_body") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN security_txt_body TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.80: server_header_value — override the Server response header value ('' = keep upstream value)
+	if !columnExists2(db, "proxy_hosts", "server_header_value") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN server_header_value TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.81: x_robots_tag — X-Robots-Tag response header value for search-engine indexing control
+	if !columnExists2(db, "proxy_hosts", "x_robots_tag") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN x_robots_tag TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.82: add_forwarded_header — inject RFC 7239 Forwarded header on upstream requests
+	if !columnExists2(db, "proxy_hosts", "add_forwarded_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_forwarded_header INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.83: lb_cookie_secret — HMAC secret for signed sticky-session cookies (prevents client tampering)
+	if !columnExists2(db, "proxy_hosts", "lb_cookie_secret") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_cookie_secret TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.84: passive_unhealthy_status_codes — comma-separated HTTP codes triggering passive unhealthy state
+	if !columnExists2(db, "proxy_hosts", "passive_unhealthy_status_codes") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN passive_unhealthy_status_codes TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.85: health_check_content_type — Content-Type header sent with active health check requests
+	if !columnExists2(db, "proxy_hosts", "health_check_content_type") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_content_type TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.86: upstream_tls_client_cert_file — path to PEM certificate for mTLS to upstream
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_client_cert_file") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_client_cert_file TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.87: upstream_tls_client_key_file — path to PEM private key for mTLS to upstream
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_client_key_file") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_client_key_file TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.88: block_private_ips — reject incoming requests from RFC 1918 / loopback addresses (403)
+	if !columnExists2(db, "proxy_hosts", "block_private_ips") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN block_private_ips INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.89: enable_brotli — add brotli (br) encoding to the compression handler alongside gzip/zstd
+	if !columnExists2(db, "proxy_hosts", "enable_brotli") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN enable_brotli INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.90: vary_header — set Vary response header value for caching/CDN control
+	if !columnExists2(db, "proxy_hosts", "vary_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN vary_header TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.91: strip_etag — delete ETag response header from upstream responses
+	if !columnExists2(db, "proxy_hosts", "strip_etag") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_etag INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.92: http2_push_paths — newline-separated paths to push via HTTP/2 server push before response
+	if !columnExists2(db, "proxy_hosts", "http2_push_paths") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN http2_push_paths TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.93: deny_content_types — comma-separated Content-Type prefixes that receive 415 Unsupported Media Type
+	if !columnExists2(db, "proxy_hosts", "deny_content_types") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN deny_content_types TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.94: upstream_local_addr — local IP address to bind for upstream connections
+	if !columnExists2(db, "proxy_hosts", "upstream_local_addr") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_local_addr TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.95: upstream_tls_renegotiation — TLS renegotiation policy: '' (never) | 'once' | 'freely'
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_renegotiation") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_renegotiation TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.96: upstream_tls_curves — comma-separated TLS curve names for upstream connections ('' = Caddy default)
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_curves") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_curves TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.97: upstream_tls_max_version — maximum TLS version for upstream connections ('' | '1.2' | '1.3')
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_max_version") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_max_version TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.98: upstream_tls_pins — newline-separated SHA-256 SPKI fingerprints for upstream cert pinning
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_pins") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_pins TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.99: lb_header_field — request header name used by the 'header' LB selection policy
+	if !columnExists2(db, "proxy_hosts", "lb_header_field") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_header_field TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.100: maintenance_custom_headers — newline-separated "Name: Value" extra headers on the 503 maintenance response
+	if !columnExists2(db, "proxy_hosts", "maintenance_custom_headers") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN maintenance_custom_headers TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.101: deny_extensions — comma-separated file extensions to block (e.g. ".php,.asp") — returns 403
+	if !columnExists2(db, "proxy_hosts", "deny_extensions") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN deny_extensions TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.102: inject_request_timestamp — add X-Request-Timestamp header with UNIX epoch to upstream requests
+	if !columnExists2(db, "proxy_hosts", "inject_request_timestamp") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN inject_request_timestamp INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.103: add_resp_cookies — newline-separated Set-Cookie header values added to every response
+	if !columnExists2(db, "proxy_hosts", "add_resp_cookies") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_resp_cookies TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.104: strip_accept_encoding — delete Accept-Encoding request header before forwarding to upstream
+	if !columnExists2(db, "proxy_hosts", "strip_accept_encoding") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_accept_encoding INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.105: add_upstream_timing_header — inject X-Upstream-Time response header with upstream latency
+	if !columnExists2(db, "proxy_hosts", "add_upstream_timing_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_upstream_timing_header INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.106: strip_server_header — delete Server response header from upstream replies
+	if !columnExists2(db, "proxy_hosts", "strip_server_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_server_header INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.107: block_referer_regexp — Go regexp; requests whose Referer header matches receive 403
+	if !columnExists2(db, "proxy_hosts", "block_referer_regexp") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN block_referer_regexp TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.108: add_content_type_nosniff — add X-Content-Type-Options: nosniff response header
+	if !columnExists2(db, "proxy_hosts", "add_content_type_nosniff") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_content_type_nosniff INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.109: strip_authorization_header — delete Authorization request header before forwarding to upstream
+	if !columnExists2(db, "proxy_hosts", "strip_authorization_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_authorization_header INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.110: real_ip_from_header — copy real client IP from this request header name into X-Real-IP
+	if !columnExists2(db, "proxy_hosts", "real_ip_from_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN real_ip_from_header TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.111: health_check_host_override — override Host header sent during active health check probes
+	if !columnExists2(db, "proxy_hosts", "health_check_host_override") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_host_override TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.112: add_x_forwarded_port — add X-Forwarded-Port request header with the incoming request port
+	if !columnExists2(db, "proxy_hosts", "add_x_forwarded_port") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_forwarded_port INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.113: lb_retry_on — comma-separated retry triggers (e.g. "error,5xx") applied to upstream retries
+	if !columnExists2(db, "proxy_hosts", "lb_retry_on") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_retry_on TEXT NOT NULL DEFAULT ''`)
+	}
+
+	// v2.9.114: max_buffer_size_kb — max response buffer size in KB when buffer_responses is enabled (0 = unlimited)
+	if !columnExists2(db, "proxy_hosts", "max_buffer_size_kb") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN max_buffer_size_kb INTEGER NOT NULL DEFAULT 0`)
+	}
+
+	// v2.9.115: upstream_keepalive_probes — number of TCP keepalive probes before marking connection dead (0 = OS default)
+	if !columnExists2(db, "proxy_hosts", "upstream_keepalive_probes") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_keepalive_probes INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.116: upstream_flush_interval_ms — flush_interval override in milliseconds (0 = default; -1 = immediate; positive = interval)
+	if !columnExists2(db, "proxy_hosts", "upstream_flush_interval_ms") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_flush_interval_ms INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.117: add_x_forwarded_host — inject X-Forwarded-Host request header with the original Host value
+	if !columnExists2(db, "proxy_hosts", "add_x_forwarded_host") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_forwarded_host INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.118: maintenance_allowed_ips — comma-separated CIDR ranges that bypass maintenance mode
+	if !columnExists2(db, "proxy_hosts", "maintenance_allowed_ips") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN maintenance_allowed_ips TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.119: upstream_tls_cipher_suites — comma-separated TLS cipher suite names for upstream connections
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_cipher_suites") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_cipher_suites TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.120: add_cache_control_no_store — add Cache-Control: no-store response header
+	if !columnExists2(db, "proxy_hosts", "add_cache_control_no_store") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_cache_control_no_store INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.121: deny_referer_empty — block requests with no Referer header (anti-hotlinking)
+	if !columnExists2(db, "proxy_hosts", "deny_referer_empty") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN deny_referer_empty INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.122: lb_cookie_httponly — set HttpOnly flag on the sticky-session cookie
+	if !columnExists2(db, "proxy_hosts", "lb_cookie_httponly") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_cookie_httponly INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.123: lb_cookie_secure — set Secure flag on the sticky-session cookie
+	if !columnExists2(db, "proxy_hosts", "lb_cookie_secure") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_cookie_secure INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.124: lb_cookie_same_site — SameSite attribute for the sticky-session cookie ("Strict","Lax","None")
+	if !columnExists2(db, "proxy_hosts", "lb_cookie_same_site") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_cookie_same_site TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.125: upstream_tls_early_data — enable TLS 1.3 early data (0-RTT) for upstream connections
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_early_data") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_early_data INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.126: add_via_header — add Via response header identifying this proxy
+	if !columnExists2(db, "proxy_hosts", "add_via_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_via_header INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.127: req_header_rename — newline-separated "OldName: NewName" pairs to rename request headers
+	if !columnExists2(db, "proxy_hosts", "req_header_rename") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN req_header_rename TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.128: add_expect_ct_header — add Expect-CT response header for certificate transparency enforcement
+	if !columnExists2(db, "proxy_hosts", "add_expect_ct_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_expect_ct_header INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.129: force_upstream_encoding — override Accept-Encoding header sent to upstream (e.g. "gzip","identity","br")
+	if !columnExists2(db, "proxy_hosts", "force_upstream_encoding") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN force_upstream_encoding TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.130: passive_unhealthy_count — max concurrent in-flight requests per upstream before flagging overloaded
+	if !columnExists2(db, "proxy_hosts", "passive_unhealthy_count") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN passive_unhealthy_count INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.131: strip_x_powered_by — delete X-Powered-By response header from upstream replies (privacy)
+	if !columnExists2(db, "proxy_hosts", "strip_x_powered_by") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_x_powered_by INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.132: add_timing_allow_origin — value for Timing-Allow-Origin response header (e.g. "*")
+	if !columnExists2(db, "proxy_hosts", "add_timing_allow_origin") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_timing_allow_origin TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.133: lb_cookie_max_age_sec — max-age in seconds for the sticky-session cookie
+	if !columnExists2(db, "proxy_hosts", "lb_cookie_max_age_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_cookie_max_age_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.134: cross_origin_opener_policy — Cross-Origin-Opener-Policy header value (e.g. "same-origin")
+	if !columnExists2(db, "proxy_hosts", "cross_origin_opener_policy") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN cross_origin_opener_policy TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.135: cross_origin_resource_policy — Cross-Origin-Resource-Policy header value (e.g. "same-site")
+	if !columnExists2(db, "proxy_hosts", "cross_origin_resource_policy") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN cross_origin_resource_policy TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.136: cross_origin_embedder_policy — Cross-Origin-Embedder-Policy header value (e.g. "require-corp")
+	if !columnExists2(db, "proxy_hosts", "cross_origin_embedder_policy") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN cross_origin_embedder_policy TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.137: deny_request_content_type — comma-separated MIME types to block on request Content-Type (returns 415)
+	if !columnExists2(db, "proxy_hosts", "deny_request_content_type") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN deny_request_content_type TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.138: compression_exclude_regexp — regexp of paths to exclude from response compression
+	if !columnExists2(db, "proxy_hosts", "compression_exclude_regexp") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN compression_exclude_regexp TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.139: add_cache_control_public — add Cache-Control: public response header
+	if !columnExists2(db, "proxy_hosts", "add_cache_control_public") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_cache_control_public INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.140: add_x_request_start — inject X-Request-Start header with Unix ms timestamp (APM timing)
+	if !columnExists2(db, "proxy_hosts", "add_x_request_start") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_request_start INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.141: maintenance_window_timezone — IANA timezone name for the scheduled maintenance window
+	if !columnExists2(db, "proxy_hosts", "maintenance_window_timezone") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN maintenance_window_timezone TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.142: lb_random_choose_count — "choose" count for random_choice lb policy (min 2)
+	if !columnExists2(db, "proxy_hosts", "lb_random_choose_count") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN lb_random_choose_count INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.143: add_x_forwarded_scheme — inject X-Forwarded-Scheme request header with the client-facing scheme
+	if !columnExists2(db, "proxy_hosts", "add_x_forwarded_scheme") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_forwarded_scheme INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.144: response_cache_ttl_sec — set Cache-Control: max-age=N on responses (0 = disabled)
+	if !columnExists2(db, "proxy_hosts", "response_cache_ttl_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN response_cache_ttl_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.145: add_link_preload — Link response header value for HTTP/2 preload hints (empty = disabled)
+	if !columnExists2(db, "proxy_hosts", "add_link_preload") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_link_preload TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.146: deny_path_regexp — reject requests whose path matches this regex with 403 (empty = disabled)
+	if !columnExists2(db, "proxy_hosts", "deny_path_regexp") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN deny_path_regexp TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.147: add_request_id_to_response — echo the request trace ID header in the response for client-side debugging
+	if !columnExists2(db, "proxy_hosts", "add_request_id_to_response") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_request_id_to_response INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.148: health_check_tls_server_name — TLS SNI override for active health check connections (empty = use upstream host)
+	if !columnExists2(db, "proxy_hosts", "health_check_tls_server_name") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_tls_server_name TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.149: add_x_real_ip — inject X-Real-IP header with the direct client IP address
+	if !columnExists2(db, "proxy_hosts", "add_x_real_ip") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_real_ip INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.150: strip_incoming_x_forwarded_for — delete X-Forwarded-For from incoming requests to prevent IP spoofing
+	if !columnExists2(db, "proxy_hosts", "strip_incoming_x_forwarded_for") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_incoming_x_forwarded_for INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.151: health_check_tls_insecure_skip_verify — skip TLS certificate verification for health check probes
+	if !columnExists2(db, "proxy_hosts", "health_check_tls_insecure_skip_verify") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_tls_insecure_skip_verify INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.152: add_cors_vary_header — add Vary: Origin response header for correct CDN caching of CORS responses
+	if !columnExists2(db, "proxy_hosts", "add_cors_vary_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_cors_vary_header INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.153: upstream_tls_alpn — comma-separated ALPN protocol list for upstream TLS connections
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_alpn") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_alpn TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.154: add_x_powered_by — custom X-Powered-By response header value (empty = disabled)
+	if !columnExists2(db, "proxy_hosts", "add_x_powered_by") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_powered_by TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.155: block_query_params — comma-separated query parameter names to block (403 if any present)
+	if !columnExists2(db, "proxy_hosts", "block_query_params") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN block_query_params TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.156: add_document_policy — Document-Policy response header value (empty = disabled)
+	if !columnExists2(db, "proxy_hosts", "add_document_policy") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_document_policy TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.157: maintenance_redirect_url — redirect to this URL instead of serving inline 503 during maintenance
+	if !columnExists2(db, "proxy_hosts", "maintenance_redirect_url") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN maintenance_redirect_url TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.158: upstream_keepalive_max_lifetime_sec — max lifetime for keepalive connections before being recycled (0 = no limit)
+	if !columnExists2(db, "proxy_hosts", "upstream_keepalive_max_lifetime_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_keepalive_max_lifetime_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.159: add_origin_header — inject Origin: <value> request header (for upstream APIs that require it)
+	if !columnExists2(db, "proxy_hosts", "add_origin_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_origin_header TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.160: upstream_tls_ca_pem_inline — inline PEM CA certificate for upstream TLS verification
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_ca_pem_inline") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_ca_pem_inline TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.161: add_server_timing_header — inject Server-Timing response header with upstream duration
+	if !columnExists2(db, "proxy_hosts", "add_server_timing_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_server_timing_header INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.162: add_clear_site_data — Clear-Site-Data response header value (e.g. "cache","cookies")
+	if !columnExists2(db, "proxy_hosts", "add_clear_site_data") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_clear_site_data TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.163: add_x_dns_prefetch_control — set X-DNS-Prefetch-Control: off response header
+	if !columnExists2(db, "proxy_hosts", "add_x_dns_prefetch_control") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_dns_prefetch_control INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.164: add_accept_ranges — set Accept-Ranges: bytes response header to signal byte-range support
+	if !columnExists2(db, "proxy_hosts", "add_accept_ranges") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_accept_ranges INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.165: add_content_disposition — Content-Disposition response header value (empty = disabled)
+	if !columnExists2(db, "proxy_hosts", "add_content_disposition") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_content_disposition TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.166: upstream_tls_server_name_from_host — use request Host header as upstream TLS SNI (dynamic)
+	if !columnExists2(db, "proxy_hosts", "upstream_tls_server_name_from_host") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN upstream_tls_server_name_from_host INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.167: add_x_permitted_cross_domain_policies — X-Permitted-Cross-Domain-Policies response header value
+	if !columnExists2(db, "proxy_hosts", "add_x_permitted_cross_domain_policies") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_permitted_cross_domain_policies TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.168: strip_response_headers — comma-separated list of response header names to delete
+	if !columnExists2(db, "proxy_hosts", "strip_response_headers") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN strip_response_headers TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.169: add_report_to — Report-To response header value (JSON endpoint group for CSP/NEL reporting)
+	if !columnExists2(db, "proxy_hosts", "add_report_to") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_report_to TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.170: add_nel_header — NEL (Network Error Logging) response header JSON config value
+	if !columnExists2(db, "proxy_hosts", "add_nel_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_nel_header TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.171: block_http_methods — comma-separated HTTP methods to reject with 405 Method Not Allowed
+	if !columnExists2(db, "proxy_hosts", "block_http_methods") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN block_http_methods TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.172: add_service_worker_allowed — Service-Worker-Allowed response header value (expand SW scope)
+	if !columnExists2(db, "proxy_hosts", "add_service_worker_allowed") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_service_worker_allowed TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.173: add_accept_ch — Accept-CH response header to declare accepted client hints
+	if !columnExists2(db, "proxy_hosts", "add_accept_ch") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_accept_ch TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.174: add_alt_svc — Alt-Svc response header value (advertise HTTP/2, HTTP/3 or other service)
+	if !columnExists2(db, "proxy_hosts", "add_alt_svc") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_alt_svc TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.175: add_content_language — Content-Language response header value
+	if !columnExists2(db, "proxy_hosts", "add_content_language") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_content_language TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.176: add_critical_ch — Critical-CH response header (lists client hints required before rendering)
+	if !columnExists2(db, "proxy_hosts", "add_critical_ch") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_critical_ch TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.177: add_x_download_options — set X-Download-Options: noopen to prevent IE file auto-open
+	if !columnExists2(db, "proxy_hosts", "add_x_download_options") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_download_options INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.178: deny_user_agent_regexp — block requests whose User-Agent matches this regexp with 403
+	if !columnExists2(db, "proxy_hosts", "deny_user_agent_regexp") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN deny_user_agent_regexp TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.179: add_pragma_no_cache — set Pragma: no-cache response header (HTTP/1.0 cache directive)
+	if !columnExists2(db, "proxy_hosts", "add_pragma_no_cache") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_pragma_no_cache INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.180: health_check_user_agent — custom User-Agent header value for active health check probes
+	if !columnExists2(db, "proxy_hosts", "health_check_user_agent") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN health_check_user_agent TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.181: add_x_request_path — inject X-Request-Path header with the request URI path on upstream calls
+	if !columnExists2(db, "proxy_hosts", "add_x_request_path") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_request_path INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.182: add_x_clacks_overhead — X-Clacks-Overhead response header (custom value, GNU Terry Pratchett tradition)
+	if !columnExists2(db, "proxy_hosts", "add_x_clacks_overhead") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_clacks_overhead TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.183: add_x_ua_compatible — X-UA-Compatible response header (e.g. 'IE=edge' for legacy IE rendering)
+	if !columnExists2(db, "proxy_hosts", "add_x_ua_compatible") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_ua_compatible TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.184: forward_auth_skip_paths — comma-separated path prefixes that bypass forward_auth (e.g. /health,/metrics)
+	if !columnExists2(db, "proxy_hosts", "forward_auth_skip_paths") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN forward_auth_skip_paths TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.185: add_age_zero — set Age: 0 response header to signal a fresh response (CDN bypass)
+	if !columnExists2(db, "proxy_hosts", "add_age_zero") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_age_zero INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.186: add_surrogate_control — Surrogate-Control response header value (CDN-only cache directive)
+	if !columnExists2(db, "proxy_hosts", "add_surrogate_control") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_surrogate_control TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.187: add_warning_header — Warning response header value (RFC 7234 warning codes)
+	if !columnExists2(db, "proxy_hosts", "add_warning_header") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_warning_header TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.188: add_x_request_method — forward X-Request-Method header (echoes the HTTP method) to upstream
+	if !columnExists2(db, "proxy_hosts", "add_x_request_method") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_request_method INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.189: add_x_request_query — forward X-Request-Query header (echoes the query string) to upstream
+	if !columnExists2(db, "proxy_hosts", "add_x_request_query") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_request_query INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.190: add_x_forwarded_user — static X-Forwarded-User request header value forwarded to upstream
+	if !columnExists2(db, "proxy_hosts", "add_x_forwarded_user") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_forwarded_user TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.191: add_x_real_scheme — forward X-Real-Scheme request header (http or https) to upstream
+	if !columnExists2(db, "proxy_hosts", "add_x_real_scheme") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_real_scheme INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.192: add_origin_agent_cluster — set Origin-Agent-Cluster: ?1 response header for origin-keyed isolation
+	if !columnExists2(db, "proxy_hosts", "add_origin_agent_cluster") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_origin_agent_cluster INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.193: add_x_forwarded_groups — static X-Forwarded-Groups request header value forwarded to upstream
+	if !columnExists2(db, "proxy_hosts", "add_x_forwarded_groups") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_forwarded_groups TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.194: add_x_forwarded_email — static X-Forwarded-Email request header value forwarded to upstream
+	if !columnExists2(db, "proxy_hosts", "add_x_forwarded_email") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_forwarded_email TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.195: add_x_forwarded_roles — static X-Forwarded-Roles request header value forwarded to upstream
+	if !columnExists2(db, "proxy_hosts", "add_x_forwarded_roles") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_forwarded_roles TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.196: block_query_param_regexp — block requests whose raw query string matches this regexp with 403
+	if !columnExists2(db, "proxy_hosts", "block_query_param_regexp") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN block_query_param_regexp TEXT NOT NULL DEFAULT ''`)
+	}
+	// v2.9.197: add_x_request_referer — forward X-Request-Referer header (echoes original Referer) to upstream
+	if !columnExists2(db, "proxy_hosts", "add_x_request_referer") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_request_referer INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.198: add_x_request_origin — forward X-Request-Origin header (echoes original Origin) to upstream
+	if !columnExists2(db, "proxy_hosts", "add_x_request_origin") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_request_origin INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.199: add_x_forwarded_uri — forward X-Forwarded-URI header (echoes original request URI) to upstream
+	if !columnExists2(db, "proxy_hosts", "add_x_forwarded_uri") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_forwarded_uri INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.200: add_x_no_archive — set X-No-Archive: yes response header to block search-engine archive caching
+	if !columnExists2(db, "proxy_hosts", "add_x_no_archive") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_no_archive INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.201: add_x_request_hostname — forward X-Request-Hostname header (echoes request hostname) to upstream
+	if !columnExists2(db, "proxy_hosts", "add_x_request_hostname") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_request_hostname INTEGER NOT NULL DEFAULT 0`)
+	}
+	// v2.9.202: add_x_xss_protection_disabled — set X-XSS-Protection: 0 response header (disable legacy XSS filter)
+	if !columnExists2(db, "proxy_hosts", "add_x_xss_protection_disabled") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN add_x_xss_protection_disabled INTEGER NOT NULL DEFAULT 0`)
+	}
+
 	return nil
+}
+
+// columnExists2 is a bool-only wrapper around columnExists for callers that
+// have already handled the error path and just need a true/false gate.
+func columnExists2(db *sql.DB, table, col string) bool {
+	ok, _ := columnExists(db, table, col)
+	return ok
 }
 
 func columnExists(db *sql.DB, table, col string) (bool, error) {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,9 +1,13 @@
 package models
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -25,6 +29,7 @@ type User struct {
 	CreatedAt    time.Time
 	TOTPSecret   string
 	TOTPEnabled  bool
+	BackupCodes  string // JSON array of SHA-256 hex hashes; empty means no backup codes set
 }
 
 const (
@@ -79,8 +84,510 @@ type ProxyHost struct {
 	CompressionEnabled     bool   // prepend gzip/zstd encode handler
 	SecurityHeadersEnabled bool   // add HSTS, X-Frame-Options, X-Content-Type-Options, etc.
 	TLSMinVersion          string // "" | "1.0" | "1.1" | "1.2" | "1.3"
-	CreatedAt              time.Time
-	UpdatedAt              time.Time
+	CustomReqHeaders  string // JSON: map[string]string of request headers to set/delete
+	CustomRespHeaders string // JSON: map[string]string of response headers to set/delete
+	URLRewrites       string // JSON: []URLRewriteRule
+	MaintenanceMode       bool   // v2.9.3: serve 503 instead of proxying
+	MaintenanceMsg        string // custom message shown on the 503 page
+	MaintenanceStatusCode int    // 503 (default), 429, 502, or 520
+	MaxRequestBodyMB  int    // 0 = unlimited; >0 = max body size in MiB
+	StickySessions    bool   // cookie-based LB for multi-upstream hosts
+	UpstreamTimeoutSec int  // 0 = Caddy default; >0 = dial/response timeout seconds
+	CORSEnabled  bool   // add CORS response headers
+	CORSOrigins  string // comma-separated allowed origins, or "*"
+	HealthCheckURI         string // e.g. "/health"; empty = no active checks
+	HealthCheckIntervalSec int    // default 30 when HealthCheckURI is set
+	HealthCheckMethod      string // "GET" (default) or "HEAD"
+	KeepaliveConns         int    // max idle conns per host; 0 = Caddy default
+	Tags                   string // comma-separated labels, UI-only
+	Notes                  string // freeform admin notes, UI-only
+	DisableAccessLog       bool   // skip analytics ingest for this host
+	AddRequestID           bool   // inject X-Request-Id header for distributed tracing
+	StripRespHeaders       string // comma-separated response header names to delete
+	BlockedAgents          string // comma-separated user-agent patterns to block (403)
+	ResponseCacheControl   string // override Cache-Control response header; empty = keep upstream value
+	UpstreamSNI            string // override TLS SNI for HTTPS upstreams with a different hostname
+	HSTSPreload            bool   // append "; preload" to the HSTS header when SecurityHeadersEnabled
+	MaxConnsPerHost        int    // max concurrent connections per upstream (0 = unlimited)
+	HealthCheckTimeoutSec  int    // active health check timeout in seconds (default 5)
+	UpstreamRetries        int    // number of retries on upstream failure (0 = no retry)
+	ForceHTTP1             bool   // force HTTP/1.1 to upstream (disables H2 upstreams)
+	BasicAuthRealm         string // realm shown in browser basic-auth prompt (default "Restricted")
+	ErrorPageHTML          string // custom HTML served when upstream returns 4xx/5xx; empty = pass through
+	// v2.9.5: scheduled maintenance window
+	MaintenanceWindowStart string // "HH:MM" (24-hour) when the window begins; "" = disabled
+	MaintenanceWindowEnd   string // "HH:MM" (24-hour) when the window ends
+	MaintenanceWindowDays  string // "" = every day; "mon,wed,fri" subset (3-letter abbrevs)
+	// v2.9.5: per-host security
+	IPBlocklist   string // comma-separated CIDR ranges to block (403 response)
+	LBPolicy      string // "" | "round_robin" | "random" | "ip_hash" | "least_conn" | "uri_hash" | "cookie"
+	ProxyProtocol         string // "" | "v1" | "v2" — PROXY protocol version for upstream transport
+	RobotsTxt             string // custom robots.txt body injected before the reverse proxy; empty = passthrough
+	PassiveFailDurationSec int    // seconds to hold upstream out-of-rotation after failures; 0 = disabled
+	PassiveMaxFails        int    // consecutive failures before marking unhealthy; 0 = Caddy default (1)
+	HSTSMaxAgeSec          int    // 0 = use default 31536000; >0 = custom max-age for Strict-Transport-Security
+	CSPHeader              string // Content-Security-Policy header value; empty = omit
+	H2CEnabled             bool   // use h2c (HTTP/2 cleartext) transport to upstream
+	HealthCheckHeaders     string // JSON map of headers to include in active health check requests
+	// v2.9.6: streaming, buffering, trusted proxy control
+	FlushImmediate  bool   // set flush_interval:-1 for SSE/streaming backends
+	BufferResponses bool   // buffer full response body before sending to client
+	TrustedProxies  string // comma-separated CIDR ranges trusted for X-Forwarded-For
+	// v2.9.7: host override, per-host read timeout, dotfile blocking
+	UpstreamHostOverride string // override Host header sent to upstream; "" = forward original
+	ReadTimeoutSec       int    // response body read timeout in seconds; 0 = no limit
+	DenyDotfiles         bool   // block requests to dotfiles/directories (403)
+	// v2.9.8: request buffering; CORS enhancements
+	RequestBuffersKB      int    // buffer this many KB of request body before forwarding; 0 = disabled
+	CORSAllowCredentials  bool   // add Access-Control-Allow-Credentials: true
+	CORSExposeHeaders     string // comma-separated list for Access-Control-Expose-Headers
+	// v2.9.9: upstream TLS verification; separate dial timeout
+	SSLVerifyUpstream bool // verify upstream TLS certificate (default: skip verify)
+	DialTimeoutSec    int  // dial/connect timeout in seconds; 0 = use upstream_timeout_sec or Caddy default
+	// v2.9.10: header-based API key auth; empty User-Agent blocking
+	APIKeyHeader          string // header name for API key authentication (e.g. "X-API-Key"); "" = disabled
+	APIKeyValue           string // expected API key value; "" = disabled
+	BlockEmptyUserAgent   bool   // return 403 if the request has no User-Agent header
+	// v2.9.11: error redirect URL; granular security header overrides
+	ErrorRedirectURL  string // redirect client here on 4xx/5xx from upstream (overrides error_page_html)
+	PermissionsPolicy string // custom Permissions-Policy header value; empty = omit
+	XFrameOptions     string // override X-Frame-Options in security bundle; empty = use "SAMEORIGIN"
+	ReferrerPolicy    string // override Referrer-Policy in security bundle; empty = use default
+	// v2.9.14: HSTS includeSubDomains toggle; CSP report-only; keepalive idle timeout
+	HSTSIncludeSubdomains   bool   // add "; includeSubDomains" to HSTS header (DB DEFAULT 1 preserves prior always-on behaviour)
+	CSPReportOnly           string // Content-Security-Policy-Report-Only header value
+	KeepaliveIdleTimeoutSec int    // upstream keepalive idle timeout in seconds (0 = default 90 s)
+	// v2.9.15: active health check expected response controls
+	HealthCheckExpectStatus    int    // 0 = any 2xx; >0 = require that exact HTTP status code
+	HealthCheckExpectBody      string // regexp that must match somewhere in the response body
+	HealthCheckFollowRedirects bool   // follow redirects during active health probes
+	// v2.9.16: path-based routing
+	PathMatcher     string // if non-empty, route only matches this path prefix (e.g. "/api")
+	StripPathPrefix bool   // strip PathMatcher prefix before forwarding to upstream
+	// v2.9.17: load-balancer tuning
+	StickyCookieName  string // custom cookie name for sticky-session LB (default "lb_backend")
+	LBTryDurationSec  int    // seconds to keep retrying across upstreams (0 = Caddy default)
+	LBTryIntervalMS   int    // ms between retry attempts (0 = Caddy default 250ms)
+	// v2.9.18: compression min size + client IP forwarding
+	CompressionMinSizeKB int  // minimum response size in KB to compress (0 = always compress)
+	ForwardClientIP      bool // add X-Real-IP header with the real client IP to upstream requests
+	// v2.9.19: CORS fine-tuning
+	CORSMaxAgeSec      int    // Access-Control-Max-Age in seconds (0 = default 86400)
+	CORSAllowMethods   string // override Access-Control-Allow-Methods (empty = use default)
+	CORSAllowHeaders   string // override Access-Control-Allow-Headers (empty = use default)
+	// v2.9.22
+	RetryStatusCodes string // comma-separated HTTP status codes to trigger retry (e.g. "502,503,504")
+	WriteTimeoutSec  int    // time to write request body to upstream; 0 = no limit
+	// v2.9.23
+	UpstreamTLSMinVersion string // "" | "1.2" | "1.3" — minimum TLS version for upstream connections
+	ForwardProxyURL       string // chain through an upstream HTTP proxy (e.g. "http://squid:3128")
+	// v2.9.25
+	BlockedMethods string // comma-separated HTTP methods to block with 405 (e.g. "TRACE,CONNECT")
+	// v2.9.27: forward auth
+	ForwardAuthURL         string // auth service URL; empty = disabled
+	ForwardAuthCopyHeaders string // comma-separated response headers to copy from auth service to upstream
+	// v2.9.28: query string control
+	StripQueryString  bool   // remove the entire query string before forwarding
+	DeleteQueryParams string // comma-separated query param names to strip (e.g. "utm_source,fbclid")
+	// v2.9.29: request/response timing
+	RequestBodyReadTimeoutSec  int // client→caddy request body read timeout; 0 = no limit
+	ResponseHeaderTimeoutSec   int // caddy→upstream response header wait; 0 = use upstream_timeout_sec
+	// v2.9.31: upstream connection lifetime limit
+	MaxConnDurationSec int // 0 = unlimited; >0 = max seconds before Caddy replaces the upstream conn
+	// v2.9.32: upstream response decompression before client delivery
+	DecompressResponse bool // when true, decompress gzip/br upstream responses before forwarding
+	// v2.9.33: color label for visual grouping in list views (no Caddy impact)
+	Color string // "" | "red" | "orange" | "yellow" | "green" | "teal" | "blue" | "purple" | "pink" | "gray"
+	// v2.9.34: automatic www ↔ bare domain redirect injected before the proxy
+	WWWRedirect string // "" (off) | "to_www" (bare→www) | "to_bare" (www→bare)
+	// v2.9.35: strip request headers — companion to StripRespHeaders for the request side
+	StripReqHeaders string // comma-separated request header names to delete before forwarding
+	// v2.9.36: upstream path prefix — prepend a static prefix to every upstream request URI
+	UpstreamPathPrefix string // e.g. "/v2" → proxy / → upstream /v2/
+	// v2.9.37: compression tuning
+	CompressionLevel      int  // 0 = default; 1-9 for gzip level (1 fast, 9 best)
+	CompressionPreferGzip bool // when true, prefer gzip over zstd in encode handler
+	// v2.9.39: sort order — manual ordering weight in the list view (0 = default, lower = first)
+	SortOrder int
+	// v2.9.41: allowed_methods — HTTP method allowlist; empty = allow all (complement to BlockedMethods denylist)
+	AllowedMethods string // comma-separated methods, e.g. "GET,POST,PUT" — requests with other methods get 405
+	// v2.9.42: upstream max response header size in KB (0 = Caddy default ~1MB)
+	UpstreamMaxRespHeaderKB int // transport.max_response_header_size in bytes = value * 1024
+	// v2.9.43: dedicated health check port — run active probes on a different port than traffic (0 = same port)
+	HealthCheckPort int // e.g. 8080 when the app serves /health on :8080 but traffic on :80
+	// v2.9.44: request_id_header_name — custom header for injected request IDs ('' = X-Request-Id default)
+	RequestIDHeaderName string // e.g. "X-Trace-Id"; only used when AddRequestID is true
+	// v2.9.45: lb_cookie_path — path scope for the sticky-session LB cookie ('' = / default)
+	LBCookiePath string // e.g. "/api" scopes the cookie to /api subtree only
+	// v2.9.46: passive_unhealthy_latency_ms — mark upstream passive-unhealthy above this latency (0 = disabled)
+	PassiveUnhealthyLatencyMS int // e.g. 5000 → trigger unhealthy if response > 5s
+	// v2.9.47: tls_handshake_timeout_sec — TLS handshake timeout for upstream connections (0 = Caddy default)
+	TLSHandshakeTimeoutSec int // only applies when ForwardScheme=https or UpstreamTLSMinVersion is set
+	// v2.9.48: expect_continue_timeout_sec — wait for upstream 100-Continue (0 = disabled/no wait)
+	ExpectContinueTimeoutSec int // useful for large file uploads behind a reverse proxy
+	// v2.9.49: response_buffers_kb — per-connection response streaming buffer size (0 = Caddy default)
+	ResponseBuffersKB int // sets Caddy reverse_proxy.response_buffers; distinct from BufferResponses bool
+	// v2.9.50: upstream_max_idle_conns — total idle connections across all upstream hosts (0 = Caddy default)
+	UpstreamMaxIdleConns int // transport.keep_alive.max_idle_conns; complement to per-host KeepaliveConns
+	// v2.9.51: upstream_keep_alive_probe_sec — interval for TCP keepalive probes to upstreams (0 = no probing)
+	UpstreamKeepAliveProbeIntervalSec int // transport.keep_alive.probe_interval
+	// v2.9.52: forward_auth_method — HTTP method for ForwardAuth subrequest ('' = GET default)
+	ForwardAuthMethod string // "GET" | "POST" | "HEAD" — method used when calling the auth service
+	// v2.9.53: grpc_web_enabled — prepend the grpc_web handler to transcode gRPC-Web to gRPC for the upstream
+	GRPCWebEnabled bool // allows browser clients that use gRPC-Web or gRPC-Gateway to reach gRPC upstreams
+	// v2.9.54: forward_auth_headers_prefix — prefix applied to all headers copied from the ForwardAuth response
+	ForwardAuthHeadersPrefix string // e.g. "X-Auth-" → header Foo from auth becomes X-Auth-Foo upstream
+	// v2.9.55: health_check_max_size_kb — max body bytes read from upstream during active health checks (0 = Caddy default)
+	HealthCheckMaxSizeKB int // reduces memory use when upstream returns large responses on the health endpoint
+	// v2.9.56: strip_path_suffix — strip this static suffix from the request path before proxying (e.g. ".html")
+	StripPathSuffix string // Caddy rewrite.strip_path_suffix; complements StripPathPrefix
+	// v2.9.57: add_req_query_params — newline or comma-separated key=value pairs appended to upstream query string
+	AddReqQueryParams string // e.g. "version=2,debug=false" → upstream gets ?version=2&debug=false appended
+	// v2.9.58: error_page_codes — comma-separated HTTP codes that trigger ErrorPageHTML (empty = all 4xx/5xx)
+	ErrorPageCodes string // e.g. "404,500,503" — only serve custom error page for these codes
+	// v2.9.59: upstream_tls_ca_pem_file — path to CA certificate bundle for upstream TLS verification
+	UpstreamTLSCAPEMFile string // only used when SSLVerifyUpstream=true; '' = system default CA
+	// v2.9.60: keepalive_disabled — completely disable upstream TCP keepalive (for NTLM/kerberos auth upstreams)
+	KeepaliveDisabled bool // when true, every upstream request uses a new connection (no pooling)
+	// v2.9.61: trailing_slash_redirect — auto-redirect for trailing slash normalisation ('' = off | "add" = add / | "remove" = strip /)
+	TrailingSlashRedirect string // injected as a subroute redirect before the proxy
+	// v2.9.62: dial_fallback_delay_ms — ms to wait before falling back to the next upstream on dial failure
+	DialFallbackDelayMS int // Caddy transport.dial_fallback_delay; 0 = Caddy default (300ms)
+	// v2.9.63: upstream_network — TCP protocol variant for upstream dial ('' = tcp | "tcp4" | "tcp6")
+	UpstreamNetwork string // force IPv4 or IPv6 for upstream connections
+	// v2.9.64: dns_resolver — custom DNS server for resolving upstream hostnames ('' = system resolver)
+	DNSResolver string // e.g. "1.1.1.1:53"; only used when UpstreamNetwork or dial requires DNS
+	// v2.9.65: path_matcher_type — how PathMatcher is interpreted ('' = prefix | "exact" | "regexp")
+	PathMatcherType string // '' (prefix, default) | "exact" | "regexp"
+	// v2.9.66: cors_allow_private_network — add Access-Control-Allow-Private-Network: true for Chrome private network access
+	CORSAllowPrivateNetwork bool // RFC-compliant CORS extension for private network requests from browser
+	// v2.9.67: robots_txt_disallow_all — serve "User-agent: *\nDisallow: /" robots.txt as a quick bot block
+	RobotsTxtDisallowAll bool // overrides RobotsTxt field; prepended before the proxy
+	// v2.9.68: maintenance_retry_after_sec — Retry-After header value in maintenance 503 response (0 = default 3600)
+	MaintenanceRetryAfterSec int
+	// v2.9.69: upstream_resolve_timeout_sec — timeout in seconds for DNS resolution of upstream hostnames (0 = Caddy default)
+	UpstreamResolveTimeoutSec int
+	// v2.9.70: upstream_read_buffer_size_kb — transport read buffer size in KB (0 = Caddy default 32KB)
+	UpstreamReadBufferSizeKB int
+	// v2.9.71: upstream_write_buffer_size_kb — transport write buffer size in KB (0 = Caddy default 32KB)
+	UpstreamWriteBufferSizeKB int
+	// v2.9.72: req_header_replace — newline-separated "Name|regexp|replacement" rules applied to request header values
+	ReqHeaderReplace string
+	// v2.9.73: resp_header_replace — newline-separated "Name|regexp|replacement" rules applied to response header values
+	RespHeaderReplace string
+	// v2.9.74: upstream_http_versions — comma-separated HTTP version list for upstream transport ('' = Caddy default)
+	UpstreamHTTPVersions string // e.g. "1.1" | "2" | "1.1,2" — overrides ForceHTTP1/H2CEnabled when set
+	// v2.9.75: health_check_body — request body sent with active health check probes (e.g. a JSON payload)
+	HealthCheckBody string
+	// v2.9.76: add_canonical_link_header — inject Link: <https://primarydomain/>; rel="canonical" response header
+	AddCanonicalLinkHeader bool
+	// v2.9.77: http_basic_auth_upstream — "user:pass" credentials injected as Authorization: Basic to upstream requests
+	HTTPBasicAuthUpstream string // stored in plain text; base64-encoded at config-build time
+	// v2.9.78: block_ua_regexp — Go regexp pattern; requests whose User-Agent matches receive a 403
+	BlockUARegexp string
+	// v2.9.79: security_txt_body — serve this text at GET/HEAD /.well-known/security.txt before proxying
+	SecurityTxtBody string
+	// v2.9.80: server_header_value — override the Server response header ('' = keep upstream value)
+	ServerHeaderValue string
+	// v2.9.81: x_robots_tag — X-Robots-Tag response header value ('' = omit header)
+	XRobotsTag string
+	// v2.9.82: add_forwarded_header — inject RFC 7239 Forwarded header on upstream requests
+	AddForwardedHeader bool
+	// v2.9.83: lb_cookie_secret — HMAC secret for signing sticky-session cookies (prevents client tampering)
+	LBCookieSecret string
+	// v2.9.84: passive_unhealthy_status_codes — comma-separated HTTP codes that mark upstream passive-unhealthy
+	PassiveUnhealthyStatusCodes string
+	// v2.9.85: health_check_content_type — Content-Type header value sent with active health check requests
+	HealthCheckContentType string
+	// v2.9.86: upstream_tls_client_cert_file — path to PEM client certificate for mutual TLS to upstream
+	UpstreamTLSClientCertFile string
+	// v2.9.87: upstream_tls_client_key_file — path to PEM private key matching UpstreamTLSClientCertFile
+	UpstreamTLSClientKeyFile string
+	// v2.9.88: block_private_ips — reject incoming connections from RFC 1918 / loopback IP ranges (403)
+	BlockPrivateIPs bool
+	// v2.9.89: enable_brotli — include brotli (br) in the encode handler when CompressionEnabled is true
+	EnableBrotli bool
+	// v2.9.90: vary_header — value for the Vary response header ('' = omit)
+	VaryHeader string
+	// v2.9.91: strip_etag — delete ETag response header from upstream responses
+	StripETag bool
+	// v2.9.92: http2_push_paths — newline-separated resource paths to push via HTTP/2 server push
+	HTTP2PushPaths string
+	// v2.9.93: deny_content_types — comma-separated Content-Type prefixes that receive 415
+	DenyContentTypes string
+	// v2.9.94: upstream_local_addr — local IP address to bind when dialing upstream connections
+	UpstreamLocalAddr string
+	// v2.9.95: upstream_tls_renegotiation — TLS renegotiation policy for upstream connections: '' (never) | 'once' | 'freely'
+	UpstreamTLSRenegotiation string
+	// v2.9.96: upstream_tls_curves — comma-separated TLS curve names for upstream connections ('' = Caddy default)
+	UpstreamTLSCurves string
+	// v2.9.97: upstream_tls_max_version — maximum TLS version for upstream connections: '' | '1.2' | '1.3'
+	UpstreamTLSMaxVersion string
+	// v2.9.98: upstream_tls_pins — newline-separated SHA-256 SPKI fingerprints for upstream certificate pinning
+	UpstreamTLSPins string
+	// v2.9.99: lb_header_field — request header name used by the 'header' LB selection policy for sticky routing
+	LBHeaderField string
+	// v2.9.100: maintenance_custom_headers — newline-separated "Name: Value" headers added to the 503 maintenance response
+	MaintenanceCustomHeaders string
+	// v2.9.101: deny_extensions — comma-separated file extensions to block (e.g. ".php,.asp,.aspx") — returns 403
+	DenyExtensions string
+	// v2.9.102: inject_request_timestamp — add X-Request-Timestamp header with UNIX epoch to upstream requests
+	InjectRequestTimestamp bool
+	// v2.9.103: add_resp_cookies — newline-separated Set-Cookie header values added to every response
+	AddRespCookies string
+	// v2.9.104: strip_accept_encoding — delete Accept-Encoding request header before forwarding to upstream
+	StripAcceptEncoding bool
+	// v2.9.105: add_upstream_timing_header — inject X-Upstream-Time response header with upstream latency
+	AddUpstreamTimingHeader bool
+	// v2.9.106: strip_server_header — delete Server response header from upstream replies
+	StripServerHeader bool
+	// v2.9.107: block_referer_regexp — Go regexp; requests whose Referer header matches receive 403 (hotlink protection)
+	BlockRefererRegexp string
+	// v2.9.108: add_content_type_nosniff — add X-Content-Type-Options: nosniff response header
+	AddContentTypeNosniff bool
+	// v2.9.109: strip_authorization_header — delete Authorization request header before forwarding to upstream
+	StripAuthorizationHeader bool
+	// v2.9.110: real_ip_from_header — copy real client IP from this request header name into X-Real-IP (e.g. "CF-Connecting-IP")
+	RealIPFromHeader string
+	// v2.9.111: health_check_host_override — override Host header sent during active health check probes
+	HealthCheckHostOverride string
+	// v2.9.112: add_x_forwarded_port — add X-Forwarded-Port request header with the incoming request port
+	AddXForwardedPort bool
+	// v2.9.113: lb_retry_on — comma-separated retry trigger conditions ("error","5xx","4xx","connect_error","timeout","reset")
+	LBRetryOn string
+	// v2.9.114: max_buffer_size_kb — maximum bytes to buffer when buffer_responses is enabled (0 = unlimited)
+	MaxBufferSizeKB int
+	// v2.9.115: upstream_keepalive_probes — TCP keepalive probe count for upstream connections
+	UpstreamKeepaliveProbes int
+	// v2.9.116: upstream_flush_interval_ms — flush_interval override in ms (0=default, -1=immediate, >0=interval)
+	UpstreamFlushIntervalMS int
+	// v2.9.117: add_x_forwarded_host — inject X-Forwarded-Host request header with original Host value
+	AddXForwardedHost bool
+	// v2.9.118: maintenance_allowed_ips — comma-separated CIDRs that bypass maintenance mode
+	MaintenanceAllowedIPs string
+	// v2.9.119: upstream_tls_cipher_suites — comma-separated TLS cipher suite names for upstream connections
+	UpstreamTLSCipherSuites string
+	// v2.9.120: add_cache_control_no_store — add Cache-Control: no-store response header
+	AddCacheControlNoStore bool
+	// v2.9.121: deny_referer_empty — block requests that have no Referer header (anti-hotlinking)
+	DenyRefererEmpty bool
+	// v2.9.122: lb_cookie_httponly — set HttpOnly flag on the sticky-session cookie
+	LBCookieHTTPOnly bool
+	// v2.9.123: lb_cookie_secure — set Secure flag on the sticky-session cookie
+	LBCookieSecure bool
+	// v2.9.124: lb_cookie_same_site — SameSite attribute on the sticky-session cookie ("Strict","Lax","None")
+	LBCookieSameSite string
+	// v2.9.125: upstream_tls_early_data — enable TLS 1.3 early data (0-RTT) for upstream connections
+	UpstreamTLSEarlyData bool
+	// v2.9.126: add_via_header — add Via response header identifying this proxy
+	AddViaHeader bool
+	// v2.9.127: req_header_rename — newline-separated "OldName: NewName" pairs to rename request headers
+	ReqHeaderRename string
+	// v2.9.128: add_expect_ct_header — add Expect-CT: enforce response header for certificate transparency
+	AddExpectCTHeader bool
+	// v2.9.129: force_upstream_encoding — override Accept-Encoding sent to upstream (e.g. "gzip","identity","br")
+	ForceUpstreamEncoding string
+	// v2.9.130: passive_unhealthy_count — max concurrent in-flight requests before flagging upstream overloaded
+	PassiveUnhealthyCount int
+	// v2.9.131: strip_x_powered_by — delete X-Powered-By response header from upstream replies
+	StripXPoweredBy bool
+	// v2.9.132: add_timing_allow_origin — value for Timing-Allow-Origin response header (e.g. "*")
+	AddTimingAllowOrigin string
+	// v2.9.133: lb_cookie_max_age_sec — max-age in seconds for the sticky-session cookie (0 = session)
+	LBCookieMaxAgeSec int
+	// v2.9.134: cross_origin_opener_policy — Cross-Origin-Opener-Policy response header value
+	CrossOriginOpenerPolicy string
+	// v2.9.135: cross_origin_resource_policy — Cross-Origin-Resource-Policy response header value
+	CrossOriginResourcePolicy string
+	// v2.9.136: cross_origin_embedder_policy — Cross-Origin-Embedder-Policy response header value
+	CrossOriginEmbedderPolicy string
+	// v2.9.137: deny_request_content_type — comma-separated MIME types to block on request Content-Type (returns 415)
+	DenyRequestContentType string
+	// v2.9.138: compression_exclude_regexp — regexp of paths to exclude from response compression
+	CompressionExcludeRegexp string
+	// v2.9.139: add_cache_control_public — add Cache-Control: public response header
+	AddCacheControlPublic bool
+	// v2.9.140: add_x_request_start — inject X-Request-Start header with Unix ms timestamp for APM tools
+	AddXRequestStart bool
+	// v2.9.141: maintenance_window_timezone — IANA timezone name for the scheduled maintenance window (empty = server local)
+	MaintenanceWindowTimezone string
+	// v2.9.142: lb_random_choose_count — "choose" count for random_choice lb policy (0 = disabled)
+	LBRandomChooseCount int
+	// v2.9.143: add_x_forwarded_scheme — inject X-Forwarded-Scheme: {scheme} request header
+	AddXForwardedScheme bool
+	// v2.9.144: response_cache_ttl_sec — set Cache-Control: max-age=N on responses (0 = disabled)
+	ResponseCacheTTLSec int
+	// v2.9.145: add_link_preload — Link response header value for HTTP/2 preload hints
+	AddLinkPreload string
+	// v2.9.146: deny_path_regexp — block requests whose path matches this regex (403)
+	DenyPathRegexp string
+	// v2.9.147: add_request_id_to_response — echo request trace ID in response header for debugging
+	AddRequestIDToResponse bool
+	// v2.9.148: health_check_tls_server_name — TLS SNI override for active health check connections
+	HealthCheckTLSServerName string
+	// v2.9.149: add_x_real_ip — inject X-Real-IP request header with the direct client IP
+	AddXRealIP bool
+	// v2.9.150: strip_incoming_x_forwarded_for — delete X-Forwarded-For from incoming requests (prevent IP spoofing)
+	StripIncomingXForwardedFor bool
+	// v2.9.151: health_check_tls_insecure_skip_verify — skip TLS cert verification for health check probes
+	HealthCheckTLSInsecureSkipVerify bool
+	// v2.9.152: add_cors_vary_header — add Vary: Origin response header for CDN caching of CORS responses
+	AddCORSVaryHeader bool
+	// v2.9.153: upstream_tls_alpn — comma-separated ALPN protocol list for upstream TLS connections
+	UpstreamTLSALPN string
+	// v2.9.154: add_x_powered_by — custom X-Powered-By response header value (empty = disabled)
+	AddXPoweredBy string
+	// v2.9.155: block_query_params — comma-separated query param names to block (403 if any present)
+	BlockQueryParams string
+	// v2.9.156: add_document_policy — Document-Policy response header value
+	AddDocumentPolicy string
+	// v2.9.157: maintenance_redirect_url — redirect to this URL during maintenance (overrides inline 503)
+	MaintenanceRedirectURL string
+	// v2.9.158: upstream_keepalive_max_lifetime_sec — max lifetime for keepalive connections before recycling (0 = no limit)
+	UpstreamKeepaliveMaxLifetimeSec int
+	// v2.9.159: add_origin_header — inject Origin: <value> request header for upstream APIs that require it
+	AddOriginHeader string
+	// v2.9.160: upstream_tls_ca_pem_inline — inline PEM CA certificate for upstream TLS verification
+	UpstreamTLSCAPEMInline string
+	// v2.9.161: add_server_timing_header — inject Server-Timing response header with upstream duration
+	AddServerTimingHeader bool
+	// v2.9.162: add_clear_site_data — Clear-Site-Data response header value (e.g. "cache","cookies")
+	AddClearSiteData string
+	// v2.9.163: add_x_dns_prefetch_control — set X-DNS-Prefetch-Control: off response header
+	AddXDNSPrefetchControl bool
+	// v2.9.164: add_accept_ranges — set Accept-Ranges: bytes response header
+	AddAcceptRanges bool
+	// v2.9.165: add_content_disposition — Content-Disposition response header value
+	AddContentDisposition string
+	// v2.9.166: upstream_tls_server_name_from_host — use request Host as upstream TLS SNI (dynamic)
+	UpstreamTLSServerNameFromHost bool
+	// v2.9.167: add_x_permitted_cross_domain_policies — X-Permitted-Cross-Domain-Policies response header value
+	AddXPermittedCrossDomainPolicies string
+	// v2.9.168: strip_response_headers — comma-separated list of response header names to delete
+	StripResponseHeaders string
+	// v2.9.169: add_report_to — Report-To response header value (JSON endpoint group for CSP/NEL reporting)
+	AddReportTo string
+	// v2.9.170: add_nel_header — NEL response header JSON config (Network Error Logging)
+	AddNELHeader string
+	// v2.9.171: block_http_methods — comma-separated HTTP methods to reject with 405
+	BlockHTTPMethods string
+	// v2.9.172: add_service_worker_allowed — Service-Worker-Allowed response header value
+	AddServiceWorkerAllowed string
+	// v2.9.173: add_accept_ch — Accept-CH response header value (declare accepted client hints)
+	AddAcceptCH string
+	// v2.9.174: add_alt_svc — Alt-Svc response header value (advertise HTTP/2 or HTTP/3 service endpoint)
+	AddAltSvc string
+	// v2.9.175: add_content_language — Content-Language response header value
+	AddContentLanguage string
+	// v2.9.176: add_critical_ch — Critical-CH response header (client hints required before rendering)
+	AddCriticalCH string
+	// v2.9.177: add_x_download_options — set X-Download-Options: noopen (IE file open prevention)
+	AddXDownloadOptions bool
+	// v2.9.178: deny_user_agent_regexp — block requests whose User-Agent matches this regexp with 403
+	DenyUserAgentRegexp string
+	// v2.9.179: add_pragma_no_cache — set Pragma: no-cache response header (HTTP/1.0 cache directive)
+	AddPragmaNoCache bool
+	// v2.9.180: health_check_user_agent — custom User-Agent for active health check probes
+	HealthCheckUserAgent string
+	// v2.9.181: add_x_request_path — inject X-Request-Path header (request URI path) on upstream requests
+	AddXRequestPath bool
+	// v2.9.182: add_x_clacks_overhead — X-Clacks-Overhead response header value
+	AddXClacksOverhead string
+	// v2.9.183: add_x_ua_compatible — X-UA-Compatible response header value (e.g. 'IE=edge')
+	AddXUACompatible string
+	// v2.9.184: forward_auth_skip_paths — comma-separated path prefixes that bypass forward_auth
+	ForwardAuthSkipPaths string
+	// v2.9.185: add_age_zero — set Age: 0 response header (signal fresh response to CDNs)
+	AddAgeZero bool
+	// v2.9.186: add_surrogate_control — Surrogate-Control response header value (CDN-only cache directive)
+	AddSurrogateControl string
+	// v2.9.187: add_warning_header — Warning response header value (RFC 7234 warning codes)
+	AddWarningHeader string
+	// v2.9.188: add_x_request_method — forward X-Request-Method header (echoes HTTP method) to upstream
+	AddXRequestMethod bool
+	// v2.9.189: add_x_request_query — forward X-Request-Query header (echoes query string) to upstream
+	AddXRequestQuery bool
+	// v2.9.190: add_x_forwarded_user — static X-Forwarded-User request header value
+	AddXForwardedUser string
+	// v2.9.191: add_x_real_scheme — forward X-Real-Scheme request header (http or https) to upstream
+	AddXRealScheme bool
+	// v2.9.192: add_origin_agent_cluster — set Origin-Agent-Cluster: ?1 response header (origin-keyed isolation hint)
+	AddOriginAgentCluster bool
+	// v2.9.193: add_x_forwarded_groups — static X-Forwarded-Groups request header value
+	AddXForwardedGroups string
+	// v2.9.194: add_x_forwarded_email — static X-Forwarded-Email request header value
+	AddXForwardedEmail string
+	// v2.9.195: add_x_forwarded_roles — static X-Forwarded-Roles request header value
+	AddXForwardedRoles string
+	// v2.9.196: block_query_param_regexp — block requests whose raw query string matches this regexp with 403
+	BlockQueryParamRegexp string
+	// v2.9.197: add_x_request_referer — forward X-Request-Referer header (echoes original Referer) to upstream
+	AddXRequestReferer bool
+	// v2.9.198: add_x_request_origin — forward X-Request-Origin header (echoes original Origin) to upstream
+	AddXRequestOrigin bool
+	// v2.9.199: add_x_forwarded_uri — forward X-Forwarded-URI header (echoes original URI) to upstream
+	AddXForwardedURI bool
+	// v2.9.200: add_x_no_archive — set X-No-Archive: yes response header to block archive caching
+	AddXNoArchive bool
+	// v2.9.201: add_x_request_hostname — forward X-Request-Hostname header (echoes hostname) to upstream
+	AddXRequestHostname bool
+	// v2.9.202: add_x_xss_protection_disabled — set X-XSS-Protection: 0 response header
+	AddXXSSProtectionDisabled bool
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+// InScheduledMaintenanceWindow returns true when the current wall-clock time
+// falls inside this host's scheduled maintenance window, respecting the optional
+// day-of-week restriction (MaintenanceWindowDays). Returns false when the window
+// is not configured or the time strings are malformed.
+func (p *ProxyHost) InScheduledMaintenanceWindow() bool {
+	if p.MaintenanceWindowStart == "" || p.MaintenanceWindowEnd == "" {
+		return false
+	}
+	now := time.Now()
+	// v2.9.141: maintenance_window_timezone — evaluate the window in the configured IANA timezone.
+	if p.MaintenanceWindowTimezone != "" {
+		if loc, err := time.LoadLocation(p.MaintenanceWindowTimezone); err == nil {
+			now = now.In(loc)
+		}
+	}
+	if p.MaintenanceWindowDays != "" {
+		abbr := strings.ToLower(now.Weekday().String()[:3])
+		matched := false
+		for _, d := range strings.Split(strings.ToLower(p.MaintenanceWindowDays), ",") {
+			if strings.TrimSpace(d) == abbr {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	parseHHMM := func(s string) (int, bool) {
+		parts := strings.SplitN(strings.TrimSpace(s), ":", 2)
+		if len(parts) != 2 {
+			return 0, false
+		}
+		h, e1 := strconv.Atoi(parts[0])
+		m, e2 := strconv.Atoi(parts[1])
+		if e1 != nil || e2 != nil || h < 0 || h > 23 || m < 0 || m > 59 {
+			return 0, false
+		}
+		return h*60 + m, true
+	}
+	startMins, ok1 := parseHHMM(p.MaintenanceWindowStart)
+	endMins, ok2 := parseHHMM(p.MaintenanceWindowEnd)
+	if !ok1 || !ok2 {
+		return false
+	}
+	nowMins := now.Hour()*60 + now.Minute()
+	if startMins < endMins {
+		return nowMins >= startMins && nowMins < endMins
+	}
+	// Overnight window (e.g. 23:00–01:00): active after start OR before end.
+	return nowMins >= startMins || nowMins < endMins
 }
 
 // BasicAuthUserList parses the JSON-encoded BasicAuthUsers string into a slice.
@@ -105,6 +612,47 @@ func (p *ProxyHost) ExtraUpstreamList() []string {
 	return list
 }
 
+// CustomReqHeaderMap parses CustomReqHeaders into a map. Returns nil if empty.
+func (p *ProxyHost) CustomReqHeaderMap() map[string]string {
+	if p.CustomReqHeaders == "" || p.CustomReqHeaders == "{}" {
+		return nil
+	}
+	var m map[string]string
+	_ = json.Unmarshal([]byte(p.CustomReqHeaders), &m)
+	return m
+}
+
+// CustomRespHeaderMap parses CustomRespHeaders into a map. Returns nil if empty.
+func (p *ProxyHost) CustomRespHeaderMap() map[string]string {
+	if p.CustomRespHeaders == "" || p.CustomRespHeaders == "{}" {
+		return nil
+	}
+	var m map[string]string
+	_ = json.Unmarshal([]byte(p.CustomRespHeaders), &m)
+	return m
+}
+
+// URLRewriteRule is one rewrite entry on a proxy host.
+// Type is "strip_prefix", "add_prefix", or "regex".
+// For strip_prefix/add_prefix: From is the prefix string, To is ignored/target prefix.
+// For regex: From is the pattern, To is the replacement.
+type URLRewriteRule struct {
+	Type string `json:"type"` // "strip_prefix" | "add_prefix" | "regex"
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// URLRewriteList parses the JSON-encoded URLRewrites string.
+// Returns nil if empty or unparseable.
+func (p *ProxyHost) URLRewriteList() []URLRewriteRule {
+	if p.URLRewrites == "" || p.URLRewrites == "[]" {
+		return nil
+	}
+	var rules []URLRewriteRule
+	_ = json.Unmarshal([]byte(p.URLRewrites), &rules)
+	return rules
+}
+
 func (p ProxyHost) DomainList() []string {
 	parts := strings.Split(p.Domains, ",")
 	out := make([]string, 0, len(parts))
@@ -112,6 +660,52 @@ func (p ProxyHost) DomainList() []string {
 		d = strings.TrimSpace(d)
 		if d != "" {
 			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// TagList returns Tags split into individual trimmed strings, filtering empties.
+func (p *ProxyHost) TagList() []string {
+	if p.Tags == "" {
+		return nil
+	}
+	parts := strings.Split(p.Tags, ",")
+	out := make([]string, 0, len(parts))
+	for _, t := range parts {
+		t = strings.TrimSpace(t)
+		if t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// StripRespHeaderList parses the comma-separated strip_resp_headers field.
+func (p *ProxyHost) StripRespHeaderList() []string {
+	if p.StripRespHeaders == "" {
+		return nil
+	}
+	var out []string
+	for _, h := range strings.Split(p.StripRespHeaders, ",") {
+		h = strings.TrimSpace(h)
+		if h != "" {
+			out = append(out, http.CanonicalHeaderKey(h))
+		}
+	}
+	return out
+}
+
+// StripReqHeaderList parses the comma-separated strip_req_headers field.
+func (p *ProxyHost) StripReqHeaderList() []string {
+	if p.StripReqHeaders == "" {
+		return nil
+	}
+	var out []string
+	for _, h := range strings.Split(p.StripReqHeaders, ",") {
+		h = strings.TrimSpace(h)
+		if h != "" {
+			out = append(out, http.CanonicalHeaderKey(h))
 		}
 	}
 	return out
@@ -130,8 +724,30 @@ type RedirectionHost struct {
 	CertificateID   int64
 	OwnerID         sql.NullInt64
 	OwnerEmail      string // populated via JOIN for display
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	Tags            string // comma-separated labels (UI-only, same as proxy hosts)
+	Notes           string // freeform admin notes (UI-only)
+	// v2.9.13: access control + maintenance mode (parity with proxy hosts)
+	AccessList      string // comma/newline-separated CIDR allowlist (empty = allow all)
+	MaintenanceMode bool   // when true, respond 503 before redirecting
+	MaintenanceMsg  string // custom maintenance message body
+	// v2.9.20: custom response headers injected into every redirect response
+	CustomRespHeaders string // JSON: map[string]string — empty value means delete header
+	// v2.9.21: IP blocklist — deny specific CIDRs before the redirect fires
+	IPBlocklist string // comma-separated CIDR ranges to block with 403
+	// v2.9.24: HSTS — inject Strict-Transport-Security on redirect responses
+	HSTSMaxAgeSec         int  // 0 = disabled; >0 = seconds for max-age
+	HSTSIncludeSubdomains bool // include includeSubDomains directive
+	HSTSPreload           bool // include preload directive
+	// v2.9.26: advanced config — raw JSON array of Caddy handlers injected before the redirect
+	AdvancedConfig string // JSON: []any of handler maps
+	// v2.9.33: color label for visual grouping in list views (no Caddy impact)
+	Color string // "" | "red" | "orange" | "yellow" | "green" | "teal" | "blue" | "purple" | "pink" | "gray"
+	// v2.9.38: maintenance status code — HTTP code used during maintenance mode (default 503)
+	MaintenanceStatusCode int // 503 (default), 429, 502, 520
+	// v2.9.39: sort order — manual ordering weight in the list view (0 = default, lower = first)
+	SortOrder int
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 func (r RedirectionHost) DomainList() []string {
@@ -146,16 +762,26 @@ func (r RedirectionHost) DomainList() []string {
 	return out
 }
 
+// CustomRespHeaderMap parses CustomRespHeaders into a map. Returns nil if empty.
+func (r RedirectionHost) CustomRespHeaderMap() map[string]string {
+	if r.CustomRespHeaders == "" || r.CustomRespHeaders == "{}" {
+		return nil
+	}
+	var m map[string]string
+	_ = json.Unmarshal([]byte(r.CustomRespHeaders), &m)
+	return m
+}
+
 const userCols = `id, email, password_hash, COALESCE(name,''), is_admin,
     COALESCE(role, CASE WHEN is_admin=1 THEN 'admin' ELSE 'view' END), created_at,
-    COALESCE(totp_secret,''), COALESCE(totp_enabled,0)`
+    COALESCE(totp_secret,''), COALESCE(totp_enabled,0), COALESCE(totp_backup_codes,'')`
 
 func scanUser(s interface {
 	Scan(dest ...any) error
 }) (*User, error) {
 	u := &User{}
 	var isAdmin, totpEnabled int
-	if err := s.Scan(&u.ID, &u.Email, &u.PasswordHash, &u.Name, &isAdmin, &u.Role, &u.CreatedAt, &u.TOTPSecret, &totpEnabled); err != nil {
+	if err := s.Scan(&u.ID, &u.Email, &u.PasswordHash, &u.Name, &isAdmin, &u.Role, &u.CreatedAt, &u.TOTPSecret, &totpEnabled, &u.BackupCodes); err != nil {
 		return nil, err
 	}
 	u.IsAdmin = isAdmin == 1
@@ -168,6 +794,60 @@ func scanUser(s interface {
 		}
 	}
 	return u, nil
+}
+
+// GenerateBackupCodes creates n single-use backup codes as uppercase alphanumeric strings.
+func GenerateBackupCodes(n int) ([]string, error) {
+	const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	codes := make([]string, n)
+	for i := range codes {
+		b := make([]byte, 8)
+		if _, err := rand.Read(b); err != nil {
+			return nil, err
+		}
+		for j := range b {
+			b[j] = chars[int(b[j])%len(chars)]
+		}
+		codes[i] = string(b)
+	}
+	return codes, nil
+}
+
+// HashBackupCode returns the hex-encoded SHA-256 of an uppercase code.
+func HashBackupCode(code string) string {
+	sum := sha256.Sum256([]byte(strings.ToUpper(strings.TrimSpace(code))))
+	return fmt.Sprintf("%x", sum)
+}
+
+// SaveBackupCodes stores hashed backup codes for the user.
+func SaveBackupCodes(db *sql.DB, userID int64, codes []string) error {
+	hashes := make([]string, len(codes))
+	for i, c := range codes {
+		hashes[i] = HashBackupCode(c)
+	}
+	data, _ := json.Marshal(hashes)
+	_, err := db.Exec(`UPDATE users SET totp_backup_codes = ? WHERE id = ?`, string(data), userID)
+	return err
+}
+
+// ConsumeBackupCode checks whether the given code matches a stored hash.
+// If it matches, the code is removed (single-use) and the DB is updated.
+// Returns true if the code was valid and has been consumed.
+func ConsumeBackupCode(db *sql.DB, userID int64, codesJSON, rawCode string) (bool, error) {
+	var hashes []string
+	if codesJSON == "" || json.Unmarshal([]byte(codesJSON), &hashes) != nil {
+		return false, nil
+	}
+	target := HashBackupCode(rawCode)
+	for i, h := range hashes {
+		if h == target {
+			remaining := append(hashes[:i:i], hashes[i+1:]...)
+			data, _ := json.Marshal(remaining)
+			_, err := db.Exec(`UPDATE users SET totp_backup_codes = ? WHERE id = ?`, string(data), userID)
+			return err == nil, err
+		}
+	}
+	return false, nil
 }
 
 func SetUserTOTP(db *sql.DB, userID int64, secret string, enabled bool) error {
@@ -462,7 +1142,261 @@ const proxyHostBaseCols = `ph.id, ph.server_id, ph.domains, ph.forward_scheme, p
     COALESCE(ph.dns_provider,''), COALESCE(ph.dns_zone_id,''),
     COALESCE(ph.dns_zone_name,''), COALESCE(ph.dns_record_id,''),
     COALESCE(ph.compression_enabled,0), COALESCE(ph.security_headers_enabled,0),
-    COALESCE(ph.tls_min_version,'')`
+    COALESCE(ph.tls_min_version,''),
+    COALESCE(ph.custom_req_headers,'{}'), COALESCE(ph.custom_resp_headers,'{}'),
+    COALESCE(ph.url_rewrites,'[]'),
+    COALESCE(ph.maintenance_mode,0), COALESCE(ph.maintenance_msg, ''),
+    COALESCE(ph.max_request_body_mb,0),
+    COALESCE(ph.sticky_sessions,0),
+    COALESCE(ph.upstream_timeout_sec,0),
+    COALESCE(ph.cors_enabled,0), COALESCE(ph.cors_origins,'*'),
+    COALESCE(ph.health_check_uri,''), COALESCE(ph.health_check_interval_sec,30),
+    COALESCE(ph.keepalive_conns,0),
+    COALESCE(ph.tags,''),
+    COALESCE(ph.notes,''),
+    COALESCE(ph.disable_access_log,0),
+    COALESCE(ph.add_request_id,0),
+    COALESCE(ph.strip_resp_headers,''),
+    COALESCE(ph.blocked_agents,''),
+    COALESCE(ph.health_check_method,'GET'),
+    COALESCE(ph.maintenance_status_code,503),
+    COALESCE(ph.response_cache_control,''),
+    COALESCE(ph.upstream_sni,''),
+    COALESCE(ph.hsts_preload,0),
+    COALESCE(ph.max_conns_per_host,0),
+    COALESCE(ph.health_check_timeout_sec,5),
+    COALESCE(ph.upstream_retries,0),
+    COALESCE(ph.force_http1,0),
+    COALESCE(ph.basicauth_realm,'Restricted'),
+    COALESCE(ph.error_page_html,''),
+    COALESCE(ph.maintenance_window_start,''), COALESCE(ph.maintenance_window_end,''),
+    COALESCE(ph.maintenance_window_days,''),
+    COALESCE(ph.ip_blocklist,''),
+    COALESCE(ph.lb_policy,''),
+    COALESCE(ph.proxy_protocol,''),
+    COALESCE(ph.robots_txt,''),
+    COALESCE(ph.passive_fail_duration_sec,0),
+    COALESCE(ph.passive_max_fails,0),
+    COALESCE(ph.hsts_max_age_sec,0),
+    COALESCE(ph.csp_header,''),
+    COALESCE(ph.h2c_enabled,0),
+    COALESCE(ph.health_check_headers,'{}'),
+    COALESCE(ph.flush_immediate,0),
+    COALESCE(ph.buffer_responses,0),
+    COALESCE(ph.trusted_proxies,''),
+    COALESCE(ph.upstream_host_override,''),
+    COALESCE(ph.read_timeout_sec,0),
+    COALESCE(ph.deny_dotfiles,0),
+    COALESCE(ph.request_buffers_kb,0),
+    COALESCE(ph.cors_allow_credentials,0),
+    COALESCE(ph.cors_expose_headers,''),
+    COALESCE(ph.ssl_verify_upstream,0),
+    COALESCE(ph.dial_timeout_sec,0),
+    COALESCE(ph.api_key_header,''),
+    COALESCE(ph.api_key_value,''),
+    COALESCE(ph.block_empty_user_agent,0),
+    COALESCE(ph.error_redirect_url,''),
+    COALESCE(ph.permissions_policy,''),
+    COALESCE(ph.x_frame_options,''),
+    COALESCE(ph.referrer_policy,''),
+    COALESCE(ph.hsts_include_subdomains,1),
+    COALESCE(ph.csp_report_only,''),
+    COALESCE(ph.keepalive_idle_timeout_sec,0),
+    COALESCE(ph.health_check_expect_status,0),
+    COALESCE(ph.health_check_expect_body,''),
+    COALESCE(ph.health_check_follow_redirects,0),
+    COALESCE(ph.path_matcher,''),
+    COALESCE(ph.strip_path_prefix,0),
+    COALESCE(ph.sticky_cookie_name,''),
+    COALESCE(ph.lb_try_duration_sec,0),
+    COALESCE(ph.lb_try_interval_ms,0),
+    COALESCE(ph.compression_min_size_kb,0),
+    COALESCE(ph.forward_client_ip,0),
+    COALESCE(ph.cors_max_age_sec,0),
+    COALESCE(ph.cors_allow_methods,''),
+    COALESCE(ph.cors_allow_headers,''),
+    COALESCE(ph.retry_status_codes,''),
+    COALESCE(ph.write_timeout_sec,0),
+    COALESCE(ph.upstream_tls_min_version,''),
+    COALESCE(ph.forward_proxy_url,''),
+    COALESCE(ph.blocked_methods,''),
+    COALESCE(ph.forward_auth_url,''),
+    COALESCE(ph.forward_auth_copy_headers,''),
+    COALESCE(ph.strip_query_string,0),
+    COALESCE(ph.delete_query_params,''),
+    COALESCE(ph.request_body_read_timeout_sec,0),
+    COALESCE(ph.response_header_timeout_sec,0),
+    COALESCE(ph.max_conn_duration_sec,0),
+    COALESCE(ph.decompress_response,0),
+    COALESCE(ph.color,''),
+    COALESCE(ph.www_redirect,''),
+    COALESCE(ph.strip_req_headers,''),
+    COALESCE(ph.upstream_path_prefix,''),
+    COALESCE(ph.compression_level,0),
+    COALESCE(ph.compression_prefer_gzip,0),
+    COALESCE(ph.sort_order,0),
+    COALESCE(ph.allowed_methods,''),
+    COALESCE(ph.upstream_max_resp_header_kb,0),
+    COALESCE(ph.health_check_port,0),
+    COALESCE(ph.request_id_header_name,''),
+    COALESCE(ph.lb_cookie_path,''),
+    COALESCE(ph.passive_unhealthy_latency_ms,0),
+    COALESCE(ph.tls_handshake_timeout_sec,0),
+    COALESCE(ph.expect_continue_timeout_sec,0),
+    COALESCE(ph.response_buffers_kb,0),
+    COALESCE(ph.upstream_max_idle_conns,0),
+    COALESCE(ph.upstream_keep_alive_probe_sec,0),
+    COALESCE(ph.forward_auth_method,''),
+    COALESCE(ph.grpc_web_enabled,0),
+    COALESCE(ph.forward_auth_headers_prefix,''),
+    COALESCE(ph.health_check_max_size_kb,0),
+    COALESCE(ph.strip_path_suffix,''),
+    COALESCE(ph.add_req_query_params,''),
+    COALESCE(ph.error_page_codes,''),
+    COALESCE(ph.upstream_tls_ca_pem_file,''),
+    COALESCE(ph.keepalive_disabled,0),
+    COALESCE(ph.trailing_slash_redirect,''),
+    COALESCE(ph.dial_fallback_delay_ms,0),
+    COALESCE(ph.upstream_network,''),
+    COALESCE(ph.dns_resolver,''),
+    COALESCE(ph.path_matcher_type,''),
+    COALESCE(ph.cors_allow_private_network,0),
+    COALESCE(ph.robots_txt_disallow_all,0),
+    COALESCE(ph.maintenance_retry_after_sec,0),
+    COALESCE(ph.upstream_resolve_timeout_sec,0),
+    COALESCE(ph.upstream_read_buffer_size_kb,0),
+    COALESCE(ph.upstream_write_buffer_size_kb,0),
+    COALESCE(ph.req_header_replace,''),
+    COALESCE(ph.resp_header_replace,''),
+    COALESCE(ph.upstream_http_versions,''),
+    COALESCE(ph.health_check_body,''),
+    COALESCE(ph.add_canonical_link_header,0),
+    COALESCE(ph.http_basic_auth_upstream,''),
+    COALESCE(ph.block_ua_regexp,''),
+    COALESCE(ph.security_txt_body,''),
+    COALESCE(ph.server_header_value,''),
+    COALESCE(ph.x_robots_tag,''),
+    COALESCE(ph.add_forwarded_header,0),
+    COALESCE(ph.lb_cookie_secret,''),
+    COALESCE(ph.passive_unhealthy_status_codes,''),
+    COALESCE(ph.health_check_content_type,''),
+    COALESCE(ph.upstream_tls_client_cert_file,''),
+    COALESCE(ph.upstream_tls_client_key_file,''),
+    COALESCE(ph.block_private_ips,0),
+    COALESCE(ph.enable_brotli,0),
+    COALESCE(ph.vary_header,''),
+    COALESCE(ph.strip_etag,0),
+    COALESCE(ph.http2_push_paths,''),
+    COALESCE(ph.deny_content_types,''),
+    COALESCE(ph.upstream_local_addr,''),
+    COALESCE(ph.upstream_tls_renegotiation,''),
+    COALESCE(ph.upstream_tls_curves,''),
+    COALESCE(ph.upstream_tls_max_version,''),
+    COALESCE(ph.upstream_tls_pins,''),
+    COALESCE(ph.lb_header_field,''),
+    COALESCE(ph.maintenance_custom_headers,''),
+    COALESCE(ph.deny_extensions,''),
+    COALESCE(ph.inject_request_timestamp,0),
+    COALESCE(ph.add_resp_cookies,''),
+    COALESCE(ph.strip_accept_encoding,0),
+    COALESCE(ph.add_upstream_timing_header,0),
+    COALESCE(ph.strip_server_header,0),
+    COALESCE(ph.block_referer_regexp,''),
+    COALESCE(ph.add_content_type_nosniff,0),
+    COALESCE(ph.strip_authorization_header,0),
+    COALESCE(ph.real_ip_from_header,''),
+    COALESCE(ph.health_check_host_override,''),
+    COALESCE(ph.add_x_forwarded_port,0),
+    COALESCE(ph.lb_retry_on,''),
+    COALESCE(ph.max_buffer_size_kb,0),
+    COALESCE(ph.upstream_keepalive_probes,0),
+    COALESCE(ph.upstream_flush_interval_ms,0),
+    COALESCE(ph.add_x_forwarded_host,0),
+    COALESCE(ph.maintenance_allowed_ips,''),
+    COALESCE(ph.upstream_tls_cipher_suites,''),
+    COALESCE(ph.add_cache_control_no_store,0),
+    COALESCE(ph.deny_referer_empty,0),
+    COALESCE(ph.lb_cookie_httponly,0),
+    COALESCE(ph.lb_cookie_secure,0),
+    COALESCE(ph.lb_cookie_same_site,''),
+    COALESCE(ph.upstream_tls_early_data,0),
+    COALESCE(ph.add_via_header,0),
+    COALESCE(ph.req_header_rename,''),
+    COALESCE(ph.add_expect_ct_header,0),
+    COALESCE(ph.force_upstream_encoding,''),
+    COALESCE(ph.passive_unhealthy_count,0),
+    COALESCE(ph.strip_x_powered_by,0),
+    COALESCE(ph.add_timing_allow_origin,''),
+    COALESCE(ph.lb_cookie_max_age_sec,0),
+    COALESCE(ph.cross_origin_opener_policy,''),
+    COALESCE(ph.cross_origin_resource_policy,''),
+    COALESCE(ph.cross_origin_embedder_policy,''),
+    COALESCE(ph.deny_request_content_type,''),
+    COALESCE(ph.compression_exclude_regexp,''),
+    COALESCE(ph.add_cache_control_public,0),
+    COALESCE(ph.add_x_request_start,0),
+    COALESCE(ph.maintenance_window_timezone,''),
+    COALESCE(ph.lb_random_choose_count,0),
+    COALESCE(ph.add_x_forwarded_scheme,0),
+    COALESCE(ph.response_cache_ttl_sec,0),
+    COALESCE(ph.add_link_preload,''),
+    COALESCE(ph.deny_path_regexp,''),
+    COALESCE(ph.add_request_id_to_response,0),
+    COALESCE(ph.health_check_tls_server_name,''),
+    COALESCE(ph.add_x_real_ip,0),
+    COALESCE(ph.strip_incoming_x_forwarded_for,0),
+    COALESCE(ph.health_check_tls_insecure_skip_verify,0),
+    COALESCE(ph.add_cors_vary_header,0),
+    COALESCE(ph.upstream_tls_alpn,''),
+    COALESCE(ph.add_x_powered_by,''),
+    COALESCE(ph.block_query_params,''),
+    COALESCE(ph.add_document_policy,''),
+    COALESCE(ph.maintenance_redirect_url,''),
+    COALESCE(ph.upstream_keepalive_max_lifetime_sec,0),
+    COALESCE(ph.add_origin_header,''),
+    COALESCE(ph.upstream_tls_ca_pem_inline,''),
+    COALESCE(ph.add_server_timing_header,0),
+    COALESCE(ph.add_clear_site_data,''),
+    COALESCE(ph.add_x_dns_prefetch_control,0),
+    COALESCE(ph.add_accept_ranges,0),
+    COALESCE(ph.add_content_disposition,''),
+    COALESCE(ph.upstream_tls_server_name_from_host,0),
+    COALESCE(ph.add_x_permitted_cross_domain_policies,''),
+    COALESCE(ph.strip_response_headers,''),
+    COALESCE(ph.add_report_to,''),
+    COALESCE(ph.add_nel_header,''),
+    COALESCE(ph.block_http_methods,''),
+    COALESCE(ph.add_service_worker_allowed,''),
+    COALESCE(ph.add_accept_ch,''),
+    COALESCE(ph.add_alt_svc,''),
+    COALESCE(ph.add_content_language,''),
+    COALESCE(ph.add_critical_ch,''),
+    COALESCE(ph.add_x_download_options,0),
+    COALESCE(ph.deny_user_agent_regexp,''),
+    COALESCE(ph.add_pragma_no_cache,0),
+    COALESCE(ph.health_check_user_agent,''),
+    COALESCE(ph.add_x_request_path,0),
+    COALESCE(ph.add_x_clacks_overhead,''),
+    COALESCE(ph.add_x_ua_compatible,''),
+    COALESCE(ph.forward_auth_skip_paths,''),
+    COALESCE(ph.add_age_zero,0),
+    COALESCE(ph.add_surrogate_control,''),
+    COALESCE(ph.add_warning_header,''),
+    COALESCE(ph.add_x_request_method,0),
+    COALESCE(ph.add_x_request_query,0),
+    COALESCE(ph.add_x_forwarded_user,''),
+    COALESCE(ph.add_x_real_scheme,0),
+    COALESCE(ph.add_origin_agent_cluster,0),
+    COALESCE(ph.add_x_forwarded_groups,''),
+    COALESCE(ph.add_x_forwarded_email,''),
+    COALESCE(ph.add_x_forwarded_roles,''),
+    COALESCE(ph.block_query_param_regexp,''),
+    COALESCE(ph.add_x_request_referer,0),
+    COALESCE(ph.add_x_request_origin,0),
+    COALESCE(ph.add_x_forwarded_uri,0),
+    COALESCE(ph.add_x_no_archive,0),
+    COALESCE(ph.add_x_request_hostname,0),
+    COALESCE(ph.add_x_xss_protection_disabled,0)`
 
 // scanProxyHost pulls a single row into the struct. Centralises the
 // bool-int unpack so each query site doesn't repeat it.
@@ -471,7 +1405,7 @@ func scanProxyHost(s interface {
 }, p *ProxyHost, ownerEmail *string) error {
 	var ws, bce, ssl, sslf, h2, en, bae int
 	var ownerID int64
-	var compr, sechdrs int
+	var compr, sechdrs, maint, sticky, cors, disableAccessLog, addReqID, hstsPreload, forceHTTP1, h2c, flushImm, bufResp, denyDot, corsCredentials, sslVerify, blockUA, hstsSubdomains, hcFollowRedirects, stripPfx, fwdClientIP, stripQS, decompResp, comprPrefGzip, grpcWeb, kaDisabled, corsPrivNet, robotsDisallowAll, canonicalLink, fwdHeader, blockPrivIP, brotli, stripEtag, injectReqTimestamp, stripAcceptEnc, addUpstreamTiming, stripSrvHdr, addNosniff, stripAuthHdr, addXFwdPort, addXFwdHost, addCacheCtrlNoStore, denyRefEmpty, lbCookieHTTPOnly, lbCookieSecure, tlsEarlyData, addVia, addExpectCT, stripXPoweredBy, addCacheCtrlPublic, addXReqStart, addXFwdScheme, addReqIDToResp, addXRealIP, stripIncomingXFwdFor, hcTLSSkipVerify, addCORSVary, addSrvTiming, addXDNSPrefetch, addAcceptRanges, tlsSNIFromHost, addXDlOpts, addPragmaNC, addXReqPath, addAgeZero, addXReqMethod, addXReqQuery, addXRealScheme, addOAC, addXReqReferer, addXReqOrigin, addXFwdURI, addXNoArch, addXReqHost, addXXSSDis int
 	dst := []any{
 		&p.ID, &p.ServerID, &p.Domains, &p.ForwardScheme, &p.ForwardHost, &p.ForwardPort,
 		&ws, &bce, &ssl, &sslf, &h2, &p.AdvancedConfig, &en, &p.CertificateID,
@@ -481,6 +1415,259 @@ func scanProxyHost(s interface {
 		&ownerID,
 		&p.DNSProvider, &p.DNSZoneID, &p.DNSZoneName, &p.DNSRecordID,
 		&compr, &sechdrs, &p.TLSMinVersion,
+		&p.CustomReqHeaders, &p.CustomRespHeaders,
+		&p.URLRewrites,
+		&maint,
+		&p.MaintenanceMsg,
+		&p.MaxRequestBodyMB,
+		&sticky,
+		&p.UpstreamTimeoutSec,
+		&cors, &p.CORSOrigins,
+		&p.HealthCheckURI, &p.HealthCheckIntervalSec, &p.KeepaliveConns,
+		&p.Tags,
+		&p.Notes,
+		&disableAccessLog,
+		&addReqID,
+		&p.StripRespHeaders,
+		&p.BlockedAgents,
+		&p.HealthCheckMethod,
+		&p.MaintenanceStatusCode,
+		&p.ResponseCacheControl,
+		&p.UpstreamSNI,
+		&hstsPreload,
+		&p.MaxConnsPerHost,
+		&p.HealthCheckTimeoutSec,
+		&p.UpstreamRetries,
+		&forceHTTP1,
+		&p.BasicAuthRealm,
+		&p.ErrorPageHTML,
+		&p.MaintenanceWindowStart, &p.MaintenanceWindowEnd, &p.MaintenanceWindowDays,
+		&p.IPBlocklist,
+		&p.LBPolicy,
+		&p.ProxyProtocol,
+		&p.RobotsTxt,
+		&p.PassiveFailDurationSec,
+		&p.PassiveMaxFails,
+		&p.HSTSMaxAgeSec,
+		&p.CSPHeader,
+		&h2c,
+		&p.HealthCheckHeaders,
+		&flushImm,
+		&bufResp,
+		&p.TrustedProxies,
+		&p.UpstreamHostOverride,
+		&p.ReadTimeoutSec,
+		&denyDot,
+		&p.RequestBuffersKB,
+		&corsCredentials,
+		&p.CORSExposeHeaders,
+		&sslVerify,
+		&p.DialTimeoutSec,
+		&p.APIKeyHeader,
+		&p.APIKeyValue,
+		&blockUA,
+		&p.ErrorRedirectURL,
+		&p.PermissionsPolicy,
+		&p.XFrameOptions,
+		&p.ReferrerPolicy,
+		&hstsSubdomains,
+		&p.CSPReportOnly,
+		&p.KeepaliveIdleTimeoutSec,
+		&p.HealthCheckExpectStatus,
+		&p.HealthCheckExpectBody,
+		&hcFollowRedirects,
+		&p.PathMatcher,
+		&stripPfx,
+		&p.StickyCookieName,
+		&p.LBTryDurationSec,
+		&p.LBTryIntervalMS,
+		&p.CompressionMinSizeKB,
+		&fwdClientIP,
+		&p.CORSMaxAgeSec,
+		&p.CORSAllowMethods,
+		&p.CORSAllowHeaders,
+		&p.RetryStatusCodes,
+		&p.WriteTimeoutSec,
+		&p.UpstreamTLSMinVersion,
+		&p.ForwardProxyURL,
+		&p.BlockedMethods,
+		&p.ForwardAuthURL,
+		&p.ForwardAuthCopyHeaders,
+		&stripQS,
+		&p.DeleteQueryParams,
+		&p.RequestBodyReadTimeoutSec,
+		&p.ResponseHeaderTimeoutSec,
+		&p.MaxConnDurationSec,
+		&decompResp,
+		&p.Color,
+		&p.WWWRedirect,
+		&p.StripReqHeaders,
+		&p.UpstreamPathPrefix,
+		&p.CompressionLevel,
+		&comprPrefGzip,
+		&p.SortOrder,
+		&p.AllowedMethods,
+		&p.UpstreamMaxRespHeaderKB,
+		&p.HealthCheckPort,
+		&p.RequestIDHeaderName,
+		&p.LBCookiePath,
+		&p.PassiveUnhealthyLatencyMS,
+		&p.TLSHandshakeTimeoutSec,
+		&p.ExpectContinueTimeoutSec,
+		&p.ResponseBuffersKB,
+		&p.UpstreamMaxIdleConns,
+		&p.UpstreamKeepAliveProbeIntervalSec,
+		&p.ForwardAuthMethod,
+		&grpcWeb,
+		&p.ForwardAuthHeadersPrefix,
+		&p.HealthCheckMaxSizeKB,
+		&p.StripPathSuffix,
+		&p.AddReqQueryParams,
+		&p.ErrorPageCodes,
+		&p.UpstreamTLSCAPEMFile,
+		&kaDisabled,
+		&p.TrailingSlashRedirect,
+		&p.DialFallbackDelayMS,
+		&p.UpstreamNetwork,
+		&p.DNSResolver,
+		&p.PathMatcherType,
+		&corsPrivNet,
+		&robotsDisallowAll,
+		&p.MaintenanceRetryAfterSec,
+		&p.UpstreamResolveTimeoutSec,
+		&p.UpstreamReadBufferSizeKB,
+		&p.UpstreamWriteBufferSizeKB,
+		&p.ReqHeaderReplace,
+		&p.RespHeaderReplace,
+		&p.UpstreamHTTPVersions,
+		&p.HealthCheckBody,
+		&canonicalLink,
+		&p.HTTPBasicAuthUpstream,
+		&p.BlockUARegexp,
+		&p.SecurityTxtBody,
+		&p.ServerHeaderValue,
+		&p.XRobotsTag,
+		&fwdHeader,
+		&p.LBCookieSecret,
+		&p.PassiveUnhealthyStatusCodes,
+		&p.HealthCheckContentType,
+		&p.UpstreamTLSClientCertFile,
+		&p.UpstreamTLSClientKeyFile,
+		&blockPrivIP,
+		&brotli,
+		&p.VaryHeader,
+		&stripEtag,
+		&p.HTTP2PushPaths,
+		&p.DenyContentTypes,
+		&p.UpstreamLocalAddr,
+		&p.UpstreamTLSRenegotiation,
+		&p.UpstreamTLSCurves,
+		&p.UpstreamTLSMaxVersion,
+		&p.UpstreamTLSPins,
+		&p.LBHeaderField,
+		&p.MaintenanceCustomHeaders,
+		&p.DenyExtensions,
+		&injectReqTimestamp,
+		&p.AddRespCookies,
+		&stripAcceptEnc,
+		&addUpstreamTiming,
+		&stripSrvHdr,
+		&p.BlockRefererRegexp,
+		&addNosniff,
+		&stripAuthHdr,
+		&p.RealIPFromHeader,
+		&p.HealthCheckHostOverride,
+		&addXFwdPort,
+		&p.LBRetryOn,
+		&p.MaxBufferSizeKB,
+		&p.UpstreamKeepaliveProbes,
+		&p.UpstreamFlushIntervalMS,
+		&addXFwdHost,
+		&p.MaintenanceAllowedIPs,
+		&p.UpstreamTLSCipherSuites,
+		&addCacheCtrlNoStore,
+		&denyRefEmpty,
+		&lbCookieHTTPOnly,
+		&lbCookieSecure,
+		&p.LBCookieSameSite,
+		&tlsEarlyData,
+		&addVia,
+		&p.ReqHeaderRename,
+		&addExpectCT,
+		&p.ForceUpstreamEncoding,
+		&p.PassiveUnhealthyCount,
+		&stripXPoweredBy,
+		&p.AddTimingAllowOrigin,
+		&p.LBCookieMaxAgeSec,
+		&p.CrossOriginOpenerPolicy,
+		&p.CrossOriginResourcePolicy,
+		&p.CrossOriginEmbedderPolicy,
+		&p.DenyRequestContentType,
+		&p.CompressionExcludeRegexp,
+		&addCacheCtrlPublic,
+		&addXReqStart,
+		&p.MaintenanceWindowTimezone,
+		&p.LBRandomChooseCount,
+		&addXFwdScheme,
+		&p.ResponseCacheTTLSec,
+		&p.AddLinkPreload,
+		&p.DenyPathRegexp,
+		&addReqIDToResp,
+		&p.HealthCheckTLSServerName,
+		&addXRealIP,
+		&stripIncomingXFwdFor,
+		&hcTLSSkipVerify,
+		&addCORSVary,
+		&p.UpstreamTLSALPN,
+		&p.AddXPoweredBy,
+		&p.BlockQueryParams,
+		&p.AddDocumentPolicy,
+		&p.MaintenanceRedirectURL,
+		&p.UpstreamKeepaliveMaxLifetimeSec,
+		&p.AddOriginHeader,
+		&p.UpstreamTLSCAPEMInline,
+		&addSrvTiming,
+		&p.AddClearSiteData,
+		&addXDNSPrefetch,
+		&addAcceptRanges,
+		&p.AddContentDisposition,
+		&tlsSNIFromHost,
+		&p.AddXPermittedCrossDomainPolicies,
+		&p.StripResponseHeaders,
+		&p.AddReportTo,
+		&p.AddNELHeader,
+		&p.BlockHTTPMethods,
+		&p.AddServiceWorkerAllowed,
+		&p.AddAcceptCH,
+		&p.AddAltSvc,
+		&p.AddContentLanguage,
+		&p.AddCriticalCH,
+		&addXDlOpts,
+		&p.DenyUserAgentRegexp,
+		&addPragmaNC,
+		&p.HealthCheckUserAgent,
+		&addXReqPath,
+		&p.AddXClacksOverhead,
+		&p.AddXUACompatible,
+		&p.ForwardAuthSkipPaths,
+		&addAgeZero,
+		&p.AddSurrogateControl,
+		&p.AddWarningHeader,
+		&addXReqMethod,
+		&addXReqQuery,
+		&p.AddXForwardedUser,
+		&addXRealScheme,
+		&addOAC,
+		&p.AddXForwardedGroups,
+		&p.AddXForwardedEmail,
+		&p.AddXForwardedRoles,
+		&p.BlockQueryParamRegexp,
+		&addXReqReferer,
+		&addXReqOrigin,
+		&addXFwdURI,
+		&addXNoArch,
+		&addXReqHost,
+		&addXXSSDis,
 	}
 	if ownerEmail != nil {
 		dst = append(dst, ownerEmail)
@@ -497,6 +1684,78 @@ func scanProxyHost(s interface {
 	p.BasicAuthEnabled = bae == 1
 	p.CompressionEnabled = compr == 1
 	p.SecurityHeadersEnabled = sechdrs == 1
+	p.MaintenanceMode = maint == 1
+	p.StickySessions = sticky == 1
+	p.CORSEnabled = cors == 1
+	p.DisableAccessLog = disableAccessLog == 1
+	p.AddRequestID = addReqID == 1
+	p.HSTSPreload = hstsPreload == 1
+	p.ForceHTTP1 = forceHTTP1 == 1
+	p.H2CEnabled = h2c == 1
+	p.FlushImmediate = flushImm == 1
+	p.BufferResponses = bufResp == 1
+	p.DenyDotfiles = denyDot == 1
+	p.CORSAllowCredentials = corsCredentials == 1
+	p.SSLVerifyUpstream = sslVerify == 1
+	p.BlockEmptyUserAgent = blockUA == 1
+	p.HSTSIncludeSubdomains = hstsSubdomains == 1
+	p.HealthCheckFollowRedirects = hcFollowRedirects == 1
+	p.StripPathPrefix = stripPfx == 1
+	p.ForwardClientIP = fwdClientIP == 1
+	p.StripQueryString = stripQS == 1
+	p.DecompressResponse = decompResp == 1
+	p.CompressionPreferGzip = comprPrefGzip == 1
+	p.GRPCWebEnabled = grpcWeb == 1
+	p.KeepaliveDisabled = kaDisabled == 1
+	p.CORSAllowPrivateNetwork = corsPrivNet == 1
+	p.RobotsTxtDisallowAll = robotsDisallowAll == 1
+	p.AddCanonicalLinkHeader = canonicalLink == 1
+	p.AddForwardedHeader = fwdHeader == 1
+	p.BlockPrivateIPs = blockPrivIP == 1
+	p.EnableBrotli = brotli == 1
+	p.StripETag = stripEtag == 1
+	p.InjectRequestTimestamp = injectReqTimestamp == 1
+	p.StripAcceptEncoding = stripAcceptEnc == 1
+	p.AddUpstreamTimingHeader = addUpstreamTiming == 1
+	p.StripServerHeader = stripSrvHdr == 1
+	p.AddContentTypeNosniff = addNosniff == 1
+	p.StripAuthorizationHeader = stripAuthHdr == 1
+	p.AddXForwardedPort = addXFwdPort == 1
+	p.AddXForwardedHost = addXFwdHost == 1
+	p.AddCacheControlNoStore = addCacheCtrlNoStore == 1
+	p.DenyRefererEmpty = denyRefEmpty == 1
+	p.LBCookieHTTPOnly = lbCookieHTTPOnly == 1
+	p.LBCookieSecure = lbCookieSecure == 1
+	p.UpstreamTLSEarlyData = tlsEarlyData == 1
+	p.AddViaHeader = addVia == 1
+	p.AddExpectCTHeader = addExpectCT == 1
+	p.StripXPoweredBy = stripXPoweredBy == 1
+	p.AddCacheControlPublic = addCacheCtrlPublic == 1
+	p.AddXRequestStart = addXReqStart == 1
+	p.AddXForwardedScheme = addXFwdScheme == 1
+	p.AddRequestIDToResponse = addReqIDToResp == 1
+	p.AddXRealIP = addXRealIP == 1
+	p.StripIncomingXForwardedFor = stripIncomingXFwdFor == 1
+	p.HealthCheckTLSInsecureSkipVerify = hcTLSSkipVerify == 1
+	p.AddCORSVaryHeader = addCORSVary == 1
+	p.AddServerTimingHeader = addSrvTiming == 1
+	p.AddXDNSPrefetchControl = addXDNSPrefetch == 1
+	p.AddAcceptRanges = addAcceptRanges == 1
+	p.UpstreamTLSServerNameFromHost = tlsSNIFromHost == 1
+	p.AddXDownloadOptions = addXDlOpts == 1
+	p.AddPragmaNoCache = addPragmaNC == 1
+	p.AddXRequestPath = addXReqPath == 1
+	p.AddAgeZero = addAgeZero == 1
+	p.AddXRequestMethod = addXReqMethod == 1
+	p.AddXRequestQuery = addXReqQuery == 1
+	p.AddXRealScheme = addXRealScheme == 1
+	p.AddOriginAgentCluster = addOAC == 1
+	p.AddXRequestReferer = addXReqReferer == 1
+	p.AddXRequestOrigin = addXReqOrigin == 1
+	p.AddXForwardedURI = addXFwdURI == 1
+	p.AddXNoArchive = addXNoArch == 1
+	p.AddXRequestHostname = addXReqHost == 1
+	p.AddXXSSProtectionDisabled = addXXSSDis == 1
 	if ownerID != 0 {
 		p.OwnerID = sql.NullInt64{Int64: ownerID, Valid: true}
 	}
@@ -518,7 +1777,7 @@ func ListProxyHosts(db *sql.DB, serverID int64, viewerID int64, isAdmin bool, pe
         SELECT `+proxyHostBaseCols+`, COALESCE(u.email, '')
         FROM proxy_hosts ph
         LEFT JOIN users u ON u.id = ph.owner_id
-        WHERE ph.server_id = ? ORDER BY ph.id DESC`, serverID)
+        WHERE ph.server_id = ? ORDER BY ph.sort_order ASC, ph.id DESC`, serverID)
 	} else {
 		inStr, inArgs := inClause(peerIDs)
 		args := append([]any{serverID, viewerID}, inArgs...)
@@ -528,7 +1787,7 @@ func ListProxyHosts(db *sql.DB, serverID int64, viewerID int64, isAdmin bool, pe
         LEFT JOIN users u ON u.id = ph.owner_id
         WHERE ph.server_id = ?
           AND (ph.owner_id = ? OR ph.owner_id IN (`+inStr+`))
-        ORDER BY ph.id DESC`, args...)
+        ORDER BY ph.sort_order ASC, ph.id DESC`, args...)
 	}
 	if err != nil {
 		return nil, err
@@ -559,6 +1818,26 @@ func GetProxyHost(db *sql.DB, id int64) (*ProxyHost, error) {
 	return &p, nil
 }
 
+// ListProxyHostsWithMaintenanceWindow returns all enabled proxy hosts that have
+// a scheduled maintenance window configured (maintenance_window_start is non-empty).
+// Used by the background window-boundary loop to know which servers need a sync.
+func ListProxyHostsWithMaintenanceWindow(db *sql.DB) ([]ProxyHost, error) {
+	rows, err := db.Query(`SELECT ` + proxyHostBaseCols + ` FROM proxy_hosts ph WHERE ph.maintenance_window_start != '' AND ph.enabled = 1`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ProxyHost
+	for rows.Next() {
+		var p ProxyHost
+		if err := scanProxyHost(rows, &p, nil); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
 // nilIfZero returns nil for 0 so INSERT/UPDATE stores NULL in certificate_id.
 func nilIfZero(id int64) any {
 	if id == 0 {
@@ -585,14 +1864,112 @@ func CreateProxyHost(db *sql.DB, serverID int64, ownerID int64, p *ProxyHost) (i
 	if p.ExtraUpstreams == "" {
 		p.ExtraUpstreams = "[]"
 	}
+	if p.CustomReqHeaders == "" {
+		p.CustomReqHeaders = "{}"
+	}
+	if p.CustomRespHeaders == "" {
+		p.CustomRespHeaders = "{}"
+	}
+	if p.URLRewrites == "" {
+		p.URLRewrites = "[]"
+	}
 	res, err := db.Exec(`
         INSERT INTO proxy_hosts (server_id, domains, forward_scheme, forward_host, forward_port,
             websocket_support, block_common_exploits, ssl_enabled, ssl_forced,
             http2_support, advanced_config, enabled, certificate_id,
             basicauth_enabled, basicauth_users, access_list, extra_upstreams, owner_id,
             dns_provider, dns_zone_id, dns_zone_name, dns_record_id,
-            compression_enabled, security_headers_enabled, tls_min_version)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            compression_enabled, security_headers_enabled, tls_min_version,
+            custom_req_headers, custom_resp_headers, url_rewrites, maintenance_mode, maintenance_msg,
+            max_request_body_mb, sticky_sessions, upstream_timeout_sec,
+            cors_enabled, cors_origins,
+            health_check_uri, health_check_interval_sec, keepalive_conns,
+            tags, notes, disable_access_log,
+            add_request_id, strip_resp_headers, blocked_agents, health_check_method,
+            maintenance_status_code, response_cache_control,
+            upstream_sni, hsts_preload, max_conns_per_host,
+            health_check_timeout_sec, upstream_retries,
+            force_http1, basicauth_realm, error_page_html,
+            maintenance_window_start, maintenance_window_end, maintenance_window_days,
+            ip_blocklist, lb_policy, proxy_protocol, robots_txt,
+            passive_fail_duration_sec, passive_max_fails,
+            hsts_max_age_sec, csp_header,
+            h2c_enabled, health_check_headers,
+            flush_immediate, buffer_responses, trusted_proxies,
+            upstream_host_override, read_timeout_sec, deny_dotfiles,
+            request_buffers_kb, cors_allow_credentials, cors_expose_headers,
+            ssl_verify_upstream, dial_timeout_sec,
+            api_key_header, api_key_value, block_empty_user_agent,
+            error_redirect_url, permissions_policy, x_frame_options, referrer_policy,
+            hsts_include_subdomains, csp_report_only, keepalive_idle_timeout_sec,
+            health_check_expect_status, health_check_expect_body, health_check_follow_redirects,
+            path_matcher, strip_path_prefix,
+            sticky_cookie_name, lb_try_duration_sec, lb_try_interval_ms,
+            compression_min_size_kb, forward_client_ip,
+            cors_max_age_sec, cors_allow_methods, cors_allow_headers,
+            retry_status_codes, write_timeout_sec,
+            upstream_tls_min_version, forward_proxy_url,
+            blocked_methods, forward_auth_url, forward_auth_copy_headers,
+            strip_query_string, delete_query_params,
+            request_body_read_timeout_sec, response_header_timeout_sec,
+            max_conn_duration_sec, decompress_response, color, www_redirect,
+            strip_req_headers, upstream_path_prefix,
+            compression_level, compression_prefer_gzip, sort_order,
+            allowed_methods, upstream_max_resp_header_kb, health_check_port,
+            request_id_header_name, lb_cookie_path, passive_unhealthy_latency_ms,
+            tls_handshake_timeout_sec, expect_continue_timeout_sec, response_buffers_kb,
+            upstream_max_idle_conns, upstream_keep_alive_probe_sec, forward_auth_method,
+            grpc_web_enabled, forward_auth_headers_prefix, health_check_max_size_kb,
+            strip_path_suffix, add_req_query_params, error_page_codes,
+            upstream_tls_ca_pem_file, keepalive_disabled, trailing_slash_redirect,
+            dial_fallback_delay_ms, upstream_network, dns_resolver,
+            path_matcher_type, cors_allow_private_network, robots_txt_disallow_all,
+            maintenance_retry_after_sec, upstream_resolve_timeout_sec, upstream_read_buffer_size_kb,
+            upstream_write_buffer_size_kb, req_header_replace, resp_header_replace,
+            upstream_http_versions, health_check_body, add_canonical_link_header,
+            http_basic_auth_upstream, block_ua_regexp, security_txt_body,
+            server_header_value, x_robots_tag, add_forwarded_header,
+            lb_cookie_secret, passive_unhealthy_status_codes, health_check_content_type,
+            upstream_tls_client_cert_file, upstream_tls_client_key_file, block_private_ips,
+            enable_brotli, vary_header, strip_etag,
+            http2_push_paths, deny_content_types, upstream_local_addr,
+            upstream_tls_renegotiation, upstream_tls_curves, upstream_tls_max_version,
+            upstream_tls_pins, lb_header_field, maintenance_custom_headers,
+            deny_extensions, inject_request_timestamp, add_resp_cookies,
+            strip_accept_encoding, add_upstream_timing_header, strip_server_header,
+            block_referer_regexp, add_content_type_nosniff, strip_authorization_header,
+            real_ip_from_header, health_check_host_override, add_x_forwarded_port,
+            lb_retry_on, max_buffer_size_kb, upstream_keepalive_probes,
+            upstream_flush_interval_ms, add_x_forwarded_host, maintenance_allowed_ips,
+            upstream_tls_cipher_suites, add_cache_control_no_store, deny_referer_empty,
+            lb_cookie_httponly, lb_cookie_secure, lb_cookie_same_site,
+            upstream_tls_early_data, add_via_header, req_header_rename,
+            add_expect_ct_header, force_upstream_encoding, passive_unhealthy_count,
+            strip_x_powered_by, add_timing_allow_origin, lb_cookie_max_age_sec,
+            cross_origin_opener_policy, cross_origin_resource_policy, cross_origin_embedder_policy,
+            deny_request_content_type, compression_exclude_regexp, add_cache_control_public,
+            add_x_request_start, maintenance_window_timezone, lb_random_choose_count,
+            add_x_forwarded_scheme, response_cache_ttl_sec, add_link_preload,
+            deny_path_regexp, add_request_id_to_response, health_check_tls_server_name,
+            add_x_real_ip, strip_incoming_x_forwarded_for, health_check_tls_insecure_skip_verify,
+            add_cors_vary_header, upstream_tls_alpn, add_x_powered_by,
+            block_query_params, add_document_policy, maintenance_redirect_url,
+            upstream_keepalive_max_lifetime_sec, add_origin_header, upstream_tls_ca_pem_inline,
+            add_server_timing_header, add_clear_site_data, add_x_dns_prefetch_control,
+            add_accept_ranges, add_content_disposition, upstream_tls_server_name_from_host,
+            add_x_permitted_cross_domain_policies, strip_response_headers, add_report_to,
+            add_nel_header, block_http_methods, add_service_worker_allowed,
+            add_accept_ch, add_alt_svc, add_content_language,
+            add_critical_ch, add_x_download_options, deny_user_agent_regexp,
+            add_pragma_no_cache, health_check_user_agent, add_x_request_path,
+            add_x_clacks_overhead, add_x_ua_compatible, forward_auth_skip_paths,
+            add_age_zero, add_surrogate_control, add_warning_header,
+            add_x_request_method, add_x_request_query, add_x_forwarded_user,
+            add_x_real_scheme, add_origin_agent_cluster, add_x_forwarded_groups,
+            add_x_forwarded_email, add_x_forwarded_roles, block_query_param_regexp,
+            add_x_request_referer, add_x_request_origin, add_x_forwarded_uri,
+            add_x_no_archive, add_x_request_hostname, add_x_xss_protection_disabled)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		serverID,
 		p.Domains, p.ForwardScheme, p.ForwardHost, p.ForwardPort,
 		boolInt(p.WebsocketSupport), boolInt(p.BlockCommonExploits),
@@ -603,6 +1980,95 @@ func CreateProxyHost(db *sql.DB, serverID int64, ownerID int64, p *ProxyHost) (i
 		nilIfZero(ownerID),
 		p.DNSProvider, p.DNSZoneID, p.DNSZoneName, p.DNSRecordID,
 		boolInt(p.CompressionEnabled), boolInt(p.SecurityHeadersEnabled), p.TLSMinVersion,
+		p.CustomReqHeaders, p.CustomRespHeaders, p.URLRewrites, boolInt(p.MaintenanceMode), p.MaintenanceMsg,
+		p.MaxRequestBodyMB, boolInt(p.StickySessions), p.UpstreamTimeoutSec,
+		boolInt(p.CORSEnabled), p.CORSOrigins,
+		p.HealthCheckURI, p.HealthCheckIntervalSec, p.KeepaliveConns,
+		p.Tags, p.Notes, boolInt(p.DisableAccessLog),
+		boolInt(p.AddRequestID), p.StripRespHeaders, p.BlockedAgents, p.HealthCheckMethod,
+		p.MaintenanceStatusCode, p.ResponseCacheControl,
+		p.UpstreamSNI, boolInt(p.HSTSPreload), p.MaxConnsPerHost,
+		p.HealthCheckTimeoutSec, p.UpstreamRetries,
+		boolInt(p.ForceHTTP1), p.BasicAuthRealm, p.ErrorPageHTML,
+		p.MaintenanceWindowStart, p.MaintenanceWindowEnd, p.MaintenanceWindowDays,
+		p.IPBlocklist, p.LBPolicy, p.ProxyProtocol, p.RobotsTxt,
+		p.PassiveFailDurationSec, p.PassiveMaxFails,
+		p.HSTSMaxAgeSec, p.CSPHeader,
+		boolInt(p.H2CEnabled), p.HealthCheckHeaders,
+		boolInt(p.FlushImmediate), boolInt(p.BufferResponses), p.TrustedProxies,
+		p.UpstreamHostOverride, p.ReadTimeoutSec, boolInt(p.DenyDotfiles),
+		p.RequestBuffersKB, boolInt(p.CORSAllowCredentials), p.CORSExposeHeaders,
+		boolInt(p.SSLVerifyUpstream), p.DialTimeoutSec,
+		p.APIKeyHeader, p.APIKeyValue, boolInt(p.BlockEmptyUserAgent),
+		p.ErrorRedirectURL, p.PermissionsPolicy, p.XFrameOptions, p.ReferrerPolicy,
+		boolInt(p.HSTSIncludeSubdomains), p.CSPReportOnly, p.KeepaliveIdleTimeoutSec,
+		p.HealthCheckExpectStatus, p.HealthCheckExpectBody, boolInt(p.HealthCheckFollowRedirects),
+		p.PathMatcher, boolInt(p.StripPathPrefix),
+		p.StickyCookieName, p.LBTryDurationSec, p.LBTryIntervalMS,
+		p.CompressionMinSizeKB, boolInt(p.ForwardClientIP),
+		p.CORSMaxAgeSec, p.CORSAllowMethods, p.CORSAllowHeaders,
+		p.RetryStatusCodes, p.WriteTimeoutSec,
+		p.UpstreamTLSMinVersion, p.ForwardProxyURL,
+		p.BlockedMethods, p.ForwardAuthURL, p.ForwardAuthCopyHeaders,
+		boolInt(p.StripQueryString), p.DeleteQueryParams,
+		p.RequestBodyReadTimeoutSec, p.ResponseHeaderTimeoutSec,
+		p.MaxConnDurationSec, boolInt(p.DecompressResponse), p.Color, p.WWWRedirect,
+		p.StripReqHeaders, p.UpstreamPathPrefix,
+		p.CompressionLevel, boolInt(p.CompressionPreferGzip), p.SortOrder,
+		p.AllowedMethods, p.UpstreamMaxRespHeaderKB, p.HealthCheckPort,
+		p.RequestIDHeaderName, p.LBCookiePath, p.PassiveUnhealthyLatencyMS,
+		p.TLSHandshakeTimeoutSec, p.ExpectContinueTimeoutSec, p.ResponseBuffersKB,
+		p.UpstreamMaxIdleConns, p.UpstreamKeepAliveProbeIntervalSec, p.ForwardAuthMethod,
+		boolInt(p.GRPCWebEnabled), p.ForwardAuthHeadersPrefix, p.HealthCheckMaxSizeKB,
+		p.StripPathSuffix, p.AddReqQueryParams, p.ErrorPageCodes,
+		p.UpstreamTLSCAPEMFile, boolInt(p.KeepaliveDisabled), p.TrailingSlashRedirect,
+		p.DialFallbackDelayMS, p.UpstreamNetwork, p.DNSResolver,
+		p.PathMatcherType, boolInt(p.CORSAllowPrivateNetwork), boolInt(p.RobotsTxtDisallowAll),
+		p.MaintenanceRetryAfterSec, p.UpstreamResolveTimeoutSec, p.UpstreamReadBufferSizeKB,
+		p.UpstreamWriteBufferSizeKB, p.ReqHeaderReplace, p.RespHeaderReplace,
+		p.UpstreamHTTPVersions, p.HealthCheckBody, boolInt(p.AddCanonicalLinkHeader),
+		p.HTTPBasicAuthUpstream, p.BlockUARegexp, p.SecurityTxtBody,
+		p.ServerHeaderValue, p.XRobotsTag, boolInt(p.AddForwardedHeader),
+		p.LBCookieSecret, p.PassiveUnhealthyStatusCodes, p.HealthCheckContentType,
+		p.UpstreamTLSClientCertFile, p.UpstreamTLSClientKeyFile, boolInt(p.BlockPrivateIPs),
+		boolInt(p.EnableBrotli), p.VaryHeader, boolInt(p.StripETag),
+		p.HTTP2PushPaths, p.DenyContentTypes, p.UpstreamLocalAddr,
+		p.UpstreamTLSRenegotiation, p.UpstreamTLSCurves, p.UpstreamTLSMaxVersion,
+		p.UpstreamTLSPins, p.LBHeaderField, p.MaintenanceCustomHeaders,
+		p.DenyExtensions, boolInt(p.InjectRequestTimestamp), p.AddRespCookies,
+		boolInt(p.StripAcceptEncoding), boolInt(p.AddUpstreamTimingHeader), boolInt(p.StripServerHeader),
+		p.BlockRefererRegexp, boolInt(p.AddContentTypeNosniff), boolInt(p.StripAuthorizationHeader),
+		p.RealIPFromHeader, p.HealthCheckHostOverride, boolInt(p.AddXForwardedPort),
+		p.LBRetryOn, p.MaxBufferSizeKB, p.UpstreamKeepaliveProbes,
+		p.UpstreamFlushIntervalMS, boolInt(p.AddXForwardedHost), p.MaintenanceAllowedIPs,
+		p.UpstreamTLSCipherSuites, boolInt(p.AddCacheControlNoStore), boolInt(p.DenyRefererEmpty),
+		boolInt(p.LBCookieHTTPOnly), boolInt(p.LBCookieSecure), p.LBCookieSameSite,
+		boolInt(p.UpstreamTLSEarlyData), boolInt(p.AddViaHeader), p.ReqHeaderRename,
+		boolInt(p.AddExpectCTHeader), p.ForceUpstreamEncoding, p.PassiveUnhealthyCount,
+		boolInt(p.StripXPoweredBy), p.AddTimingAllowOrigin, p.LBCookieMaxAgeSec,
+		p.CrossOriginOpenerPolicy, p.CrossOriginResourcePolicy, p.CrossOriginEmbedderPolicy,
+		p.DenyRequestContentType, p.CompressionExcludeRegexp, boolInt(p.AddCacheControlPublic),
+		boolInt(p.AddXRequestStart), p.MaintenanceWindowTimezone, p.LBRandomChooseCount,
+		boolInt(p.AddXForwardedScheme), p.ResponseCacheTTLSec, p.AddLinkPreload,
+		p.DenyPathRegexp, boolInt(p.AddRequestIDToResponse), p.HealthCheckTLSServerName,
+		boolInt(p.AddXRealIP), boolInt(p.StripIncomingXForwardedFor), boolInt(p.HealthCheckTLSInsecureSkipVerify),
+		boolInt(p.AddCORSVaryHeader), p.UpstreamTLSALPN, p.AddXPoweredBy,
+		p.BlockQueryParams, p.AddDocumentPolicy, p.MaintenanceRedirectURL,
+		p.UpstreamKeepaliveMaxLifetimeSec, p.AddOriginHeader, p.UpstreamTLSCAPEMInline,
+		boolInt(p.AddServerTimingHeader), p.AddClearSiteData, boolInt(p.AddXDNSPrefetchControl),
+		boolInt(p.AddAcceptRanges), p.AddContentDisposition, boolInt(p.UpstreamTLSServerNameFromHost),
+		p.AddXPermittedCrossDomainPolicies, p.StripResponseHeaders, p.AddReportTo,
+		p.AddNELHeader, p.BlockHTTPMethods, p.AddServiceWorkerAllowed,
+		p.AddAcceptCH, p.AddAltSvc, p.AddContentLanguage,
+		p.AddCriticalCH, boolInt(p.AddXDownloadOptions), p.DenyUserAgentRegexp,
+		boolInt(p.AddPragmaNoCache), p.HealthCheckUserAgent, boolInt(p.AddXRequestPath),
+		p.AddXClacksOverhead, p.AddXUACompatible, p.ForwardAuthSkipPaths,
+		boolInt(p.AddAgeZero), p.AddSurrogateControl, p.AddWarningHeader,
+		boolInt(p.AddXRequestMethod), boolInt(p.AddXRequestQuery), p.AddXForwardedUser,
+		boolInt(p.AddXRealScheme), boolInt(p.AddOriginAgentCluster), p.AddXForwardedGroups,
+		p.AddXForwardedEmail, p.AddXForwardedRoles, p.BlockQueryParamRegexp,
+		boolInt(p.AddXRequestReferer), boolInt(p.AddXRequestOrigin), boolInt(p.AddXForwardedURI),
+		boolInt(p.AddXNoArchive), boolInt(p.AddXRequestHostname), boolInt(p.AddXXSSProtectionDisabled),
 	)
 	if err != nil {
 		return 0, err
@@ -620,6 +2086,15 @@ func UpdateProxyHost(db *sql.DB, p *ProxyHost) error {
 	if p.ExtraUpstreams == "" {
 		p.ExtraUpstreams = "[]"
 	}
+	if p.CustomReqHeaders == "" {
+		p.CustomReqHeaders = "{}"
+	}
+	if p.CustomRespHeaders == "" {
+		p.CustomRespHeaders = "{}"
+	}
+	if p.URLRewrites == "" {
+		p.URLRewrites = "[]"
+	}
 	_, err := db.Exec(`
         UPDATE proxy_hosts SET domains=?, forward_scheme=?, forward_host=?, forward_port=?,
             websocket_support=?, block_common_exploits=?, ssl_enabled=?, ssl_forced=?,
@@ -628,6 +2103,250 @@ func UpdateProxyHost(db *sql.DB, p *ProxyHost) error {
             access_list=?, extra_upstreams=?,
             dns_provider=?, dns_zone_id=?, dns_zone_name=?, dns_record_id=?,
             compression_enabled=?, security_headers_enabled=?, tls_min_version=?,
+            custom_req_headers=?, custom_resp_headers=?, url_rewrites=?,
+            maintenance_mode=?, maintenance_msg=?, max_request_body_mb=?, sticky_sessions=?,
+            upstream_timeout_sec=?, cors_enabled=?, cors_origins=?,
+            health_check_uri=?, health_check_interval_sec=?, keepalive_conns=?,
+            tags=?, notes=?, disable_access_log=?,
+            add_request_id=?, strip_resp_headers=?, blocked_agents=?,
+            health_check_method=?,
+            maintenance_status_code=?,
+            response_cache_control=?,
+            upstream_sni=?,
+            hsts_preload=?,
+            max_conns_per_host=?,
+            health_check_timeout_sec=?,
+            upstream_retries=?,
+            force_http1=?,
+            basicauth_realm=?,
+            error_page_html=?,
+            maintenance_window_start=?, maintenance_window_end=?, maintenance_window_days=?,
+            ip_blocklist=?,
+            lb_policy=?,
+            proxy_protocol=?,
+            robots_txt=?,
+            passive_fail_duration_sec=?,
+            passive_max_fails=?,
+            hsts_max_age_sec=?,
+            csp_header=?,
+            h2c_enabled=?,
+            health_check_headers=?,
+            flush_immediate=?,
+            buffer_responses=?,
+            trusted_proxies=?,
+            upstream_host_override=?,
+            read_timeout_sec=?,
+            deny_dotfiles=?,
+            request_buffers_kb=?,
+            cors_allow_credentials=?,
+            cors_expose_headers=?,
+            ssl_verify_upstream=?,
+            dial_timeout_sec=?,
+            api_key_header=?,
+            api_key_value=?,
+            block_empty_user_agent=?,
+            error_redirect_url=?,
+            permissions_policy=?,
+            x_frame_options=?,
+            referrer_policy=?,
+            hsts_include_subdomains=?,
+            csp_report_only=?,
+            keepalive_idle_timeout_sec=?,
+            health_check_expect_status=?,
+            health_check_expect_body=?,
+            health_check_follow_redirects=?,
+            path_matcher=?,
+            strip_path_prefix=?,
+            sticky_cookie_name=?,
+            lb_try_duration_sec=?,
+            lb_try_interval_ms=?,
+            compression_min_size_kb=?,
+            forward_client_ip=?,
+            cors_max_age_sec=?,
+            cors_allow_methods=?,
+            cors_allow_headers=?,
+            retry_status_codes=?,
+            write_timeout_sec=?,
+            upstream_tls_min_version=?,
+            forward_proxy_url=?,
+            blocked_methods=?,
+            forward_auth_url=?,
+            forward_auth_copy_headers=?,
+            strip_query_string=?,
+            delete_query_params=?,
+            request_body_read_timeout_sec=?,
+            response_header_timeout_sec=?,
+            max_conn_duration_sec=?,
+            decompress_response=?,
+            color=?,
+            www_redirect=?,
+            strip_req_headers=?,
+            upstream_path_prefix=?,
+            compression_level=?,
+            compression_prefer_gzip=?,
+            sort_order=?,
+            allowed_methods=?,
+            upstream_max_resp_header_kb=?,
+            health_check_port=?,
+            request_id_header_name=?,
+            lb_cookie_path=?,
+            passive_unhealthy_latency_ms=?,
+            tls_handshake_timeout_sec=?,
+            expect_continue_timeout_sec=?,
+            response_buffers_kb=?,
+            upstream_max_idle_conns=?,
+            upstream_keep_alive_probe_sec=?,
+            forward_auth_method=?,
+            grpc_web_enabled=?,
+            forward_auth_headers_prefix=?,
+            health_check_max_size_kb=?,
+            strip_path_suffix=?,
+            add_req_query_params=?,
+            error_page_codes=?,
+            upstream_tls_ca_pem_file=?,
+            keepalive_disabled=?,
+            trailing_slash_redirect=?,
+            dial_fallback_delay_ms=?,
+            upstream_network=?,
+            dns_resolver=?,
+            path_matcher_type=?,
+            cors_allow_private_network=?,
+            robots_txt_disallow_all=?,
+            maintenance_retry_after_sec=?,
+            upstream_resolve_timeout_sec=?,
+            upstream_read_buffer_size_kb=?,
+            upstream_write_buffer_size_kb=?,
+            req_header_replace=?,
+            resp_header_replace=?,
+            upstream_http_versions=?,
+            health_check_body=?,
+            add_canonical_link_header=?,
+            http_basic_auth_upstream=?,
+            block_ua_regexp=?,
+            security_txt_body=?,
+            server_header_value=?,
+            x_robots_tag=?,
+            add_forwarded_header=?,
+            lb_cookie_secret=?,
+            passive_unhealthy_status_codes=?,
+            health_check_content_type=?,
+            upstream_tls_client_cert_file=?,
+            upstream_tls_client_key_file=?,
+            block_private_ips=?,
+            enable_brotli=?,
+            vary_header=?,
+            strip_etag=?,
+            http2_push_paths=?,
+            deny_content_types=?,
+            upstream_local_addr=?,
+            upstream_tls_renegotiation=?,
+            upstream_tls_curves=?,
+            upstream_tls_max_version=?,
+            upstream_tls_pins=?,
+            lb_header_field=?,
+            maintenance_custom_headers=?,
+            deny_extensions=?,
+            inject_request_timestamp=?,
+            add_resp_cookies=?,
+            strip_accept_encoding=?,
+            add_upstream_timing_header=?,
+            strip_server_header=?,
+            block_referer_regexp=?,
+            add_content_type_nosniff=?,
+            strip_authorization_header=?,
+            real_ip_from_header=?,
+            health_check_host_override=?,
+            add_x_forwarded_port=?,
+            lb_retry_on=?,
+            max_buffer_size_kb=?,
+            upstream_keepalive_probes=?,
+            upstream_flush_interval_ms=?,
+            add_x_forwarded_host=?,
+            maintenance_allowed_ips=?,
+            upstream_tls_cipher_suites=?,
+            add_cache_control_no_store=?,
+            deny_referer_empty=?,
+            lb_cookie_httponly=?,
+            lb_cookie_secure=?,
+            lb_cookie_same_site=?,
+            upstream_tls_early_data=?,
+            add_via_header=?,
+            req_header_rename=?,
+            add_expect_ct_header=?,
+            force_upstream_encoding=?,
+            passive_unhealthy_count=?,
+            strip_x_powered_by=?,
+            add_timing_allow_origin=?,
+            lb_cookie_max_age_sec=?,
+            cross_origin_opener_policy=?,
+            cross_origin_resource_policy=?,
+            cross_origin_embedder_policy=?,
+            deny_request_content_type=?,
+            compression_exclude_regexp=?,
+            add_cache_control_public=?,
+            add_x_request_start=?,
+            maintenance_window_timezone=?,
+            lb_random_choose_count=?,
+            add_x_forwarded_scheme=?,
+            response_cache_ttl_sec=?,
+            add_link_preload=?,
+            deny_path_regexp=?,
+            add_request_id_to_response=?,
+            health_check_tls_server_name=?,
+            add_x_real_ip=?,
+            strip_incoming_x_forwarded_for=?,
+            health_check_tls_insecure_skip_verify=?,
+            add_cors_vary_header=?,
+            upstream_tls_alpn=?,
+            add_x_powered_by=?,
+            block_query_params=?,
+            add_document_policy=?,
+            maintenance_redirect_url=?,
+            upstream_keepalive_max_lifetime_sec=?,
+            add_origin_header=?,
+            upstream_tls_ca_pem_inline=?,
+            add_server_timing_header=?,
+            add_clear_site_data=?,
+            add_x_dns_prefetch_control=?,
+            add_accept_ranges=?,
+            add_content_disposition=?,
+            upstream_tls_server_name_from_host=?,
+            add_x_permitted_cross_domain_policies=?,
+            strip_response_headers=?,
+            add_report_to=?,
+            add_nel_header=?,
+            block_http_methods=?,
+            add_service_worker_allowed=?,
+            add_accept_ch=?,
+            add_alt_svc=?,
+            add_content_language=?,
+            add_critical_ch=?,
+            add_x_download_options=?,
+            deny_user_agent_regexp=?,
+            add_pragma_no_cache=?,
+            health_check_user_agent=?,
+            add_x_request_path=?,
+            add_x_clacks_overhead=?,
+            add_x_ua_compatible=?,
+            forward_auth_skip_paths=?,
+            add_age_zero=?,
+            add_surrogate_control=?,
+            add_warning_header=?,
+            add_x_request_method=?,
+            add_x_request_query=?,
+            add_x_forwarded_user=?,
+            add_x_real_scheme=?,
+            add_origin_agent_cluster=?,
+            add_x_forwarded_groups=?,
+            add_x_forwarded_email=?,
+            add_x_forwarded_roles=?,
+            block_query_param_regexp=?,
+            add_x_request_referer=?,
+            add_x_request_origin=?,
+            add_x_forwarded_uri=?,
+            add_x_no_archive=?,
+            add_x_request_hostname=?,
+            add_x_xss_protection_disabled=?,
             updated_at=CURRENT_TIMESTAMP
         WHERE id = ?`,
 		p.Domains, p.ForwardScheme, p.ForwardHost, p.ForwardPort,
@@ -638,6 +2357,250 @@ func UpdateProxyHost(db *sql.DB, p *ProxyHost) error {
 		p.AccessList, p.ExtraUpstreams,
 		p.DNSProvider, p.DNSZoneID, p.DNSZoneName, p.DNSRecordID,
 		boolInt(p.CompressionEnabled), boolInt(p.SecurityHeadersEnabled), p.TLSMinVersion,
+		p.CustomReqHeaders, p.CustomRespHeaders, p.URLRewrites,
+		boolInt(p.MaintenanceMode), p.MaintenanceMsg, p.MaxRequestBodyMB, boolInt(p.StickySessions),
+		p.UpstreamTimeoutSec, boolInt(p.CORSEnabled), p.CORSOrigins,
+		p.HealthCheckURI, p.HealthCheckIntervalSec, p.KeepaliveConns,
+		p.Tags, p.Notes, boolInt(p.DisableAccessLog),
+		boolInt(p.AddRequestID), p.StripRespHeaders, p.BlockedAgents,
+		p.HealthCheckMethod,
+		p.MaintenanceStatusCode,
+		p.ResponseCacheControl,
+		p.UpstreamSNI,
+		boolInt(p.HSTSPreload),
+		p.MaxConnsPerHost,
+		p.HealthCheckTimeoutSec,
+		p.UpstreamRetries,
+		boolInt(p.ForceHTTP1),
+		p.BasicAuthRealm,
+		p.ErrorPageHTML,
+		p.MaintenanceWindowStart, p.MaintenanceWindowEnd, p.MaintenanceWindowDays,
+		p.IPBlocklist,
+		p.LBPolicy,
+		p.ProxyProtocol,
+		p.RobotsTxt,
+		p.PassiveFailDurationSec,
+		p.PassiveMaxFails,
+		p.HSTSMaxAgeSec,
+		p.CSPHeader,
+		boolInt(p.H2CEnabled),
+		p.HealthCheckHeaders,
+		boolInt(p.FlushImmediate),
+		boolInt(p.BufferResponses),
+		p.TrustedProxies,
+		p.UpstreamHostOverride,
+		p.ReadTimeoutSec,
+		boolInt(p.DenyDotfiles),
+		p.RequestBuffersKB,
+		boolInt(p.CORSAllowCredentials),
+		p.CORSExposeHeaders,
+		boolInt(p.SSLVerifyUpstream),
+		p.DialTimeoutSec,
+		p.APIKeyHeader,
+		p.APIKeyValue,
+		boolInt(p.BlockEmptyUserAgent),
+		p.ErrorRedirectURL,
+		p.PermissionsPolicy,
+		p.XFrameOptions,
+		p.ReferrerPolicy,
+		boolInt(p.HSTSIncludeSubdomains),
+		p.CSPReportOnly,
+		p.KeepaliveIdleTimeoutSec,
+		p.HealthCheckExpectStatus,
+		p.HealthCheckExpectBody,
+		boolInt(p.HealthCheckFollowRedirects),
+		p.PathMatcher,
+		boolInt(p.StripPathPrefix),
+		p.StickyCookieName,
+		p.LBTryDurationSec,
+		p.LBTryIntervalMS,
+		p.CompressionMinSizeKB,
+		boolInt(p.ForwardClientIP),
+		p.CORSMaxAgeSec,
+		p.CORSAllowMethods,
+		p.CORSAllowHeaders,
+		p.RetryStatusCodes,
+		p.WriteTimeoutSec,
+		p.UpstreamTLSMinVersion,
+		p.ForwardProxyURL,
+		p.BlockedMethods,
+		p.ForwardAuthURL,
+		p.ForwardAuthCopyHeaders,
+		boolInt(p.StripQueryString),
+		p.DeleteQueryParams,
+		p.RequestBodyReadTimeoutSec,
+		p.ResponseHeaderTimeoutSec,
+		p.MaxConnDurationSec,
+		boolInt(p.DecompressResponse),
+		p.Color,
+		p.WWWRedirect,
+		p.StripReqHeaders,
+		p.UpstreamPathPrefix,
+		p.CompressionLevel,
+		boolInt(p.CompressionPreferGzip),
+		p.SortOrder,
+		p.AllowedMethods,
+		p.UpstreamMaxRespHeaderKB,
+		p.HealthCheckPort,
+		p.RequestIDHeaderName,
+		p.LBCookiePath,
+		p.PassiveUnhealthyLatencyMS,
+		p.TLSHandshakeTimeoutSec,
+		p.ExpectContinueTimeoutSec,
+		p.ResponseBuffersKB,
+		p.UpstreamMaxIdleConns,
+		p.UpstreamKeepAliveProbeIntervalSec,
+		p.ForwardAuthMethod,
+		boolInt(p.GRPCWebEnabled),
+		p.ForwardAuthHeadersPrefix,
+		p.HealthCheckMaxSizeKB,
+		p.StripPathSuffix,
+		p.AddReqQueryParams,
+		p.ErrorPageCodes,
+		p.UpstreamTLSCAPEMFile,
+		boolInt(p.KeepaliveDisabled),
+		p.TrailingSlashRedirect,
+		p.DialFallbackDelayMS,
+		p.UpstreamNetwork,
+		p.DNSResolver,
+		p.PathMatcherType,
+		boolInt(p.CORSAllowPrivateNetwork),
+		boolInt(p.RobotsTxtDisallowAll),
+		p.MaintenanceRetryAfterSec,
+		p.UpstreamResolveTimeoutSec,
+		p.UpstreamReadBufferSizeKB,
+		p.UpstreamWriteBufferSizeKB,
+		p.ReqHeaderReplace,
+		p.RespHeaderReplace,
+		p.UpstreamHTTPVersions,
+		p.HealthCheckBody,
+		boolInt(p.AddCanonicalLinkHeader),
+		p.HTTPBasicAuthUpstream,
+		p.BlockUARegexp,
+		p.SecurityTxtBody,
+		p.ServerHeaderValue,
+		p.XRobotsTag,
+		boolInt(p.AddForwardedHeader),
+		p.LBCookieSecret,
+		p.PassiveUnhealthyStatusCodes,
+		p.HealthCheckContentType,
+		p.UpstreamTLSClientCertFile,
+		p.UpstreamTLSClientKeyFile,
+		boolInt(p.BlockPrivateIPs),
+		boolInt(p.EnableBrotli),
+		p.VaryHeader,
+		boolInt(p.StripETag),
+		p.HTTP2PushPaths,
+		p.DenyContentTypes,
+		p.UpstreamLocalAddr,
+		p.UpstreamTLSRenegotiation,
+		p.UpstreamTLSCurves,
+		p.UpstreamTLSMaxVersion,
+		p.UpstreamTLSPins,
+		p.LBHeaderField,
+		p.MaintenanceCustomHeaders,
+		p.DenyExtensions,
+		boolInt(p.InjectRequestTimestamp),
+		p.AddRespCookies,
+		boolInt(p.StripAcceptEncoding),
+		boolInt(p.AddUpstreamTimingHeader),
+		boolInt(p.StripServerHeader),
+		p.BlockRefererRegexp,
+		boolInt(p.AddContentTypeNosniff),
+		boolInt(p.StripAuthorizationHeader),
+		p.RealIPFromHeader,
+		p.HealthCheckHostOverride,
+		boolInt(p.AddXForwardedPort),
+		p.LBRetryOn,
+		p.MaxBufferSizeKB,
+		p.UpstreamKeepaliveProbes,
+		p.UpstreamFlushIntervalMS,
+		boolInt(p.AddXForwardedHost),
+		p.MaintenanceAllowedIPs,
+		p.UpstreamTLSCipherSuites,
+		boolInt(p.AddCacheControlNoStore),
+		boolInt(p.DenyRefererEmpty),
+		boolInt(p.LBCookieHTTPOnly),
+		boolInt(p.LBCookieSecure),
+		p.LBCookieSameSite,
+		boolInt(p.UpstreamTLSEarlyData),
+		boolInt(p.AddViaHeader),
+		p.ReqHeaderRename,
+		boolInt(p.AddExpectCTHeader),
+		p.ForceUpstreamEncoding,
+		p.PassiveUnhealthyCount,
+		boolInt(p.StripXPoweredBy),
+		p.AddTimingAllowOrigin,
+		p.LBCookieMaxAgeSec,
+		p.CrossOriginOpenerPolicy,
+		p.CrossOriginResourcePolicy,
+		p.CrossOriginEmbedderPolicy,
+		p.DenyRequestContentType,
+		p.CompressionExcludeRegexp,
+		boolInt(p.AddCacheControlPublic),
+		boolInt(p.AddXRequestStart),
+		p.MaintenanceWindowTimezone,
+		p.LBRandomChooseCount,
+		boolInt(p.AddXForwardedScheme),
+		p.ResponseCacheTTLSec,
+		p.AddLinkPreload,
+		p.DenyPathRegexp,
+		boolInt(p.AddRequestIDToResponse),
+		p.HealthCheckTLSServerName,
+		boolInt(p.AddXRealIP),
+		boolInt(p.StripIncomingXForwardedFor),
+		boolInt(p.HealthCheckTLSInsecureSkipVerify),
+		boolInt(p.AddCORSVaryHeader),
+		p.UpstreamTLSALPN,
+		p.AddXPoweredBy,
+		p.BlockQueryParams,
+		p.AddDocumentPolicy,
+		p.MaintenanceRedirectURL,
+		p.UpstreamKeepaliveMaxLifetimeSec,
+		p.AddOriginHeader,
+		p.UpstreamTLSCAPEMInline,
+		boolInt(p.AddServerTimingHeader),
+		p.AddClearSiteData,
+		boolInt(p.AddXDNSPrefetchControl),
+		boolInt(p.AddAcceptRanges),
+		p.AddContentDisposition,
+		boolInt(p.UpstreamTLSServerNameFromHost),
+		p.AddXPermittedCrossDomainPolicies,
+		p.StripResponseHeaders,
+		p.AddReportTo,
+		p.AddNELHeader,
+		p.BlockHTTPMethods,
+		p.AddServiceWorkerAllowed,
+		p.AddAcceptCH,
+		p.AddAltSvc,
+		p.AddContentLanguage,
+		p.AddCriticalCH,
+		boolInt(p.AddXDownloadOptions),
+		p.DenyUserAgentRegexp,
+		boolInt(p.AddPragmaNoCache),
+		p.HealthCheckUserAgent,
+		boolInt(p.AddXRequestPath),
+		p.AddXClacksOverhead,
+		p.AddXUACompatible,
+		p.ForwardAuthSkipPaths,
+		boolInt(p.AddAgeZero),
+		p.AddSurrogateControl,
+		p.AddWarningHeader,
+		boolInt(p.AddXRequestMethod),
+		boolInt(p.AddXRequestQuery),
+		p.AddXForwardedUser,
+		boolInt(p.AddXRealScheme),
+		boolInt(p.AddOriginAgentCluster),
+		p.AddXForwardedGroups,
+		p.AddXForwardedEmail,
+		p.AddXForwardedRoles,
+		p.BlockQueryParamRegexp,
+		boolInt(p.AddXRequestReferer),
+		boolInt(p.AddXRequestOrigin),
+		boolInt(p.AddXForwardedURI),
+		boolInt(p.AddXNoArchive),
+		boolInt(p.AddXRequestHostname),
+		boolInt(p.AddXXSSProtectionDisabled),
 		p.ID,
 	)
 	return err
@@ -743,10 +2706,19 @@ func ListRedirectionHosts(db *sql.DB, serverID int64, viewerID int64, isAdmin bo
         SELECT rh.id, rh.domains, rh.forward_scheme, rh.forward_domain, rh.forward_http_code,
                rh.preserve_path, rh.ssl_enabled, rh.ssl_forced, rh.enabled,
                COALESCE(rh.certificate_id, 0), rh.created_at, rh.updated_at,
-               COALESCE(rh.owner_id, 0), COALESCE(u.email, '')
+               COALESCE(rh.owner_id, 0), COALESCE(u.email, ''),
+               COALESCE(rh.tags,''), COALESCE(rh.notes,''),
+               COALESCE(rh.access_list,''), COALESCE(rh.maintenance_mode,0), COALESCE(rh.maintenance_msg,''),
+               COALESCE(rh.custom_resp_headers,'{}'),
+               COALESCE(rh.ip_blocklist,''),
+               COALESCE(rh.hsts_max_age_sec,0), COALESCE(rh.hsts_include_subdomains,0), COALESCE(rh.hsts_preload,0),
+               COALESCE(rh.advanced_config,''),
+               COALESCE(rh.color,''),
+               COALESCE(rh.maintenance_status_code,503),
+               COALESCE(rh.sort_order,0)
         FROM redirection_hosts rh
         LEFT JOIN users u ON u.id = rh.owner_id
-        WHERE rh.server_id = ? ORDER BY rh.id DESC`, serverID)
+        WHERE rh.server_id = ? ORDER BY rh.sort_order ASC, rh.id DESC`, serverID)
 	} else {
 		inStr, inArgs := inClause(peerIDs)
 		args := append([]any{serverID, viewerID}, inArgs...)
@@ -754,12 +2726,21 @@ func ListRedirectionHosts(db *sql.DB, serverID int64, viewerID int64, isAdmin bo
         SELECT rh.id, rh.domains, rh.forward_scheme, rh.forward_domain, rh.forward_http_code,
                rh.preserve_path, rh.ssl_enabled, rh.ssl_forced, rh.enabled,
                COALESCE(rh.certificate_id, 0), rh.created_at, rh.updated_at,
-               COALESCE(rh.owner_id, 0), COALESCE(u.email, '')
+               COALESCE(rh.owner_id, 0), COALESCE(u.email, ''),
+               COALESCE(rh.tags,''), COALESCE(rh.notes,''),
+               COALESCE(rh.access_list,''), COALESCE(rh.maintenance_mode,0), COALESCE(rh.maintenance_msg,''),
+               COALESCE(rh.custom_resp_headers,'{}'),
+               COALESCE(rh.ip_blocklist,''),
+               COALESCE(rh.hsts_max_age_sec,0), COALESCE(rh.hsts_include_subdomains,0), COALESCE(rh.hsts_preload,0),
+               COALESCE(rh.advanced_config,''),
+               COALESCE(rh.color,''),
+               COALESCE(rh.maintenance_status_code,503),
+               COALESCE(rh.sort_order,0)
         FROM redirection_hosts rh
         LEFT JOIN users u ON u.id = rh.owner_id
         WHERE rh.server_id = ?
           AND (rh.owner_id = ? OR rh.owner_id IN (`+inStr+`))
-        ORDER BY rh.id DESC`, args...)
+        ORDER BY rh.sort_order ASC, rh.id DESC`, args...)
 	}
 	if err != nil {
 		return nil, err
@@ -768,17 +2749,27 @@ func ListRedirectionHosts(db *sql.DB, serverID int64, viewerID int64, isAdmin bo
 	var out []RedirectionHost
 	for rows.Next() {
 		var r RedirectionHost
-		var pp, ssl, sslf, en int
+		var pp, ssl, sslf, en, maintMode int
 		var ownerID int64
+		var hstsSubdomains, hstsPreload int
 		if err := rows.Scan(&r.ID, &r.Domains, &r.ForwardScheme, &r.ForwardDomain,
 			&r.ForwardHTTPCode, &pp, &ssl, &sslf, &en, &r.CertificateID,
-			&r.CreatedAt, &r.UpdatedAt, &ownerID, &r.OwnerEmail); err != nil {
+			&r.CreatedAt, &r.UpdatedAt, &ownerID, &r.OwnerEmail,
+			&r.Tags, &r.Notes,
+			&r.AccessList, &maintMode, &r.MaintenanceMsg,
+			&r.CustomRespHeaders, &r.IPBlocklist,
+			&r.HSTSMaxAgeSec, &hstsSubdomains, &hstsPreload,
+			&r.AdvancedConfig, &r.Color,
+			&r.MaintenanceStatusCode, &r.SortOrder); err != nil {
 			return nil, err
 		}
 		r.PreservePath = pp == 1
 		r.SSLEnabled = ssl == 1
 		r.SSLForced = sslf == 1
 		r.Enabled = en == 1
+		r.MaintenanceMode = maintMode == 1
+		r.HSTSIncludeSubdomains = hstsSubdomains == 1
+		r.HSTSPreload = hstsPreload == 1
 		if ownerID != 0 {
 			r.OwnerID = sql.NullInt64{Int64: ownerID, Valid: true}
 		}
@@ -789,17 +2780,32 @@ func ListRedirectionHosts(db *sql.DB, serverID int64, viewerID int64, isAdmin bo
 
 func GetRedirectionHost(db *sql.DB, id int64) (*RedirectionHost, error) {
 	var r RedirectionHost
-	var pp, ssl, sslf, en int
+	var pp, ssl, sslf, en, maintMode int
 	var ownerID int64
+	var hstsSubdomains, hstsPreload int
 	err := db.QueryRow(`
         SELECT id, domains, forward_scheme, forward_domain, forward_http_code,
                preserve_path, ssl_enabled, ssl_forced, enabled,
                COALESCE(certificate_id, 0), created_at, updated_at,
-               COALESCE(owner_id, 0)
+               COALESCE(owner_id, 0),
+               COALESCE(tags,''), COALESCE(notes,''),
+               COALESCE(access_list,''), COALESCE(maintenance_mode,0), COALESCE(maintenance_msg,''),
+               COALESCE(custom_resp_headers,'{}'),
+               COALESCE(ip_blocklist,''),
+               COALESCE(hsts_max_age_sec,0), COALESCE(hsts_include_subdomains,0), COALESCE(hsts_preload,0),
+               COALESCE(advanced_config,''),
+               COALESCE(color,''),
+               COALESCE(maintenance_status_code,503),
+               COALESCE(sort_order,0)
         FROM redirection_hosts WHERE id = ?`, id).Scan(
 		&r.ID, &r.Domains, &r.ForwardScheme, &r.ForwardDomain, &r.ForwardHTTPCode,
 		&pp, &ssl, &sslf, &en, &r.CertificateID, &r.CreatedAt, &r.UpdatedAt,
-		&ownerID,
+		&ownerID, &r.Tags, &r.Notes,
+		&r.AccessList, &maintMode, &r.MaintenanceMsg,
+		&r.CustomRespHeaders, &r.IPBlocklist,
+		&r.HSTSMaxAgeSec, &hstsSubdomains, &hstsPreload,
+		&r.AdvancedConfig, &r.Color,
+		&r.MaintenanceStatusCode, &r.SortOrder,
 	)
 	if err != nil {
 		return nil, err
@@ -808,6 +2814,9 @@ func GetRedirectionHost(db *sql.DB, id int64) (*RedirectionHost, error) {
 	r.SSLEnabled = ssl == 1
 	r.SSLForced = sslf == 1
 	r.Enabled = en == 1
+	r.MaintenanceMode = maintMode == 1
+	r.HSTSIncludeSubdomains = hstsSubdomains == 1
+	r.HSTSPreload = hstsPreload == 1
 	if ownerID != 0 {
 		r.OwnerID = sql.NullInt64{Int64: ownerID, Valid: true}
 	}
@@ -822,15 +2831,29 @@ func CreateRedirectionHost(db *sql.DB, serverID int64, ownerID int64, r *Redirec
 	if r.ForwardHTTPCode == 0 {
 		r.ForwardHTTPCode = 301
 	}
+	if r.CustomRespHeaders == "" {
+		r.CustomRespHeaders = "{}"
+	}
+	if r.MaintenanceStatusCode == 0 {
+		r.MaintenanceStatusCode = 503
+	}
 	res, err := db.Exec(`
         INSERT INTO redirection_hosts (server_id, domains, forward_scheme, forward_domain,
-            forward_http_code, preserve_path, ssl_enabled, ssl_forced, enabled, certificate_id, owner_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            forward_http_code, preserve_path, ssl_enabled, ssl_forced, enabled, certificate_id, owner_id,
+            tags, notes, access_list, maintenance_mode, maintenance_msg, custom_resp_headers, ip_blocklist,
+            hsts_max_age_sec, hsts_include_subdomains, hsts_preload, advanced_config, color,
+            maintenance_status_code, sort_order)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		serverID,
 		r.Domains, r.ForwardScheme, r.ForwardDomain, r.ForwardHTTPCode,
 		boolInt(r.PreservePath), boolInt(r.SSLEnabled), boolInt(r.SSLForced),
 		boolInt(r.Enabled), nilIfZero(r.CertificateID),
 		nilIfZero(ownerID),
+		r.Tags, r.Notes, r.AccessList, boolInt(r.MaintenanceMode), r.MaintenanceMsg,
+		r.CustomRespHeaders, r.IPBlocklist,
+		r.HSTSMaxAgeSec, boolInt(r.HSTSIncludeSubdomains), boolInt(r.HSTSPreload),
+		r.AdvancedConfig, r.Color,
+		r.MaintenanceStatusCode, r.SortOrder,
 	)
 	if err != nil {
 		return 0, err
@@ -842,13 +2865,31 @@ func UpdateRedirectionHost(db *sql.DB, r *RedirectionHost) error {
 	if r.ForwardScheme == "" {
 		r.ForwardScheme = "auto"
 	}
+	if r.CustomRespHeaders == "" {
+		r.CustomRespHeaders = "{}"
+	}
+	if r.MaintenanceStatusCode == 0 {
+		r.MaintenanceStatusCode = 503
+	}
 	_, err := db.Exec(`
         UPDATE redirection_hosts SET domains=?, forward_scheme=?, forward_domain=?,
             forward_http_code=?, preserve_path=?, ssl_enabled=?, ssl_forced=?, enabled=?,
-            certificate_id=?, updated_at=CURRENT_TIMESTAMP WHERE id = ?`,
+            certificate_id=?, tags=?, notes=?,
+            access_list=?, maintenance_mode=?, maintenance_msg=?,
+            custom_resp_headers=?, ip_blocklist=?,
+            hsts_max_age_sec=?, hsts_include_subdomains=?, hsts_preload=?,
+            advanced_config=?, color=?,
+            maintenance_status_code=?, sort_order=?,
+            updated_at=CURRENT_TIMESTAMP WHERE id = ?`,
 		r.Domains, r.ForwardScheme, r.ForwardDomain, r.ForwardHTTPCode,
 		boolInt(r.PreservePath), boolInt(r.SSLEnabled), boolInt(r.SSLForced),
-		boolInt(r.Enabled), nilIfZero(r.CertificateID), r.ID,
+		boolInt(r.Enabled), nilIfZero(r.CertificateID), r.Tags, r.Notes,
+		r.AccessList, boolInt(r.MaintenanceMode), r.MaintenanceMsg,
+		r.CustomRespHeaders, r.IPBlocklist,
+		r.HSTSMaxAgeSec, boolInt(r.HSTSIncludeSubdomains), boolInt(r.HSTSPreload),
+		r.AdvancedConfig, r.Color,
+		r.MaintenanceStatusCode, r.SortOrder,
+		r.ID,
 	)
 	return err
 }
@@ -1460,6 +3501,40 @@ func ListActivity(db *sql.DB, serverID int64, limit int) ([]Activity, error) {
 	return out, rows.Err()
 }
 
+// ListActivitySearch is like ListActivity but filters rows where actor, action,
+// target, or detail contain the given search string (case-insensitive LIKE).
+// When search is empty it behaves identically to ListActivity.
+func ListActivitySearch(db *sql.DB, serverID int64, limit int, search string) ([]Activity, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	if search == "" {
+		return ListActivity(db, serverID, limit)
+	}
+	like := "%" + search + "%"
+	rows, err := db.Query(`SELECT id, actor, action, target, detail, success, created_at
+        FROM activity_log
+        WHERE server_id = ?
+          AND (actor LIKE ? OR action LIKE ? OR target LIKE ? OR detail LIKE ?)
+        ORDER BY id DESC LIMIT ?`,
+		serverID, like, like, like, like, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Activity
+	for rows.Next() {
+		var a Activity
+		var ok int
+		if err := rows.Scan(&a.ID, &a.Actor, &a.Action, &a.Target, &a.Detail, &ok, &a.CreatedAt); err != nil {
+			return nil, err
+		}
+		a.Success = ok == 1
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
 // CertificateInUse returns the number of proxy/redirect/raw routes currently referencing this cert.
 func CertificateInUse(db *sql.DB, id int64) (int, error) {
 	var n int
@@ -1493,4 +3568,226 @@ func CertificateInUseByOthers(db *sql.DB, id int64, excludeOwnerID int64) (int, 
 		return 0, err
 	}
 	return n, nil
+}
+
+// --- API Tokens ---
+
+// API token scope values. Stored verbatim in the scopes column.
+const (
+	TokenScopeFull       = "full"        // full access as the user's role
+	TokenScopeReadOnly   = "read_only"   // GET/HEAD requests only
+	TokenScopeProxyWrite = "proxy_write" // proxy-host write + everything else read-only
+)
+
+// APIToken is a named bearer-token credential for programmatic access.
+// The raw token is shown exactly once at creation; only the SHA-256 hash
+// is persisted. Expiry == zero means the token never expires.
+type APIToken struct {
+	ID         int64
+	UserID     int64
+	UserEmail  string // populated via JOIN on list queries
+	Name       string
+	TokenHash  string
+	Scopes     string
+	LastUsedAt sql.NullTime
+	ExpiresAt  sql.NullTime
+	CreatedAt  time.Time
+}
+
+func (t *APIToken) Expired() bool {
+	return t.ExpiresAt.Valid && t.ExpiresAt.Time.Before(time.Now())
+}
+
+// CreateAPIToken inserts a new API token row and returns the inserted ID.
+// tokenHash must be hex(sha256(rawToken)).
+func CreateAPIToken(db *sql.DB, userID int64, name, tokenHash, scopes string, expiresAt *time.Time) (int64, error) {
+	var exp any
+	if expiresAt != nil {
+		exp = *expiresAt
+	}
+	res, err := db.Exec(
+		`INSERT INTO api_tokens (user_id, name, token_hash, scopes, expires_at) VALUES (?, ?, ?, ?, ?)`,
+		userID, strings.TrimSpace(name), tokenHash, scopes, exp,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// ListAPITokens returns all tokens for the given user.
+// If isAdmin is true, all users' tokens are returned with user email.
+func ListAPITokens(db *sql.DB, userID int64, isAdmin bool) ([]APIToken, error) {
+	var rows *sql.Rows
+	var err error
+	if isAdmin {
+		rows, err = db.Query(`
+			SELECT t.id, t.user_id, COALESCE(u.email,''), t.name, t.token_hash, t.scopes,
+			       t.last_used_at, t.expires_at, t.created_at
+			FROM api_tokens t
+			LEFT JOIN users u ON u.id = t.user_id
+			ORDER BY t.id DESC`)
+	} else {
+		rows, err = db.Query(`
+			SELECT t.id, t.user_id, COALESCE(u.email,''), t.name, t.token_hash, t.scopes,
+			       t.last_used_at, t.expires_at, t.created_at
+			FROM api_tokens t
+			LEFT JOIN users u ON u.id = t.user_id
+			WHERE t.user_id = ?
+			ORDER BY t.id DESC`, userID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []APIToken
+	for rows.Next() {
+		var t APIToken
+		if err := rows.Scan(&t.ID, &t.UserID, &t.UserEmail, &t.Name, &t.TokenHash, &t.Scopes,
+			&t.LastUsedAt, &t.ExpiresAt, &t.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// GetAPITokenByHash looks up a token by its SHA-256 hex hash. Returns nil if not found.
+func GetAPITokenByHash(db *sql.DB, tokenHash string) (*APIToken, error) {
+	var t APIToken
+	err := db.QueryRow(`
+		SELECT t.id, t.user_id, COALESCE(u.email,''), t.name, t.token_hash, t.scopes,
+		       t.last_used_at, t.expires_at, t.created_at
+		FROM api_tokens t
+		LEFT JOIN users u ON u.id = t.user_id
+		WHERE t.token_hash = ?`, tokenHash).
+		Scan(&t.ID, &t.UserID, &t.UserEmail, &t.Name, &t.TokenHash, &t.Scopes,
+			&t.LastUsedAt, &t.ExpiresAt, &t.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// TouchAPIToken updates last_used_at to now.
+func TouchAPIToken(db *sql.DB, id int64) {
+	_, _ = db.Exec(`UPDATE api_tokens SET last_used_at = CURRENT_TIMESTAMP WHERE id = ?`, id)
+}
+
+// DeleteAPIToken removes a token by ID. ownerID == 0 skips the ownership check (admin path).
+func DeleteAPIToken(db *sql.DB, id int64, ownerID int64) error {
+	if ownerID == 0 {
+		_, err := db.Exec(`DELETE FROM api_tokens WHERE id = ?`, id)
+		return err
+	}
+	_, err := db.Exec(`DELETE FROM api_tokens WHERE id = ? AND user_id = ?`, id, ownerID)
+	return err
+}
+
+// --- Proxy Health ---
+
+// ProxyHealthCheck is a single health-check result for a proxy host.
+type ProxyHealthCheck struct {
+	ID          int64
+	ProxyHostID int64
+	CheckedAt   time.Time
+	OK          bool
+	StatusCode  int
+	LatencyMs   int64
+	ErrorMsg    string
+}
+
+// LatestProxyHealth returns the most recent health check for each proxy host ID
+// in the given list. Returns a map of proxyHostID → ProxyHealthCheck.
+// Hosts with no check history are absent from the map.
+func LatestProxyHealth(db *sql.DB, hostIDs []int64) (map[int64]ProxyHealthCheck, error) {
+	if len(hostIDs) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(hostIDs))
+	args := make([]any, len(hostIDs))
+	for i, id := range hostIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	rows, err := db.Query(`
+		SELECT ph.proxy_host_id, ph.checked_at, ph.ok, ph.status_code, ph.latency_ms, ph.error_msg
+		FROM proxy_health ph
+		INNER JOIN (
+			SELECT proxy_host_id, MAX(checked_at) AS max_ts
+			FROM proxy_health
+			WHERE proxy_host_id IN (`+strings.Join(placeholders, ",")+`)
+			GROUP BY proxy_host_id
+		) latest ON ph.proxy_host_id = latest.proxy_host_id AND ph.checked_at = latest.max_ts
+	`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[int64]ProxyHealthCheck)
+	for rows.Next() {
+		var h ProxyHealthCheck
+		var ok int
+		var ts int64
+		if err := rows.Scan(&h.ProxyHostID, &ts, &ok, &h.StatusCode, &h.LatencyMs, &h.ErrorMsg); err != nil {
+			return nil, err
+		}
+		h.OK = ok == 1
+		h.CheckedAt = time.Unix(ts, 0)
+		out[h.ProxyHostID] = h
+	}
+	return out, rows.Err()
+}
+
+// InsertProxyHealth stores a health check result and prunes old rows for that host
+// to keep at most 288 entries (24 hours at 5-min intervals).
+func InsertProxyHealth(db *sql.DB, hostID int64, ok bool, statusCode int, latencyMs int64, errMsg string) error {
+	ts := time.Now().Unix()
+	okInt := 0
+	if ok {
+		okInt = 1
+	}
+	if _, err := db.Exec(`
+		INSERT INTO proxy_health (proxy_host_id, checked_at, ok, status_code, latency_ms, error_msg)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		hostID, ts, okInt, statusCode, latencyMs, errMsg); err != nil {
+		return err
+	}
+	// Prune: keep only the newest 288 rows per host.
+	_, err := db.Exec(`
+		DELETE FROM proxy_health
+		WHERE proxy_host_id = ? AND id NOT IN (
+			SELECT id FROM proxy_health WHERE proxy_host_id = ? ORDER BY checked_at DESC LIMIT 288
+		)`, hostID, hostID)
+	return err
+}
+
+// GetProxyHealthHistory returns the last N health checks for a given proxy host,
+// ordered newest first.
+func GetProxyHealthHistory(db *sql.DB, hostID int64, limit int) ([]ProxyHealthCheck, error) {
+	rows, err := db.Query(`
+		SELECT checked_at, ok, status_code, latency_ms, error_msg
+		FROM proxy_health WHERE proxy_host_id = ?
+		ORDER BY checked_at DESC LIMIT ?`, hostID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ProxyHealthCheck
+	for rows.Next() {
+		var h ProxyHealthCheck
+		var ok int
+		var ts int64
+		if err := rows.Scan(&ts, &ok, &h.StatusCode, &h.LatencyMs, &h.ErrorMsg); err != nil {
+			return nil, err
+		}
+		h.OK = ok == 1
+		h.CheckedAt = time.Unix(ts, 0)
+		h.ProxyHostID = hostID
+		out = append(out, h)
+	}
+	return out, rows.Err()
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,10 +3,17 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
+	"encoding/base64"
+	"encoding/csv"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
@@ -76,6 +83,9 @@ type Server struct {
 	// New() arg) so the wiring order stays readable — the ingest owns a
 	// DB ref that has to exist before we hand it over.
 	analyticsIngest *analytics.Ingest
+
+	// v2.9.2: HTTP client used by the background per-proxy-host health checker.
+	healthClient *http.Client
 }
 
 // SetAnalyticsIngest plumbs the analytics ingest listener into the server
@@ -97,7 +107,7 @@ func New(db *sql.DB, caddyClient *caddy.Client, templates fs.FS, static fs.FS, c
 	// happens to be. Priority: DB value → TZ env var → UTC. See timezone.go.
 	loc := loadActiveLocation(db)
 	log.Printf("timezone: rendering timestamps in %s", loc)
-	return &Server{
+	s := &Server{
 		DB:             db,
 		Caddy:          caddyClient,
 		Templates:      tpl,
@@ -107,7 +117,22 @@ func New(db *sql.DB, caddyClient *caddy.Client, templates fs.FS, static fs.FS, c
 		DBPath:         dbPath,
 		healthFailures: map[int64]int{},
 		appHealth:      map[int64]appHealthEntry{},
-	}, nil
+	}
+	// Initialize health check HTTP client (short timeouts, no redirect following).
+	s.healthClient = &http.Client{
+		Timeout: 10 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse // don't follow redirects
+		},
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // check reachability, not cert validity
+		},
+	}
+	go s.runHealthChecker()
+	go s.runAutoSyncLoop()
+	go s.runMaintenanceWindowLoop()
+	go s.runActivityLogCleanup()
+	return s, nil
 }
 
 // healthFailThreshold is the number of consecutive failed pings required
@@ -266,6 +291,15 @@ func parseTemplates(tplFS fs.FS) (map[string]*template.Template, error) {
 		},
 		"subInt": func(a, b int) int { return a - b },
 		"addInt": func(a, b int) int { return a + b },
+		// mulDivInt64 is the int64 analogue of mulDivInt for use with
+		// BandwidthBucket.BytesOut (int64) SVG bar-height calculations.
+		"mulDivInt64": func(a, b, c int64) int64 {
+			if c == 0 {
+				return 0
+			}
+			return (a * b) / c
+		},
+		"subInt64": func(a, b int64) int64 { return a - b },
 		// fmtBytes renders a byte count as a human-readable size string.
 		// Used in analytics cards to show bandwidth totals without overwhelming
 		// the reader with raw byte counts (e.g. "1.4 GB" instead of "1503238553").
@@ -318,6 +352,33 @@ func parseTemplates(tplFS fs.FS) (map[string]*template.Template, error) {
 			}
 			return body + " ago"
 		},
+		// colorDotClass returns Tailwind bg-* classes for a host color label.
+		// Returns an empty string when the color is blank so the dot can be
+		// hidden entirely ({{ if .Host.Color }} guard in templates).
+		"colorDotClass": func(c string) string {
+			switch c {
+			case "red":
+				return "bg-red-400"
+			case "orange":
+				return "bg-orange-400"
+			case "yellow":
+				return "bg-yellow-400"
+			case "green":
+				return "bg-green-400"
+			case "teal":
+				return "bg-teal-400"
+			case "blue":
+				return "bg-blue-400"
+			case "purple":
+				return "bg-purple-400"
+			case "pink":
+				return "bg-pink-400"
+			case "gray":
+				return "bg-gray-400"
+			default:
+				return ""
+			}
+		},
 	}
 	entries, err := fs.ReadDir(tplFS, ".")
 	if err != nil {
@@ -339,6 +400,7 @@ func parseTemplates(tplFS fs.FS) (map[string]*template.Template, error) {
 
 func (s *Server) Routes() http.Handler {
 	r := chi.NewRouter()
+	r.Use(s.adminIPGate)
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 
@@ -377,6 +439,12 @@ func (s *Server) Routes() http.Handler {
 	r.Post("/logout", s.postLogout)
 	r.Get("/login/totp", s.getTOTPVerify)
 	r.Post("/login/totp", s.postTOTPVerify)
+	r.Get("/forgot-password", s.getForgotPassword)
+	r.Post("/forgot-password", s.postForgotPassword)
+	r.Get("/reset-password", s.getResetPassword)
+	r.Post("/reset-password", s.postResetPassword)
+	r.Get("/accept-invite", s.getAcceptInvite)
+	r.Post("/accept-invite", s.postAcceptInvite)
 
 	r.Group(func(r chi.Router) {
 		r.Use(s.requireAuth)
@@ -389,10 +457,15 @@ func (s *Server) Routes() http.Handler {
 		r.Get("/caddyfile-import", s.getCaddyfileImport)
 		r.Get("/snapshots", s.listSnapshots)
 		r.Get("/snapshots/{id}/download", s.downloadSnapshot)
+		r.Get("/snapshots/{id}/diff", s.getSnapshotDiff)
 		r.Get("/activity", s.listActivityLog)
+		r.Get("/activity/export.csv", s.exportActivityCSV)
 		r.Get("/certificates", s.listCertificates)
+		r.Get("/certificates/{id}/inspect", s.getCertificateInspect)
 		r.Get("/raw-routes", s.listRawRoutes)
 		r.Get("/docs", s.getDocs)
+		r.Get("/api/docs", s.getAPIDocs)
+		r.Get("/caddy-config", s.getCaddyConfig)
 
 		// Server picker — available to every authenticated role. The route
 		// only flips the caddyui_server cookie (a per-user preference) so
@@ -404,11 +477,18 @@ func (s *Server) Routes() http.Handler {
 		// Feature B: upstream health check API (authenticated, no requireWrite).
 		r.Get("/api/upstream-health", s.apiUpstreamHealth)
 
+		// Live upstream status — proxies Caddy's /reverse_proxy/upstreams response.
+		r.Get("/api/caddy-upstreams", s.apiCaddyUpstreams)
+		r.Post("/api/proxy-hosts/test-upstream", s.apiTestUpstream)
+
 		// Feature F: notifier status API (authenticated).
 		r.Get("/api/notifier-status", s.apiNotifierStatus)
 
 		// Phase 7: system stats API (authenticated, read-only).
 		r.Get("/api/system-stats", s.apiSystemStats)
+
+		// Caddy version from the admin API root endpoint.
+		r.Get("/api/caddy-version", s.apiCaddyVersion)
 
 		// Update-check: fetches latest tag from Docker Hub (cached 1h).
 		r.Get("/api/version-check", s.apiVersionCheck)
@@ -432,6 +512,14 @@ func (s *Server) Routes() http.Handler {
 		r.Get("/api/proxy-hosts/{id}/deploy-status", s.apiProxyHostDeployStatus)
 		r.Get("/raw-routes/{id}/deploying", s.rawRouteDeploying)
 		r.Get("/api/raw-routes/{id}/deploy-status", s.apiRawRouteDeployStatus)
+		// v2.9.2: per-host health history page (read-only, authenticated).
+		r.Get("/proxy-hosts/{id}/health", s.getProxyHostHealth)
+
+		// v2.9.5: REST JSON API for proxy hosts and redirection hosts (read endpoints).
+		r.Get("/api/v1/proxy-hosts", s.apiV1ListProxyHosts)
+		r.Get("/api/v1/proxy-hosts/{id}", s.apiV1GetProxyHost)
+		r.Get("/api/v1/redirection-hosts", s.apiV1ListRedirectionHosts)
+		r.Get("/api/v1/redirection-hosts/{id}", s.apiV1GetRedirectionHost)
 
 		// Write routes — admin-only in practice. Viewers get 403 via requireWrite.
 		r.Group(func(r chi.Router) {
@@ -439,10 +527,29 @@ func (s *Server) Routes() http.Handler {
 
 			r.Get("/proxy-hosts/new", s.newProxyHost)
 			r.Post("/proxy-hosts", s.createProxyHost)
+			r.Get("/proxy-hosts/{id}/export.json", s.exportProxyHost)
+			r.Get("/proxy-hosts/export-all.json", s.exportAllProxyHosts)
+			r.Post("/proxy-hosts/import", s.importProxyHost)
 			r.Get("/proxy-hosts/{id}/edit", s.editProxyHost)
 			r.Post("/proxy-hosts/{id}", s.updateProxyHost)
 			r.Post("/proxy-hosts/{id}/delete", s.deleteProxyHost)
+			r.Post("/proxy-hosts/{id}/clone", s.cloneProxyHost)
 			r.Post("/proxy-hosts/{id}/toggle", s.toggleProxyHost)
+			r.Post("/proxy-hosts/{id}/maintenance", s.toggleMaintenanceMode)
+			r.Post("/proxy-hosts/bulk-toggle", s.bulkToggleProxyHosts)
+			r.Post("/proxy-hosts/bulk-maintenance", s.bulkMaintenanceProxyHosts)
+			r.Post("/proxy-hosts/bulk-delete", s.bulkDeleteProxyHosts)
+
+			// v2.9.5: REST JSON API write routes (write-scoped, honours requireWrite).
+			r.Post("/api/v1/proxy-hosts", s.apiV1CreateProxyHost)
+			r.Put("/api/v1/proxy-hosts/{id}", s.apiV1UpdateProxyHost)
+			r.Delete("/api/v1/proxy-hosts/{id}", s.apiV1DeleteProxyHost)
+			r.Post("/api/v1/proxy-hosts/{id}/toggle", s.apiV1ToggleProxyHost)
+			r.Post("/api/v1/proxy-hosts/{id}/maintenance", s.apiV1ToggleMaintenanceProxyHost)
+			r.Post("/api/v1/redirection-hosts", s.apiV1CreateRedirectionHost)
+			r.Put("/api/v1/redirection-hosts/{id}", s.apiV1UpdateRedirectionHost)
+			r.Delete("/api/v1/redirection-hosts/{id}", s.apiV1DeleteRedirectionHost)
+			r.Post("/api/v1/redirection-hosts/{id}/toggle", s.apiV1ToggleRedirectionHost)
 
 			r.Get("/redirection-hosts/new", s.newRedirectionHost)
 			r.Post("/redirection-hosts", s.createRedirectionHost)
@@ -450,6 +557,7 @@ func (s *Server) Routes() http.Handler {
 			r.Post("/redirection-hosts/{id}", s.updateRedirectionHost)
 			r.Post("/redirection-hosts/{id}/delete", s.deleteRedirectionHost)
 			r.Post("/redirection-hosts/{id}/toggle", s.toggleRedirectionHost)
+			r.Post("/redirection-hosts/{id}/clone", s.cloneRedirectionHost)
 
 			r.Post("/caddy/reload", s.reloadCaddy)
 			r.Post("/import", s.postImport)
@@ -491,13 +599,17 @@ func (s *Server) Routes() http.Handler {
 		// TOTP setup — available to all authenticated users.
 		r.Get("/totp/setup", s.getTOTPSetup)
 		r.Post("/totp/setup", s.postTOTPSetup)
+		r.Post("/totp/regenerate-backup-codes", s.postRegenerateBackupCodes)
 
 		// v2.7.0: visitor analytics — read-only for every signed-in
 		// user. userAllowedHosts scopes non-admins to their owned
 		// sites so the page doesn't leak traffic for hosts they
 		// don't have Edit permission on.
 		r.Get("/analytics", s.getAnalytics)
+		r.Get("/analytics/export.csv", s.exportAnalyticsCSV)
 		r.Get("/analytics/{host}", s.getAnalyticsHost)
+		r.Get("/live-traffic", s.getLiveTraffic)
+		r.Get("/api/live-traffic/stream", s.liveTrafficStream)
 
 		// Global search — read-only, available to every authenticated role.
 		r.Get("/search", s.getSearch)
@@ -507,12 +619,23 @@ func (s *Server) Routes() http.Handler {
 		r.Get("/sessions", s.getSessions)
 		r.Post("/sessions/{token}/revoke", s.revokeSession)
 
+		// API token manager — every authenticated user can create/revoke their
+		// own tokens; admins see all users' tokens.
+		r.Get("/api-tokens", s.listAPITokens)
+		r.Post("/api-tokens", s.createAPIToken)
+		r.Post("/api-tokens/{id}/revoke", s.revokeAPIToken)
+
+		// Profile page — every authenticated user can update their own name/password.
+		r.Get("/profile", s.getProfile)
+		r.Post("/profile", s.postProfile)
+
 		// User management and settings — admin-only (both read and write).
 		r.Group(func(r chi.Router) {
 			r.Use(s.requireAdmin)
 			r.Get("/users", s.listUsers)
 			r.Get("/users/new", s.newUser)
 			r.Post("/users", s.createUser)
+			r.Post("/users/invite", s.postInviteUser)
 			r.Get("/users/{id}/edit", s.editUser)
 			r.Post("/users/{id}", s.updateUser)
 			r.Post("/users/{id}/delete", s.deleteUser)
@@ -557,6 +680,62 @@ func (s *Server) Routes() http.Handler {
 	return r
 }
 
+// adminIPGate returns a middleware that enforces the admin_allowlist setting.
+// If the setting is empty, all IPs are allowed. Non-matching IPs get 403.
+func (s *Server) adminIPGate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := models.GetSetting(s.DB, settingAdminAllowlist)
+		if raw == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Parse the allowlist.
+		var allowedNets []*net.IPNet
+		var allowedIPs []net.IP
+		for _, line := range strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == '\n' }) {
+			cidr := strings.TrimSpace(line)
+			if cidr == "" {
+				continue
+			}
+			if strings.Contains(cidr, "/") {
+				_, ipnet, err := net.ParseCIDR(cidr)
+				if err == nil {
+					allowedNets = append(allowedNets, ipnet)
+				}
+			} else {
+				if ip := net.ParseIP(cidr); ip != nil {
+					allowedIPs = append(allowedIPs, ip)
+				}
+			}
+		}
+		if len(allowedNets) == 0 && len(allowedIPs) == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Extract client IP.
+		clientIP, _, _ := net.SplitHostPort(r.RemoteAddr)
+		ip := net.ParseIP(clientIP)
+		if ip == nil {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		// Check against allowlist.
+		for _, allowed := range allowedIPs {
+			if allowed.Equal(ip) {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+		for _, ipnet := range allowedNets {
+			if ipnet.Contains(ip) {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+		http.Error(w, "403 Forbidden — your IP is not on the admin allowlist", http.StatusForbidden)
+	})
+}
+
 func (s *Server) requireAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n, err := models.CountUsers(s.DB)
@@ -570,23 +749,115 @@ func (s *Server) requireAuth(next http.Handler) http.Handler {
 		}
 		cookie, err := r.Cookie(auth.SessionCookie)
 		if err != nil {
+			// No session cookie — try bearer token before redirecting.
+			if u, tokenScopes := s.bearerTokenUser(r); u != nil {
+				// Enforce read-only scope: block mutating methods.
+				if tokenScopes == models.TokenScopeReadOnly &&
+					r.Method != http.MethodGet && r.Method != http.MethodHead {
+					http.Error(w, "token scope is read-only", http.StatusForbidden)
+					return
+				}
+				ctx := context.WithValue(r.Context(), auth.ContextUserKey, u)
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
 			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return
 		}
 		u, err := auth.UserFromSession(s.DB, cookie.Value)
 		if err != nil || u == nil {
 			auth.ClearSessionCookie(w, r)
+			// Session invalid — try bearer token before redirecting.
+			if u, tokenScopes := s.bearerTokenUser(r); u != nil {
+				// Enforce read-only scope: block mutating methods.
+				if tokenScopes == models.TokenScopeReadOnly &&
+					r.Method != http.MethodGet && r.Method != http.MethodHead {
+					http.Error(w, "token scope is read-only", http.StatusForbidden)
+					return
+				}
+				ctx := context.WithValue(r.Context(), auth.ContextUserKey, u)
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
 			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return
+		}
+		// Enforce 2FA policy if enabled.
+		if !u.TOTPEnabled {
+			if v, _ := models.GetSetting(s.DB, settingRequire2FA); v == "1" {
+				// Allow the TOTP setup pages and static assets through.
+				path := r.URL.Path
+				if !strings.HasPrefix(path, "/totp/") && !strings.HasPrefix(path, "/static/") &&
+					!strings.HasPrefix(path, "/api/") && path != "/logout" {
+					http.Redirect(w, r, "/totp/setup?required=1", http.StatusSeeOther)
+					return
+				}
+			}
+		}
+		// TOTP enforcement: if the admin has enabled require_totp and this user
+		// has TOTP disabled, redirect them to TOTP setup before granting access.
+		// Skip the check for the TOTP setup page itself to avoid a redirect loop.
+		if mustGetSetting(s.DB, settingRequireTOTP) == "1" {
+			if !u.TOTPEnabled {
+				// Allow /totp/setup and /logout through so the user can complete enrollment.
+				path := r.URL.Path
+				if path != "/totp/setup" && path != "/logout" && !strings.HasPrefix(path, "/static/") {
+					http.Redirect(w, r, "/totp/setup?enforce=1", http.StatusFound)
+					return
+				}
+			}
 		}
 		ctx := context.WithValue(r.Context(), auth.ContextUserKey, u)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
+// bearerTokenUser checks for an Authorization: Bearer header and resolves
+// it to a User via the api_tokens table. Returns (nil, "") if no header is
+// present or the token is invalid/expired. Callers that already resolved a
+// session user should skip this (session wins over bearer).
+func (s *Server) bearerTokenUser(r *http.Request) (*models.User, string) {
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		return nil, ""
+	}
+	raw := strings.TrimPrefix(authHeader, "Bearer ")
+	if raw == "" {
+		return nil, ""
+	}
+	h := sha256.Sum256([]byte(raw))
+	hash := fmt.Sprintf("%x", h)
+	tok, err := models.GetAPITokenByHash(s.DB, hash)
+	if err != nil || tok == nil {
+		return nil, ""
+	}
+	if tok.Expired() {
+		return nil, ""
+	}
+	u, err := models.GetUserByID(s.DB, tok.UserID)
+	if err != nil {
+		return nil, ""
+	}
+	models.TouchAPIToken(s.DB, tok.ID)
+	return u, tok.Scopes
+}
+
 func (s *Server) currentUser(r *http.Request) *models.User {
 	u, _ := r.Context().Value(auth.ContextUserKey).(*models.User)
 	return u
+}
+
+// sessionTTL returns the configured session duration, defaulting to 7 days.
+func (s *Server) sessionTTL() time.Duration {
+	v, _ := models.GetSetting(s.DB, settingSessionDays)
+	if v == "" {
+		return 7 * 24 * time.Hour
+	}
+	days, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil || days <= 0 || days > 365 {
+		return 7 * 24 * time.Hour
+	}
+	return time.Duration(days) * 24 * time.Hour
 }
 
 func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, data map[string]any) {
@@ -595,6 +866,14 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, dat
 	}
 	// Always inject app version.
 	data["AppVersion"] = s.Version
+	// Inject site title for every page so layout.html can use it.
+	if _, ok := data["SiteTitle"]; !ok {
+		data["SiteTitle"] = mustGetSetting(s.DB, settingSiteTitle)
+	}
+	// Inject custom favicon URL for every page so layout.html can override the default icon.
+	if _, ok := data["FaviconURL"]; !ok {
+		data["FaviconURL"] = mustGetSetting(s.DB, settingFaviconURL)
+	}
 	// Auto-inject server picker data (best-effort; non-fatal if DB unavailable).
 	if _, ok := data["Servers"]; !ok {
 		if servers, err := models.ListCaddyServers(s.DB); err == nil {
@@ -668,7 +947,7 @@ func (s *Server) postSetup(w http.ResponseWriter, r *http.Request) {
 		s.render(w, r, "setup.html", map[string]any{"Error": err.Error()})
 		return
 	}
-	tok, exp, err := auth.CreateSession(s.DB, id)
+	tok, exp, err := auth.CreateSessionWithTTL(s.DB, id, s.sessionTTL())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -978,7 +1257,14 @@ func (s *Server) getLogin(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/setup", http.StatusSeeOther)
 		return
 	}
-	s.render(w, r, "login.html", captchaTemplateData(loadCaptchaConfig(s.DB)))
+	data := captchaTemplateData(loadCaptchaConfig(s.DB))
+	if r.URL.Query().Get("reset") == "1" {
+		data["Reset"] = true
+	}
+	if r.URL.Query().Get("invited") == "1" {
+		data["Invited"] = true
+	}
+	s.render(w, r, "login.html", data)
 }
 
 func (s *Server) postLogin(w http.ResponseWriter, r *http.Request) {
@@ -1001,10 +1287,27 @@ func (s *Server) postLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// v2.9.5: brute-force protection — check recent failed login attempts from this IP.
+	clientIP, _, _ := net.SplitHostPort(r.RemoteAddr)
+	if maxStr, _ := models.GetSetting(s.DB, settingMaxLoginAttempts); maxStr != "" {
+		if maxAttempts, err := strconv.Atoi(strings.TrimSpace(maxStr)); err == nil && maxAttempts > 0 {
+			var failCount int
+			_ = s.DB.QueryRow(
+				`SELECT COUNT(*) FROM activity_log WHERE action = 'login_fail' AND detail LIKE ? AND created_at > datetime('now', '-15 minutes')`,
+				"%ip:"+clientIP+"%",
+			).Scan(&failCount)
+			if failCount >= maxAttempts {
+				renderLoginErr("Too many failed login attempts. Please wait 15 minutes and try again.")
+				return
+			}
+		}
+	}
+
 	email := strings.TrimSpace(r.FormValue("email"))
 	pw := r.FormValue("password")
 	u, err := models.GetUserByEmail(s.DB, email)
 	if err != nil || !auth.CheckPassword(u.PasswordHash, pw) {
+		_ = models.LogActivity(s.DB, 0, email, "login_fail", "ip:"+clientIP, "invalid credentials", false)
 		renderLoginErr("Invalid email or password")
 		return
 	}
@@ -1022,7 +1325,7 @@ func (s *Server) postLogin(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/login/totp?t="+tok, http.StatusSeeOther)
 		return
 	}
-	tok, exp, err := auth.CreateSession(s.DB, u.ID)
+	tok, exp, err := auth.CreateSessionWithTTL(s.DB, u.ID, s.sessionTTL())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1097,15 +1400,23 @@ func (s *Server) postTOTPVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	valid := totplib.Validate(code, u.TOTPSecret)
-	if !valid {
+	validTOTP := totplib.Validate(code, u.TOTPSecret)
+	if !validTOTP {
+		// Try as a single-use backup code.
+		if u2, _ := models.GetUserByID(s.DB, userID); u2 != nil {
+			if ok, _ := models.ConsumeBackupCode(s.DB, userID, u2.BackupCodes, code); ok {
+				validTOTP = true
+			}
+		}
+	}
+	if !validTOTP {
 		// Put token back so user can retry.
 		s.pendingTOTP.Store(tok, userID)
 		renderTOTPErr("Invalid code. Try again.")
 		return
 	}
 
-	sessionTok, exp, err := auth.CreateSession(s.DB, userID)
+	sessionTok, exp, err := auth.CreateSessionWithTTL(s.DB, userID, s.sessionTTL())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1125,11 +1436,31 @@ func (s *Server) getTOTPSetup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// Backup codes passed as a one-time query param after enabling/regenerating.
+	backupCodes := strings.Split(r.URL.Query().Get("backup_codes"), ",")
+	if len(backupCodes) == 1 && backupCodes[0] == "" {
+		backupCodes = nil
+	}
+
+	// Count remaining backup codes stored for this user.
+	var backupCodeCount int
+	if cu := s.currentUser(r); cu != nil && cu.BackupCodes != "" {
+		var hashes []string
+		if json.Unmarshal([]byte(cu.BackupCodes), &hashes) == nil {
+			backupCodeCount = len(hashes)
+		}
+	}
+
 	s.render(w, r, "totp_setup.html", map[string]any{
-		"User":        u,
-		"Secret":      key.Secret(),
-		"OTPAuth":     key.URL(),
-		"TOTPEnabled": u.TOTPEnabled,
+		"User":            u,
+		"Secret":          key.Secret(),
+		"OTPAuth":         key.URL(),
+		"TOTPEnabled":     u.TOTPEnabled,
+		"Required":        r.URL.Query().Get("required") == "1",
+		"Enforce":         r.URL.Query().Get("enforce") == "1",
+		"BackupCodes":     backupCodes,
+		"BackupCodeCount": backupCodeCount,
 	})
 }
 
@@ -1165,7 +1496,36 @@ func (s *Server) postTOTPSetup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// Generate fresh backup codes when TOTP is first enabled.
+	if backupCodes, err := models.GenerateBackupCodes(10); err == nil {
+		if err := models.SaveBackupCodes(s.DB, u.ID, backupCodes); err == nil {
+			// Store codes in session flash or query param for one-time display.
+			// Encode as comma-separated for URL safety.
+			codesParam := strings.Join(backupCodes, ",")
+			http.Redirect(w, r, "/totp/setup?enabled=1&backup_codes="+url.QueryEscape(codesParam), http.StatusSeeOther)
+			return
+		}
+	}
 	http.Redirect(w, r, "/totp/setup?enabled=1", http.StatusSeeOther)
+}
+
+func (s *Server) postRegenerateBackupCodes(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil || !cu.TOTPEnabled {
+		http.Redirect(w, r, "/totp/setup", http.StatusSeeOther)
+		return
+	}
+	codes, err := models.GenerateBackupCodes(10)
+	if err != nil {
+		http.Error(w, "failed to generate codes", http.StatusInternalServerError)
+		return
+	}
+	if err := models.SaveBackupCodes(s.DB, cu.ID, codes); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	codesParam := strings.Join(codes, ",")
+	http.Redirect(w, r, "/totp/setup?regen=1&backup_codes="+url.QueryEscape(codesParam), http.StatusSeeOther)
 }
 
 // --- Dashboard ---
@@ -1213,18 +1573,71 @@ func (s *Server) dashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// v2.9.2: health summary — count hosts by latest check result.
+	var healthyCount, downCount, unknownCount int
+	if len(hosts) > 0 {
+		var hostIDs []int64
+		for _, h := range hosts {
+			hostIDs = append(hostIDs, h.ID)
+		}
+		healthMap, _ := models.LatestProxyHealth(s.DB, hostIDs)
+		for _, h := range hosts {
+			if !h.Enabled {
+				continue // only count enabled hosts
+			}
+			if chk, ok := healthMap[h.ID]; ok {
+				if chk.OK {
+					healthyCount++
+				} else {
+					downCount++
+				}
+			} else {
+				unknownCount++
+			}
+		}
+	}
+
+	// Today's analytics stats (best-effort — zero-values if analytics is not yet enabled).
+	todayStart := time.Now().UTC().Truncate(24 * time.Hour)
+	todayViews, todayVisitors := 0, 0
+	var todayBandwidth int64
+	if totals, err := models.AccessTotalsSince(s.DB, todayStart, ""); err == nil {
+		todayViews = totals.Views
+		todayVisitors = totals.Visitors
+	}
+	todayBandwidth, _ = models.BandwidthSince(s.DB, todayStart, "")
+
+	// Count hosts in maintenance mode for the dashboard banner.
+	maintenanceCount := 0
+	for _, h := range hosts {
+		if h.MaintenanceMode {
+			maintenanceCount++
+		}
+	}
+	globalMaintenance, _ := models.GetSetting(s.DB, settingGlobalMaintenance)
+
 	s.render(w, r, "dashboard.html", map[string]any{
-		"User":             s.currentUser(r),
-		"ProxyHosts":       hosts,
-		"RedirectionHosts": redirs,
-		"RawRoutes":        raws,
-		"RawCount":         len(raws),
-		"CertCount":        len(certs),
-		"LastSync":         lastSync,
-		"EnabledHosts":     enabledHosts,
-		"DisabledHosts":    disabledHosts,
-		"ExpiringSoon":     expiringSoon,
-		"Section":          "dashboard",
+		"User":                 s.currentUser(r),
+		"ProxyHosts":           hosts,
+		"RedirectionHosts":     redirs,
+		"RawRoutes":            raws,
+		"RawCount":             len(raws),
+		"CertCount":            len(certs),
+		"LastSync":             lastSync,
+		"EnabledHosts":         enabledHosts,
+		"DisabledHosts":        disabledHosts,
+		"ExpiringSoon":         expiringSoon,
+		"HealthyCount":         healthyCount,
+		"DownCount":            downCount,
+		"UnknownCount":         unknownCount,
+		"TodayViews":           todayViews,
+		"TodayVisitors":        todayVisitors,
+		"TodayBandwidth":       todayBandwidth,
+		"MaintenanceCount":     maintenanceCount,
+		"GlobalMaintenance":    globalMaintenance,
+		"EnabledHostCount":     enabledHosts,
+		"MaintenanceHostCount": maintenanceCount,
+		"Section":              "dashboard",
 	})
 }
 
@@ -1297,6 +1710,81 @@ func (s *Server) listProxyHosts(w http.ResponseWriter, r *http.Request) {
 			OwnerEmail: rr.OwnerEmail, CanEdit: canEdit, IsTeamRow: isTeam,
 		})
 	}
+	// Tag filtering: ?tag=production narrows the list to hosts bearing that tag.
+	activeTag := strings.TrimSpace(r.URL.Query().Get("tag"))
+	if activeTag != "" {
+		filtered := hosts[:0]
+		for _, h := range hosts {
+			for _, t := range h.TagList() {
+				if strings.EqualFold(t, activeTag) {
+					filtered = append(filtered, h)
+					break
+				}
+			}
+		}
+		hosts = filtered
+	}
+
+	// Status filter: ?status=enabled|disabled|maintenance|all
+	statusFilter := strings.TrimSpace(r.URL.Query().Get("status"))
+	if statusFilter != "" && statusFilter != "all" {
+		filtered := hosts[:0]
+		for _, h := range hosts {
+			switch statusFilter {
+			case "enabled":
+				if h.Enabled && !h.MaintenanceMode {
+					filtered = append(filtered, h)
+				}
+			case "disabled":
+				if !h.Enabled {
+					filtered = append(filtered, h)
+				}
+			case "maintenance":
+				if h.MaintenanceMode {
+					filtered = append(filtered, h)
+				}
+			}
+		}
+		hosts = filtered
+	}
+
+	// Load latest health check for each host.
+	hostIDs := make([]int64, len(hosts))
+	for i, p := range hosts {
+		hostIDs[i] = p.ID
+	}
+	healthMap, _ := models.LatestProxyHealth(s.DB, hostIDs)
+
+	// Per-host today request counts (best-effort — zero if analytics disabled).
+	hostRequestsToday := make(map[int64]int)
+	if domainCounts, err := models.DomainRequestsToday(s.DB); err == nil {
+		for _, h := range hosts {
+			total := 0
+			for _, d := range h.DomainList() {
+				total += domainCounts[strings.ToLower(d)]
+			}
+			if total > 0 {
+				hostRequestsToday[h.ID] = total
+			}
+		}
+	}
+
+	// Build a set of host IDs that have been modified since the last sync.
+	// This lets the template show a warning badge on stale hosts.
+	var lastSyncTime time.Time
+	_ = s.DB.QueryRow(
+		`SELECT created_at FROM activity_log WHERE server_id = ? AND action = 'sync_applied' ORDER BY id DESC LIMIT 1`,
+		s.currentServerID(r),
+	).Scan(&lastSyncTime)
+	needsSync := make(map[int64]bool)
+	if !lastSyncTime.IsZero() {
+		for _, h := range hosts {
+			if h.UpdatedAt.After(lastSyncTime) {
+				needsSync[h.ID] = true
+			}
+		}
+	}
+
 	s.render(w, r, "proxy_hosts.html", map[string]any{
 		"User":         s.currentUser(r),
 		"Hosts":        hosts,
@@ -1306,7 +1794,55 @@ func (s *Server) listProxyHosts(w http.ResponseWriter, r *http.Request) {
 		// the user is only seeing via group peer-ship, and render a
 		// "Team: <email>" chip instead. Security still enforced in the
 		// update/delete handlers — this is UX clarity, not a gate.
-		"ViewerID": viewerID,
+		"ViewerID":          viewerID,
+		"HealthMap":         healthMap,
+		"ActiveTag":         activeTag,
+		"StatusFilter":      statusFilter,
+		"NeedsSync":         needsSync,
+		"HostRequestsToday": hostRequestsToday,
+	})
+}
+
+// getProxyHostHealth renders the per-host health history page (/proxy-hosts/{id}/health).
+func (s *Server) getProxyHostHealth(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	host, err := models.GetProxyHost(s.DB, id)
+	if err != nil || host == nil {
+		http.NotFound(w, r)
+		return
+	}
+	checks, err := models.GetProxyHealthHistory(s.DB, id, 50)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Calculate uptime % for last 24 h: (ok checks / total checks) * 100.
+	var total, okCount int
+	cutoff := time.Now().Add(-24 * time.Hour)
+	for _, c := range checks {
+		if c.CheckedAt.After(cutoff) {
+			total++
+			if c.OK {
+				okCount++
+			}
+		}
+	}
+	var uptime float64
+	if total > 0 {
+		uptime = float64(okCount) / float64(total) * 100
+	}
+	s.render(w, r, "proxy_host_health.html", map[string]any{
+		"User":    s.currentUser(r),
+		"Host":    host,
+		"Checks":  checks,
+		"Uptime":  uptime,
+		"Total":   total,
+		"Section": "proxy",
 	})
 }
 
@@ -1375,6 +1911,177 @@ func (s *Server) toggleProxyHost(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r), action, fmt.Sprintf("proxy:%d", id), "", true)
 	s.syncCaddy(s.currentServerID(r), false)
+	ref := r.Header.Get("Referer")
+	if ref == "" {
+		ref = "/proxy-hosts"
+	}
+	http.Redirect(w, r, ref, http.StatusSeeOther)
+}
+
+// bulkToggleProxyHosts enables or disables a set of proxy hosts in one shot.
+// Expects form fields: ids[]={id,...} and action=enable|disable.
+// Admin/write users only (the route is inside the requireWrite middleware block).
+func (s *Server) bulkToggleProxyHosts(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad form", http.StatusBadRequest)
+		return
+	}
+	action := r.FormValue("action") // "enable" or "disable"
+	if action != "enable" && action != "disable" {
+		http.Error(w, "invalid action", http.StatusBadRequest)
+		return
+	}
+	enabled := action == "enable"
+
+	rawIDs := r.Form["ids[]"]
+	if len(rawIDs) == 0 {
+		http.Redirect(w, r, "/proxy-hosts", http.StatusSeeOther)
+		return
+	}
+
+	var serverID int64
+	for _, raw := range rawIDs {
+		id, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+		if err != nil {
+			continue
+		}
+		ph, err := models.GetProxyHost(s.DB, id)
+		if err != nil || ph == nil {
+			continue
+		}
+		if ph.Enabled != enabled {
+			ph.Enabled = enabled
+			if err := models.UpdateProxyHost(s.DB, ph); err != nil {
+				log.Printf("bulkToggle: update %d: %v", id, err)
+				continue
+			}
+			if serverID == 0 {
+				serverID = ph.ServerID
+			}
+		}
+	}
+	if serverID != 0 {
+		if err := s.syncCaddy(serverID, false); err != nil {
+			log.Printf("bulkToggle: syncCaddy(%d): %v", serverID, err)
+		}
+	}
+	http.Redirect(w, r, "/proxy-hosts", http.StatusSeeOther)
+}
+
+// bulkMaintenanceProxyHosts enables or disables maintenance mode for a set of
+// proxy hosts. Expects form fields: ids[]={id,...} and action=enable|disable.
+func (s *Server) bulkMaintenanceProxyHosts(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad form", http.StatusBadRequest)
+		return
+	}
+	action := r.FormValue("action")
+	if action != "enable" && action != "disable" {
+		http.Error(w, "invalid action", http.StatusBadRequest)
+		return
+	}
+	maint := action == "enable"
+
+	rawIDs := r.Form["ids[]"]
+	if len(rawIDs) == 0 {
+		http.Redirect(w, r, "/proxy-hosts", http.StatusSeeOther)
+		return
+	}
+
+	var serverID int64
+	for _, raw := range rawIDs {
+		id, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+		if err != nil {
+			continue
+		}
+		ph, err := models.GetProxyHost(s.DB, id)
+		if err != nil || ph == nil {
+			continue
+		}
+		if ph.MaintenanceMode != maint {
+			ph.MaintenanceMode = maint
+			if err := models.UpdateProxyHost(s.DB, ph); err != nil {
+				log.Printf("bulkMaintenance: update %d: %v", id, err)
+				continue
+			}
+			if serverID == 0 {
+				serverID = ph.ServerID
+			}
+		}
+	}
+	if serverID != 0 {
+		if err := s.syncCaddy(serverID, false); err != nil {
+			log.Printf("bulkMaintenance: syncCaddy(%d): %v", serverID, err)
+		}
+	}
+	http.Redirect(w, r, "/proxy-hosts", http.StatusSeeOther)
+}
+
+// bulkDeleteProxyHosts deletes a set of proxy hosts in one shot.
+// Expects form field: ids[]={id,...}.
+// Admin can delete any host; non-admins can only delete their own.
+func (s *Server) bulkDeleteProxyHosts(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	isAdmin := cu.Role == models.RoleAdmin
+	_ = r.ParseForm()
+	ids := r.Form["ids[]"]
+	if len(ids) == 0 {
+		http.Redirect(w, r, "/proxy-hosts", http.StatusSeeOther)
+		return
+	}
+	sid := s.currentServerID(r)
+	deleted := 0
+	for _, raw := range ids {
+		id, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			continue
+		}
+		// Ownership check: admin can delete any, others only their own.
+		if !isAdmin {
+			ph, err := models.GetProxyHost(s.DB, id)
+			if err != nil || ph == nil || !ph.OwnerID.Valid || ph.OwnerID.Int64 != cu.ID {
+				continue
+			}
+		}
+		if err := models.DeleteProxyHost(s.DB, id); err != nil {
+			log.Printf("bulk-delete proxy host %d: %v", id, err)
+			continue
+		}
+		deleted++
+		_ = models.LogActivity(s.DB, sid, cu.Email, "proxy_host_delete", "id", strconv.FormatInt(id, 10), true)
+	}
+	if deleted > 0 {
+		if err := s.syncCaddy(sid, false); err != nil {
+			log.Printf("bulk-delete: sync error: %v", err)
+		}
+	}
+	http.Redirect(w, r, "/proxy-hosts", http.StatusSeeOther)
+}
+
+// toggleMaintenanceMode flips the maintenance_mode flag for a proxy host.
+func (s *Server) toggleMaintenanceMode(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	ph, err := models.GetProxyHost(s.DB, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	ph.MaintenanceMode = !ph.MaintenanceMode
+	if err := models.UpdateProxyHost(s.DB, ph); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := s.syncCaddy(ph.ServerID, false); err != nil {
+		log.Printf("toggleMaintenanceMode: syncCaddy: %v", err)
+	}
 	ref := r.Header.Get("Referer")
 	if ref == "" {
 		ref = "/proxy-hosts"
@@ -1458,7 +2165,8 @@ func parseBasicAuthUsers(r *http.Request) ([]models.BasicAuthUser, error) {
 // buildBasicAuthHandler adapts a Caddyfile basicauth block for the given users
 // via Caddy's /adapt endpoint and returns the authentication JSON handler.
 // Returns nil if the user list is empty or if adaptation fails (error is logged).
-func (s *Server) buildBasicAuthHandler(caddyCl *caddy.Client, users []models.BasicAuthUser) map[string]any {
+// realm is the HTTP Basic Auth realm string shown in the browser prompt.
+func (s *Server) buildBasicAuthHandler(caddyCl *caddy.Client, users []models.BasicAuthUser, realm string) map[string]any {
 	if len(users) == 0 {
 		return nil
 	}
@@ -1481,6 +2189,14 @@ func (s *Server) buildBasicAuthHandler(caddyCl *caddy.Client, users []models.Bas
 	handles, _ := routes[0]["handle"].([]any)
 	for _, h := range handles {
 		if m, ok := h.(map[string]any); ok && m["handler"] == "authentication" {
+			if realm != "" && realm != "Restricted" {
+				// Inject the custom realm into the http_basic provider map.
+				if providers, ok := m["providers"].(map[string]any); ok {
+					if httpBasic, ok := providers["http_basic"].(map[string]any); ok {
+						httpBasic["realm"] = realm
+					}
+				}
+			}
 			return m
 		}
 	}
@@ -1701,7 +2417,103 @@ func parseProxyHostForm(r *http.Request) (*models.ProxyHost, error) {
 	default:
 		tlsMinVersion = ""
 	}
-	return &models.ProxyHost{
+	// Parse custom request headers: parallel arrays header_req_key[] + header_req_val[]
+	reqKeys := r.Form["header_req_key"]
+	reqVals := r.Form["header_req_val"]
+	reqMap := map[string]string{}
+	for i, k := range reqKeys {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		v := ""
+		if i < len(reqVals) {
+			v = strings.TrimSpace(reqVals[i])
+		}
+		reqMap[k] = v
+	}
+	customReqHeaders := "{}"
+	if len(reqMap) > 0 {
+		if b, err := json.Marshal(reqMap); err == nil {
+			customReqHeaders = string(b)
+		}
+	}
+
+	// Parse custom response headers: parallel arrays header_resp_key[] + header_resp_val[]
+	respKeys := r.Form["header_resp_key"]
+	respVals := r.Form["header_resp_val"]
+	respMap := map[string]string{}
+	for i, k := range respKeys {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		v := ""
+		if i < len(respVals) {
+			v = strings.TrimSpace(respVals[i])
+		}
+		respMap[k] = v
+	}
+	customRespHeaders := "{}"
+	if len(respMap) > 0 {
+		if b, err := json.Marshal(respMap); err == nil {
+			customRespHeaders = string(b)
+		}
+	}
+	// v2.9.2: URL rewrite rules — submitted as parallel arrays:
+	// rewrite_type[], rewrite_from[], rewrite_to[]
+	rewriteTypes := r.Form["rewrite_type[]"]
+	rewriteFroms := r.Form["rewrite_from[]"]
+	rewriteTos   := r.Form["rewrite_to[]"]
+	var urlRewrites string
+	{
+		type rule struct {
+			Type string `json:"type"`
+			From string `json:"from"`
+			To   string `json:"to"`
+		}
+		var rules []rule
+		for i := range rewriteTypes {
+			from := ""
+			to := ""
+			if i < len(rewriteFroms) { from = strings.TrimSpace(rewriteFroms[i]) }
+			if i < len(rewriteTos) { to = strings.TrimSpace(rewriteTos[i]) }
+			t := strings.TrimSpace(rewriteTypes[i])
+			if t == "" || from == "" { continue }
+			rules = append(rules, rule{Type: t, From: from, To: to})
+		}
+		if len(rules) == 0 {
+			urlRewrites = "[]"
+		} else {
+			b, _ := json.Marshal(rules)
+			urlRewrites = string(b)
+		}
+	}
+	var maxBodyMB int
+	if v := strings.TrimSpace(r.FormValue("max_request_body_mb")); v != "" && v != "0" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			maxBodyMB = n
+		}
+	}
+	var upstreamTimeoutSec int
+	if v := strings.TrimSpace(r.FormValue("upstream_timeout_sec")); v != "" && v != "0" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			upstreamTimeoutSec = n
+		}
+	}
+	var healthCheckIntervalSec int = 30
+	if v := strings.TrimSpace(r.FormValue("health_check_interval_sec")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			healthCheckIntervalSec = n
+		}
+	}
+	var keepaliveConns int
+	if v := strings.TrimSpace(r.FormValue("keepalive_conns")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			keepaliveConns = n
+		}
+	}
+	ph := &models.ProxyHost{
 		Domains:                strings.TrimSpace(r.FormValue("domains")),
 		ForwardScheme:          r.FormValue("forward_scheme"),
 		ForwardHost:            strings.TrimSpace(r.FormValue("forward_host")),
@@ -1720,8 +2532,386 @@ func parseProxyHostForm(r *http.Request) (*models.ProxyHost, error) {
 		DNSZoneName:            zoneName,
 		CompressionEnabled:     r.FormValue("compression_enabled") == "on",
 		SecurityHeadersEnabled: r.FormValue("security_headers_enabled") == "on",
+		MaintenanceMode:        r.FormValue("maintenance_mode") == "on",
+		MaintenanceMsg:         strings.TrimSpace(r.FormValue("maintenance_msg")),
+		MaintenanceStatusCode: func() int {
+			if sc, err := strconv.Atoi(r.FormValue("maintenance_status_code")); err == nil && sc > 0 {
+				return sc
+			}
+			return 503
+		}(),
+		StickySessions:         r.FormValue("sticky_sessions") == "on",
 		TLSMinVersion:          tlsMinVersion,
-	}, nil
+		CustomReqHeaders:       customReqHeaders,
+		CustomRespHeaders:      customRespHeaders,
+		URLRewrites:            urlRewrites,
+		MaxRequestBodyMB:       maxBodyMB,
+		UpstreamTimeoutSec:     upstreamTimeoutSec,
+		CORSEnabled:            r.FormValue("cors_enabled") == "on",
+		CORSOrigins:            strings.TrimSpace(r.FormValue("cors_origins")),
+		HealthCheckURI:         strings.TrimSpace(r.FormValue("health_check_uri")),
+		HealthCheckIntervalSec: healthCheckIntervalSec,
+		HealthCheckMethod: func() string {
+			m := r.FormValue("health_check_method")
+			if m == "" {
+				return "GET"
+			}
+			return m
+		}(),
+		KeepaliveConns:         keepaliveConns,
+		Tags:                   strings.TrimSpace(r.FormValue("tags")),
+		Notes:                  r.FormValue("notes"),
+		DisableAccessLog:       r.FormValue("disable_access_log") == "on",
+		AddRequestID:           r.FormValue("add_request_id") == "on",
+		StripRespHeaders:       strings.TrimSpace(r.FormValue("strip_resp_headers")),
+		BlockedAgents:          strings.TrimSpace(r.FormValue("blocked_agents")),
+		ResponseCacheControl:   strings.TrimSpace(r.FormValue("response_cache_control")),
+		UpstreamSNI:            strings.TrimSpace(r.FormValue("upstream_sni")),
+		HSTSPreload:            r.FormValue("hsts_preload") == "on",
+		MaxConnsPerHost: func() int {
+			n, _ := strconv.Atoi(r.FormValue("max_conns_per_host"))
+			return n
+		}(),
+	}
+	hcTimeout, _ := strconv.Atoi(r.FormValue("health_check_timeout_sec"))
+	ph.HealthCheckTimeoutSec = hcTimeout
+	retries, _ := strconv.Atoi(r.FormValue("upstream_retries"))
+	ph.UpstreamRetries = retries
+	ph.ForceHTTP1 = r.FormValue("force_http1") == "on"
+	ph.BasicAuthRealm = strings.TrimSpace(r.FormValue("basicauth_realm"))
+	if ph.BasicAuthRealm == "" {
+		ph.BasicAuthRealm = "Restricted"
+	}
+	ph.ErrorPageHTML = r.FormValue("error_page_html")
+	ph.MaintenanceWindowStart = strings.TrimSpace(r.FormValue("maintenance_window_start"))
+	ph.MaintenanceWindowEnd = strings.TrimSpace(r.FormValue("maintenance_window_end"))
+	ph.MaintenanceWindowDays = strings.Join(r.Form["maintenance_window_days"], ",")
+	ph.IPBlocklist = strings.TrimSpace(r.FormValue("ip_blocklist"))
+	ph.LBPolicy = r.FormValue("lb_policy")
+	ph.ProxyProtocol = r.FormValue("proxy_protocol")
+	ph.RobotsTxt = r.FormValue("robots_txt")
+	ph.PassiveFailDurationSec, _ = strconv.Atoi(r.FormValue("passive_fail_duration_sec"))
+	ph.PassiveMaxFails, _ = strconv.Atoi(r.FormValue("passive_max_fails"))
+	ph.HSTSMaxAgeSec, _ = strconv.Atoi(r.FormValue("hsts_max_age_sec"))
+	ph.CSPHeader = strings.TrimSpace(r.FormValue("csp_header"))
+	ph.H2CEnabled = r.FormValue("h2c_enabled") == "on"
+	if hch := strings.TrimSpace(r.FormValue("health_check_headers")); hch != "" {
+		ph.HealthCheckHeaders = hch
+	} else {
+		ph.HealthCheckHeaders = "{}"
+	}
+	ph.FlushImmediate = r.FormValue("flush_immediate") == "on"
+	ph.BufferResponses = r.FormValue("buffer_responses") == "on"
+	ph.TrustedProxies = strings.TrimSpace(r.FormValue("trusted_proxies"))
+	ph.UpstreamHostOverride = strings.TrimSpace(r.FormValue("upstream_host_override"))
+	ph.ReadTimeoutSec, _ = strconv.Atoi(r.FormValue("read_timeout_sec"))
+	ph.DenyDotfiles = r.FormValue("deny_dotfiles") == "on"
+	ph.RequestBuffersKB, _ = strconv.Atoi(r.FormValue("request_buffers_kb"))
+	ph.CORSAllowCredentials = r.FormValue("cors_allow_credentials") == "on"
+	ph.CORSExposeHeaders = strings.TrimSpace(r.FormValue("cors_expose_headers"))
+	ph.SSLVerifyUpstream = r.FormValue("ssl_verify_upstream") == "on"
+	ph.DialTimeoutSec, _ = strconv.Atoi(r.FormValue("dial_timeout_sec"))
+	ph.APIKeyHeader = strings.TrimSpace(r.FormValue("api_key_header"))
+	ph.APIKeyValue = strings.TrimSpace(r.FormValue("api_key_value"))
+	ph.BlockEmptyUserAgent = r.FormValue("block_empty_user_agent") == "on"
+	ph.ErrorRedirectURL = strings.TrimSpace(r.FormValue("error_redirect_url"))
+	ph.PermissionsPolicy = strings.TrimSpace(r.FormValue("permissions_policy"))
+	ph.XFrameOptions = strings.TrimSpace(r.FormValue("x_frame_options"))
+	ph.ReferrerPolicy = strings.TrimSpace(r.FormValue("referrer_policy"))
+	ph.HSTSIncludeSubdomains = r.FormValue("hsts_include_subdomains") == "on"
+	ph.CSPReportOnly = strings.TrimSpace(r.FormValue("csp_report_only"))
+	ph.KeepaliveIdleTimeoutSec, _ = strconv.Atoi(r.FormValue("keepalive_idle_timeout_sec"))
+	ph.HealthCheckExpectStatus, _ = strconv.Atoi(r.FormValue("health_check_expect_status"))
+	ph.HealthCheckExpectBody = strings.TrimSpace(r.FormValue("health_check_expect_body"))
+	ph.HealthCheckFollowRedirects = r.FormValue("health_check_follow_redirects") == "on"
+	ph.PathMatcher = strings.TrimSpace(r.FormValue("path_matcher"))
+	ph.StripPathPrefix = r.FormValue("strip_path_prefix") == "on"
+	ph.StickyCookieName = strings.TrimSpace(r.FormValue("sticky_cookie_name"))
+	ph.LBTryDurationSec, _ = strconv.Atoi(r.FormValue("lb_try_duration_sec"))
+	ph.LBTryIntervalMS, _ = strconv.Atoi(r.FormValue("lb_try_interval_ms"))
+	ph.CompressionMinSizeKB, _ = strconv.Atoi(r.FormValue("compression_min_size_kb"))
+	ph.ForwardClientIP = r.FormValue("forward_client_ip") == "on"
+	ph.CORSMaxAgeSec, _ = strconv.Atoi(r.FormValue("cors_max_age_sec"))
+	ph.CORSAllowMethods = strings.TrimSpace(r.FormValue("cors_allow_methods"))
+	ph.CORSAllowHeaders = strings.TrimSpace(r.FormValue("cors_allow_headers"))
+	ph.RetryStatusCodes = strings.TrimSpace(r.FormValue("retry_status_codes"))
+	ph.WriteTimeoutSec, _ = strconv.Atoi(r.FormValue("write_timeout_sec"))
+	ph.UpstreamTLSMinVersion = r.FormValue("upstream_tls_min_version")
+	ph.ForwardProxyURL = strings.TrimSpace(r.FormValue("forward_proxy_url"))
+	ph.BlockedMethods = strings.TrimSpace(r.FormValue("blocked_methods"))
+	ph.ForwardAuthURL = strings.TrimSpace(r.FormValue("forward_auth_url"))
+	ph.ForwardAuthCopyHeaders = strings.TrimSpace(r.FormValue("forward_auth_copy_headers"))
+	ph.StripQueryString = r.FormValue("strip_query_string") == "on"
+	ph.DeleteQueryParams = strings.TrimSpace(r.FormValue("delete_query_params"))
+	ph.RequestBodyReadTimeoutSec, _ = strconv.Atoi(r.FormValue("request_body_read_timeout_sec"))
+	ph.ResponseHeaderTimeoutSec, _ = strconv.Atoi(r.FormValue("response_header_timeout_sec"))
+	ph.MaxConnDurationSec, _ = strconv.Atoi(r.FormValue("max_conn_duration_sec"))
+	ph.DecompressResponse = r.FormValue("decompress_response") == "on"
+	ph.Color = strings.TrimSpace(r.FormValue("color"))
+	ph.WWWRedirect = r.FormValue("www_redirect") // "" | "to_www" | "to_bare"
+	ph.StripReqHeaders = strings.TrimSpace(r.FormValue("strip_req_headers"))
+	ph.UpstreamPathPrefix = strings.TrimSpace(r.FormValue("upstream_path_prefix"))
+	ph.CompressionLevel, _ = strconv.Atoi(r.FormValue("compression_level"))
+	ph.CompressionPreferGzip = r.FormValue("compression_prefer_gzip") == "on"
+	ph.SortOrder, _ = strconv.Atoi(r.FormValue("sort_order"))
+	ph.AllowedMethods = strings.TrimSpace(r.FormValue("allowed_methods"))
+	ph.UpstreamMaxRespHeaderKB, _ = strconv.Atoi(r.FormValue("upstream_max_resp_header_kb"))
+	ph.HealthCheckPort, _ = strconv.Atoi(r.FormValue("health_check_port"))
+	ph.RequestIDHeaderName = strings.TrimSpace(r.FormValue("request_id_header_name"))
+	ph.LBCookiePath = strings.TrimSpace(r.FormValue("lb_cookie_path"))
+	ph.PassiveUnhealthyLatencyMS, _ = strconv.Atoi(r.FormValue("passive_unhealthy_latency_ms"))
+	ph.TLSHandshakeTimeoutSec, _ = strconv.Atoi(r.FormValue("tls_handshake_timeout_sec"))
+	ph.ExpectContinueTimeoutSec, _ = strconv.Atoi(r.FormValue("expect_continue_timeout_sec"))
+	ph.ResponseBuffersKB, _ = strconv.Atoi(r.FormValue("response_buffers_kb"))
+	ph.UpstreamMaxIdleConns, _ = strconv.Atoi(r.FormValue("upstream_max_idle_conns"))
+	ph.UpstreamKeepAliveProbeIntervalSec, _ = strconv.Atoi(r.FormValue("upstream_keep_alive_probe_sec"))
+	ph.ForwardAuthMethod = strings.TrimSpace(r.FormValue("forward_auth_method"))
+	ph.GRPCWebEnabled = r.FormValue("grpc_web_enabled") == "on"
+	ph.ForwardAuthHeadersPrefix = strings.TrimSpace(r.FormValue("forward_auth_headers_prefix"))
+	ph.HealthCheckMaxSizeKB, _ = strconv.Atoi(r.FormValue("health_check_max_size_kb"))
+	ph.StripPathSuffix = strings.TrimSpace(r.FormValue("strip_path_suffix"))
+	ph.AddReqQueryParams = strings.TrimSpace(r.FormValue("add_req_query_params"))
+	ph.ErrorPageCodes = strings.TrimSpace(r.FormValue("error_page_codes"))
+	ph.UpstreamTLSCAPEMFile = strings.TrimSpace(r.FormValue("upstream_tls_ca_pem_file"))
+	ph.KeepaliveDisabled = r.FormValue("keepalive_disabled") == "on"
+	ph.TrailingSlashRedirect = r.FormValue("trailing_slash_redirect")
+	ph.DialFallbackDelayMS, _ = strconv.Atoi(r.FormValue("dial_fallback_delay_ms"))
+	ph.UpstreamNetwork = strings.TrimSpace(r.FormValue("upstream_network"))
+	ph.DNSResolver = strings.TrimSpace(r.FormValue("dns_resolver"))
+	ph.PathMatcherType = r.FormValue("path_matcher_type")
+	ph.CORSAllowPrivateNetwork = r.FormValue("cors_allow_private_network") == "on"
+	ph.RobotsTxtDisallowAll = r.FormValue("robots_txt_disallow_all") == "on"
+	ph.MaintenanceRetryAfterSec, _ = strconv.Atoi(r.FormValue("maintenance_retry_after_sec"))
+	ph.UpstreamResolveTimeoutSec, _ = strconv.Atoi(r.FormValue("upstream_resolve_timeout_sec"))
+	ph.UpstreamReadBufferSizeKB, _ = strconv.Atoi(r.FormValue("upstream_read_buffer_size_kb"))
+	ph.UpstreamWriteBufferSizeKB, _ = strconv.Atoi(r.FormValue("upstream_write_buffer_size_kb"))
+	ph.ReqHeaderReplace = strings.TrimSpace(r.FormValue("req_header_replace"))
+	ph.RespHeaderReplace = strings.TrimSpace(r.FormValue("resp_header_replace"))
+	ph.UpstreamHTTPVersions = strings.TrimSpace(r.FormValue("upstream_http_versions"))
+	ph.HealthCheckBody = strings.TrimSpace(r.FormValue("health_check_body"))
+	ph.AddCanonicalLinkHeader = r.FormValue("add_canonical_link_header") == "on"
+	ph.HTTPBasicAuthUpstream = strings.TrimSpace(r.FormValue("http_basic_auth_upstream"))
+	ph.BlockUARegexp = strings.TrimSpace(r.FormValue("block_ua_regexp"))
+	ph.SecurityTxtBody = strings.TrimSpace(r.FormValue("security_txt_body"))
+	ph.ServerHeaderValue = strings.TrimSpace(r.FormValue("server_header_value"))
+	ph.XRobotsTag = strings.TrimSpace(r.FormValue("x_robots_tag"))
+	ph.AddForwardedHeader = r.FormValue("add_forwarded_header") == "on"
+	ph.LBCookieSecret = strings.TrimSpace(r.FormValue("lb_cookie_secret"))
+	ph.PassiveUnhealthyStatusCodes = strings.TrimSpace(r.FormValue("passive_unhealthy_status_codes"))
+	ph.HealthCheckContentType = strings.TrimSpace(r.FormValue("health_check_content_type"))
+	ph.UpstreamTLSClientCertFile = strings.TrimSpace(r.FormValue("upstream_tls_client_cert_file"))
+	ph.UpstreamTLSClientKeyFile = strings.TrimSpace(r.FormValue("upstream_tls_client_key_file"))
+	ph.BlockPrivateIPs = r.FormValue("block_private_ips") == "on"
+	ph.EnableBrotli = r.FormValue("enable_brotli") == "on"
+	ph.VaryHeader = strings.TrimSpace(r.FormValue("vary_header"))
+	ph.StripETag = r.FormValue("strip_etag") == "on"
+	ph.HTTP2PushPaths = strings.TrimSpace(r.FormValue("http2_push_paths"))
+	ph.DenyContentTypes = strings.TrimSpace(r.FormValue("deny_content_types"))
+	ph.UpstreamLocalAddr = strings.TrimSpace(r.FormValue("upstream_local_addr"))
+	ph.UpstreamTLSRenegotiation = r.FormValue("upstream_tls_renegotiation")
+	ph.UpstreamTLSCurves = strings.TrimSpace(r.FormValue("upstream_tls_curves"))
+	ph.UpstreamTLSMaxVersion = r.FormValue("upstream_tls_max_version")
+	ph.UpstreamTLSPins = strings.TrimSpace(r.FormValue("upstream_tls_pins"))
+	ph.LBHeaderField = strings.TrimSpace(r.FormValue("lb_header_field"))
+	ph.MaintenanceCustomHeaders = strings.TrimSpace(r.FormValue("maintenance_custom_headers"))
+	ph.DenyExtensions = strings.TrimSpace(r.FormValue("deny_extensions"))
+	ph.InjectRequestTimestamp = r.FormValue("inject_request_timestamp") == "on"
+	ph.AddRespCookies = strings.TrimSpace(r.FormValue("add_resp_cookies"))
+	ph.StripAcceptEncoding = r.FormValue("strip_accept_encoding") == "on"
+	ph.AddUpstreamTimingHeader = r.FormValue("add_upstream_timing_header") == "on"
+	ph.StripServerHeader = r.FormValue("strip_server_header") == "on"
+	ph.BlockRefererRegexp = strings.TrimSpace(r.FormValue("block_referer_regexp"))
+	ph.AddContentTypeNosniff = r.FormValue("add_content_type_nosniff") == "on"
+	ph.StripAuthorizationHeader = r.FormValue("strip_authorization_header") == "on"
+	ph.RealIPFromHeader = strings.TrimSpace(r.FormValue("real_ip_from_header"))
+	ph.HealthCheckHostOverride = strings.TrimSpace(r.FormValue("health_check_host_override"))
+	ph.AddXForwardedPort = r.FormValue("add_x_forwarded_port") == "on"
+	ph.LBRetryOn = strings.TrimSpace(r.FormValue("lb_retry_on"))
+	if v := strings.TrimSpace(r.FormValue("max_buffer_size_kb")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			ph.MaxBufferSizeKB = n
+		}
+	}
+	if v := strings.TrimSpace(r.FormValue("upstream_keepalive_probes")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			ph.UpstreamKeepaliveProbes = n
+		}
+	}
+	if v := strings.TrimSpace(r.FormValue("upstream_flush_interval_ms")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			ph.UpstreamFlushIntervalMS = n
+		}
+	}
+	ph.AddXForwardedHost = r.FormValue("add_x_forwarded_host") == "on"
+	ph.MaintenanceAllowedIPs = strings.TrimSpace(r.FormValue("maintenance_allowed_ips"))
+	ph.UpstreamTLSCipherSuites = strings.TrimSpace(r.FormValue("upstream_tls_cipher_suites"))
+	ph.AddCacheControlNoStore = r.FormValue("add_cache_control_no_store") == "on"
+	ph.DenyRefererEmpty = r.FormValue("deny_referer_empty") == "on"
+	ph.LBCookieHTTPOnly = r.FormValue("lb_cookie_httponly") == "on"
+	ph.LBCookieSecure = r.FormValue("lb_cookie_secure") == "on"
+	ph.LBCookieSameSite = r.FormValue("lb_cookie_same_site")
+	ph.UpstreamTLSEarlyData = r.FormValue("upstream_tls_early_data") == "on"
+	ph.AddViaHeader = r.FormValue("add_via_header") == "on"
+	ph.ReqHeaderRename = strings.TrimSpace(r.FormValue("req_header_rename"))
+	ph.AddExpectCTHeader = r.FormValue("add_expect_ct_header") == "on"
+	ph.ForceUpstreamEncoding = strings.TrimSpace(r.FormValue("force_upstream_encoding"))
+	if v := strings.TrimSpace(r.FormValue("passive_unhealthy_count")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			ph.PassiveUnhealthyCount = n
+		}
+	}
+	ph.StripXPoweredBy = r.FormValue("strip_x_powered_by") == "on"
+	ph.AddTimingAllowOrigin = strings.TrimSpace(r.FormValue("add_timing_allow_origin"))
+	if v := strings.TrimSpace(r.FormValue("lb_cookie_max_age_sec")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			ph.LBCookieMaxAgeSec = n
+		}
+	}
+	ph.CrossOriginOpenerPolicy = strings.TrimSpace(r.FormValue("cross_origin_opener_policy"))
+	ph.CrossOriginResourcePolicy = strings.TrimSpace(r.FormValue("cross_origin_resource_policy"))
+	ph.CrossOriginEmbedderPolicy = strings.TrimSpace(r.FormValue("cross_origin_embedder_policy"))
+	ph.DenyRequestContentType = strings.TrimSpace(r.FormValue("deny_request_content_type"))
+	ph.CompressionExcludeRegexp = strings.TrimSpace(r.FormValue("compression_exclude_regexp"))
+	ph.AddCacheControlPublic = r.FormValue("add_cache_control_public") == "on"
+	// v2.9.140: add_x_request_start — inject X-Request-Start: t=<epoch_ms> for APM timing.
+	ph.AddXRequestStart = r.FormValue("add_x_request_start") == "on"
+	// v2.9.141: maintenance_window_timezone — IANA timezone for the scheduled maintenance window.
+	ph.MaintenanceWindowTimezone = strings.TrimSpace(r.FormValue("maintenance_window_timezone"))
+	// v2.9.142: lb_random_choose_count — "choose" count for the random_choice lb policy.
+	if v := strings.TrimSpace(r.FormValue("lb_random_choose_count")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			ph.LBRandomChooseCount = n
+		}
+	}
+	// v2.9.143: add_x_forwarded_scheme — inject X-Forwarded-Scheme with the client-facing scheme.
+	ph.AddXForwardedScheme = r.FormValue("add_x_forwarded_scheme") == "on"
+	// v2.9.144: response_cache_ttl_sec — set Cache-Control: max-age=N (0 = disabled).
+	if v := strings.TrimSpace(r.FormValue("response_cache_ttl_sec")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			ph.ResponseCacheTTLSec = n
+		}
+	}
+	// v2.9.145: add_link_preload — Link response header for HTTP/2 preload hints.
+	ph.AddLinkPreload = strings.TrimSpace(r.FormValue("add_link_preload"))
+	// v2.9.146: deny_path_regexp — block requests whose path matches this regex (403).
+	ph.DenyPathRegexp = strings.TrimSpace(r.FormValue("deny_path_regexp"))
+	// v2.9.147: add_request_id_to_response — echo request trace ID in response header.
+	ph.AddRequestIDToResponse = r.FormValue("add_request_id_to_response") == "on"
+	// v2.9.148: health_check_tls_server_name — TLS SNI override for health check connections.
+	ph.HealthCheckTLSServerName = strings.TrimSpace(r.FormValue("health_check_tls_server_name"))
+	// v2.9.149: add_x_real_ip — inject X-Real-IP with the direct client IP.
+	ph.AddXRealIP = r.FormValue("add_x_real_ip") == "on"
+	// v2.9.150: strip_incoming_x_forwarded_for — delete incoming X-Forwarded-For.
+	ph.StripIncomingXForwardedFor = r.FormValue("strip_incoming_x_forwarded_for") == "on"
+	// v2.9.151: health_check_tls_insecure_skip_verify — skip TLS cert verification for health check probes.
+	ph.HealthCheckTLSInsecureSkipVerify = r.FormValue("health_check_tls_insecure_skip_verify") == "on"
+	// v2.9.152: add_cors_vary_header — add Vary: Origin response header for CDN caching of CORS responses.
+	ph.AddCORSVaryHeader = r.FormValue("add_cors_vary_header") == "on"
+	// v2.9.153: upstream_tls_alpn — ALPN protocol list for upstream TLS connections.
+	ph.UpstreamTLSALPN = strings.TrimSpace(r.FormValue("upstream_tls_alpn"))
+	// v2.9.154: add_x_powered_by — custom X-Powered-By response header value.
+	ph.AddXPoweredBy = strings.TrimSpace(r.FormValue("add_x_powered_by"))
+	// v2.9.155: block_query_params — comma-separated query param names to block (403).
+	ph.BlockQueryParams = strings.TrimSpace(r.FormValue("block_query_params"))
+	// v2.9.156: add_document_policy — Document-Policy response header value.
+	ph.AddDocumentPolicy = strings.TrimSpace(r.FormValue("add_document_policy"))
+	// v2.9.157: maintenance_redirect_url — redirect to this URL during maintenance.
+	ph.MaintenanceRedirectURL = strings.TrimSpace(r.FormValue("maintenance_redirect_url"))
+	// v2.9.158: upstream_keepalive_max_lifetime_sec — max keepalive connection lifetime.
+	if v := strings.TrimSpace(r.FormValue("upstream_keepalive_max_lifetime_sec")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			ph.UpstreamKeepaliveMaxLifetimeSec = n
+		}
+	}
+	// v2.9.159: add_origin_header — inject Origin request header.
+	ph.AddOriginHeader = strings.TrimSpace(r.FormValue("add_origin_header"))
+	// v2.9.160: upstream_tls_ca_pem_inline — inline PEM CA certificate for upstream TLS.
+	ph.UpstreamTLSCAPEMInline = strings.TrimSpace(r.FormValue("upstream_tls_ca_pem_inline"))
+	// v2.9.161: add_server_timing_header — inject Server-Timing with upstream duration.
+	ph.AddServerTimingHeader = r.FormValue("add_server_timing_header") == "on"
+	// v2.9.162: add_clear_site_data — Clear-Site-Data response header value.
+	ph.AddClearSiteData = strings.TrimSpace(r.FormValue("add_clear_site_data"))
+	// v2.9.163: add_x_dns_prefetch_control — set X-DNS-Prefetch-Control: off.
+	ph.AddXDNSPrefetchControl = r.FormValue("add_x_dns_prefetch_control") == "on"
+	// v2.9.164: add_accept_ranges — signal byte-range support with Accept-Ranges: bytes.
+	ph.AddAcceptRanges = r.FormValue("add_accept_ranges") == "on"
+	// v2.9.165: add_content_disposition — set a custom Content-Disposition response header.
+	ph.AddContentDisposition = strings.TrimSpace(r.FormValue("add_content_disposition"))
+	// v2.9.166: upstream_tls_server_name_from_host — use Host header value as upstream TLS SNI.
+	ph.UpstreamTLSServerNameFromHost = r.FormValue("upstream_tls_server_name_from_host") == "on"
+	// v2.9.167: add_x_permitted_cross_domain_policies — X-Permitted-Cross-Domain-Policies response header value.
+	ph.AddXPermittedCrossDomainPolicies = strings.TrimSpace(r.FormValue("add_x_permitted_cross_domain_policies"))
+	// v2.9.168: strip_response_headers — comma-separated list of response headers to delete.
+	ph.StripResponseHeaders = strings.TrimSpace(r.FormValue("strip_response_headers"))
+	// v2.9.169: add_report_to — Report-To response header value (JSON endpoint group config).
+	ph.AddReportTo = strings.TrimSpace(r.FormValue("add_report_to"))
+	// v2.9.170: add_nel_header — NEL response header JSON config for Network Error Logging.
+	ph.AddNELHeader = strings.TrimSpace(r.FormValue("add_nel_header"))
+	// v2.9.171: block_http_methods — comma-separated HTTP methods to reject with 405.
+	ph.BlockHTTPMethods = strings.TrimSpace(r.FormValue("block_http_methods"))
+	// v2.9.172: add_service_worker_allowed — Service-Worker-Allowed response header value.
+	ph.AddServiceWorkerAllowed = strings.TrimSpace(r.FormValue("add_service_worker_allowed"))
+	// v2.9.173: add_accept_ch — Accept-CH response header to declare accepted client hints.
+	ph.AddAcceptCH = strings.TrimSpace(r.FormValue("add_accept_ch"))
+	// v2.9.174: add_alt_svc — Alt-Svc response header for alternate service advertisement.
+	ph.AddAltSvc = strings.TrimSpace(r.FormValue("add_alt_svc"))
+	// v2.9.175: add_content_language — Content-Language response header value.
+	ph.AddContentLanguage = strings.TrimSpace(r.FormValue("add_content_language"))
+	// v2.9.176: add_critical_ch — Critical-CH response header (marks client hints required before rendering).
+	ph.AddCriticalCH = strings.TrimSpace(r.FormValue("add_critical_ch"))
+	// v2.9.177: add_x_download_options — set X-Download-Options: noopen (IE file open prevention).
+	ph.AddXDownloadOptions = r.FormValue("add_x_download_options") == "on"
+	// v2.9.178: deny_user_agent_regexp — block requests whose User-Agent matches this regexp with 403.
+	ph.DenyUserAgentRegexp = strings.TrimSpace(r.FormValue("deny_user_agent_regexp"))
+	// v2.9.179: add_pragma_no_cache — set Pragma: no-cache response header.
+	ph.AddPragmaNoCache = r.FormValue("add_pragma_no_cache") == "on"
+	// v2.9.180: health_check_user_agent — custom User-Agent for active health check probes.
+	ph.HealthCheckUserAgent = strings.TrimSpace(r.FormValue("health_check_user_agent"))
+	// v2.9.181: add_x_request_path — inject X-Request-Path request header on upstream calls.
+	ph.AddXRequestPath = r.FormValue("add_x_request_path") == "on"
+	// v2.9.182: add_x_clacks_overhead — X-Clacks-Overhead response header value.
+	ph.AddXClacksOverhead = strings.TrimSpace(r.FormValue("add_x_clacks_overhead"))
+	// v2.9.183: add_x_ua_compatible — X-UA-Compatible response header value.
+	ph.AddXUACompatible = strings.TrimSpace(r.FormValue("add_x_ua_compatible"))
+	// v2.9.184: forward_auth_skip_paths — comma-separated path prefixes that bypass forward_auth.
+	ph.ForwardAuthSkipPaths = strings.TrimSpace(r.FormValue("forward_auth_skip_paths"))
+	// v2.9.185: add_age_zero — set Age: 0 response header to signal a fresh response.
+	ph.AddAgeZero = r.FormValue("add_age_zero") == "on"
+	// v2.9.186: add_surrogate_control — Surrogate-Control response header value (CDN-only cache directive).
+	ph.AddSurrogateControl = strings.TrimSpace(r.FormValue("add_surrogate_control"))
+	// v2.9.187: add_warning_header — Warning response header value.
+	ph.AddWarningHeader = strings.TrimSpace(r.FormValue("add_warning_header"))
+	// v2.9.188: add_x_request_method — forward X-Request-Method header (echoes HTTP method) to upstream.
+	ph.AddXRequestMethod = r.FormValue("add_x_request_method") == "on"
+	// v2.9.189: add_x_request_query — forward X-Request-Query header (echoes query string) to upstream.
+	ph.AddXRequestQuery = r.FormValue("add_x_request_query") == "on"
+	// v2.9.190: add_x_forwarded_user — static X-Forwarded-User request header value.
+	ph.AddXForwardedUser = strings.TrimSpace(r.FormValue("add_x_forwarded_user"))
+	// v2.9.191: add_x_real_scheme — forward X-Real-Scheme request header to upstream.
+	ph.AddXRealScheme = r.FormValue("add_x_real_scheme") == "on"
+	// v2.9.192: add_origin_agent_cluster — set Origin-Agent-Cluster: ?1 response header.
+	ph.AddOriginAgentCluster = r.FormValue("add_origin_agent_cluster") == "on"
+	// v2.9.193: add_x_forwarded_groups — static X-Forwarded-Groups request header value.
+	ph.AddXForwardedGroups = strings.TrimSpace(r.FormValue("add_x_forwarded_groups"))
+	// v2.9.194: add_x_forwarded_email — static X-Forwarded-Email request header value.
+	ph.AddXForwardedEmail = strings.TrimSpace(r.FormValue("add_x_forwarded_email"))
+	// v2.9.195: add_x_forwarded_roles — static X-Forwarded-Roles request header value.
+	ph.AddXForwardedRoles = strings.TrimSpace(r.FormValue("add_x_forwarded_roles"))
+	// v2.9.196: block_query_param_regexp — block requests whose query string matches this regexp with 403.
+	ph.BlockQueryParamRegexp = strings.TrimSpace(r.FormValue("block_query_param_regexp"))
+	// v2.9.197: add_x_request_referer — forward X-Request-Referer header to upstream.
+	ph.AddXRequestReferer = r.FormValue("add_x_request_referer") == "on"
+	// v2.9.198: add_x_request_origin — forward X-Request-Origin header to upstream.
+	ph.AddXRequestOrigin = r.FormValue("add_x_request_origin") == "on"
+	// v2.9.199: add_x_forwarded_uri — forward X-Forwarded-URI header to upstream.
+	ph.AddXForwardedURI = r.FormValue("add_x_forwarded_uri") == "on"
+	// v2.9.200: add_x_no_archive — set X-No-Archive: yes response header.
+	ph.AddXNoArchive = r.FormValue("add_x_no_archive") == "on"
+	// v2.9.201: add_x_request_hostname — forward X-Request-Hostname header to upstream.
+	ph.AddXRequestHostname = r.FormValue("add_x_request_hostname") == "on"
+	// v2.9.202: add_x_xss_protection_disabled — set X-XSS-Protection: 0 response header.
+	ph.AddXXSSProtectionDisabled = r.FormValue("add_x_xss_protection_disabled") == "on"
+	return ph, nil
 }
 
 func (s *Server) createProxyHost(w http.ResponseWriter, r *http.Request) {
@@ -1815,6 +3005,18 @@ func (s *Server) createProxyHost(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r), "proxy_create", fmt.Sprintf("proxy:%d", id), p.Domains, true)
 	s.syncCaddy(s.currentServerID(r), p.CertificateID != 0)
+	if whURL, _ := models.GetSetting(s.DB, settingNotifyWebhookURL); whURL != "" {
+		domains := p.Domains
+		db := s.DB
+		go func() {
+			payload, _ := json.Marshal(map[string]any{
+				"event":   "proxy_host_created",
+				"message": "Proxy host created: " + domains,
+				"domains": domains,
+			})
+			sendWebhookPayload(db, whURL, payload)
+		}()
+	}
 	if len(deployTo) > 0 {
 		s.crossDeployProxyHost(s.currentUserEmail(r), p, deployTo)
 	}
@@ -1977,6 +3179,18 @@ func (s *Server) updateProxyHost(w http.ResponseWriter, r *http.Request) {
 	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r), "proxy_update", fmt.Sprintf("proxy:%d", id), p.Domains, true)
 	forceTLS := old != nil && old.CertificateID != p.CertificateID
 	s.syncCaddy(s.currentServerID(r), forceTLS)
+	if whURL, _ := models.GetSetting(s.DB, settingNotifyWebhookURL); whURL != "" {
+		domains := p.Domains
+		db := s.DB
+		go func() {
+			payload, _ := json.Marshal(map[string]any{
+				"event":   "proxy_host_updated",
+				"message": "Proxy host updated: " + domains,
+				"domains": domains,
+			})
+			sendWebhookPayload(db, whURL, payload)
+		}()
+	}
 	if len(deployTo) > 0 {
 		s.crossDeployProxyHost(s.currentUserEmail(r), p, deployTo)
 	}
@@ -2014,7 +3228,59 @@ func (s *Server) deleteProxyHost(w http.ResponseWriter, r *http.Request) {
 	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r), "proxy_delete", fmt.Sprintf("proxy:%d", id), "", true)
 	forceTLS := old != nil && old.CertificateID != 0
 	s.syncCaddy(s.currentServerID(r), forceTLS)
+	if whURL, _ := models.GetSetting(s.DB, settingNotifyWebhookURL); whURL != "" && old != nil {
+		domains := old.Domains
+		db := s.DB
+		go func() {
+			payload, _ := json.Marshal(map[string]any{
+				"event":   "proxy_host_deleted",
+				"message": "Proxy host deleted: " + domains,
+				"domains": domains,
+			})
+			sendWebhookPayload(db, whURL, payload)
+		}()
+	}
 	http.Redirect(w, r, "/proxy-hosts", http.StatusSeeOther)
+}
+
+// cloneProxyHost creates a copy of a proxy host with Enabled=false and
+// a "(copy)" suffix on each domain, then redirects to its edit page.
+func (s *Server) cloneProxyHost(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	src, err := models.GetProxyHost(s.DB, id)
+	if err != nil || src == nil {
+		http.NotFound(w, r)
+		return
+	}
+	// Build cloned domain list — append "(copy)" to each domain.
+	domains := src.DomainList()
+	cloned := make([]string, len(domains))
+	for i, d := range domains {
+		cloned[i] = d + " (copy)"
+	}
+	clone := *src // value copy
+	clone.ID = 0
+	clone.Domains = strings.Join(cloned, ",")
+	clone.Enabled = false // always disabled so it doesn't affect live traffic
+	clone.MaintenanceMode = false
+	clone.CreatedAt = time.Time{}
+	clone.UpdatedAt = time.Time{}
+
+	cu := s.currentUser(r)
+	var ownerID int64
+	if cu != nil {
+		ownerID = cu.ID
+	}
+	newID, err := models.CreateProxyHost(s.DB, src.ServerID, ownerID, &clone)
+	if err != nil {
+		http.Error(w, "clone failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, fmt.Sprintf("/proxy-hosts/%d/edit", newID), http.StatusSeeOther)
 }
 
 // --- Redirection Hosts ---
@@ -2067,6 +3333,40 @@ func parseRedirectionHostForm(r *http.Request) (*models.RedirectionHost, error) 
 		SSLForced:       r.FormValue("ssl_forced") == "on",
 		Enabled:         r.FormValue("enabled") == "on",
 		CertificateID:   certID,
+		Tags:            strings.TrimSpace(r.FormValue("rh_tags")),
+		Notes:           r.FormValue("rh_notes"),
+		// v2.9.13: access control + maintenance mode
+		AccessList:      strings.TrimSpace(r.FormValue("access_list")),
+		MaintenanceMode: r.FormValue("maintenance_mode") == "on",
+		MaintenanceMsg:  strings.TrimSpace(r.FormValue("maintenance_msg")),
+		// v2.9.20: custom response headers
+		CustomRespHeaders: func() string {
+			v := strings.TrimSpace(r.FormValue("custom_resp_headers"))
+			if v == "" {
+				return "{}"
+			}
+			return v
+		}(),
+		// v2.9.21: IP blocklist
+		IPBlocklist: strings.TrimSpace(r.FormValue("ip_blocklist")),
+		// v2.9.24: HSTS
+		HSTSMaxAgeSec:         func() int { v, _ := strconv.Atoi(r.FormValue("hsts_max_age_sec")); return v }(),
+		HSTSIncludeSubdomains: r.FormValue("hsts_include_subdomains") == "on",
+		HSTSPreload:           r.FormValue("hsts_preload") == "on",
+		// v2.9.26: advanced config (raw JSON handlers)
+		AdvancedConfig: strings.TrimSpace(r.FormValue("rh_advanced_config")),
+		// v2.9.33: color label
+		Color: strings.TrimSpace(r.FormValue("color")),
+		// v2.9.38: maintenance status code
+		MaintenanceStatusCode: func() int {
+			v, _ := strconv.Atoi(r.FormValue("maintenance_status_code"))
+			if v == 0 {
+				return 503
+			}
+			return v
+		}(),
+		// v2.9.39: sort order
+		SortOrder: func() int { v, _ := strconv.Atoi(r.FormValue("sort_order")); return v }(),
 	}, nil
 }
 
@@ -2219,6 +3519,46 @@ func (s *Server) deleteRedirectionHost(w http.ResponseWriter, r *http.Request) {
 	forceTLS := old != nil && old.CertificateID != 0
 	s.syncCaddy(s.currentServerID(r), forceTLS)
 	http.Redirect(w, r, "/redirection-hosts", http.StatusSeeOther)
+}
+
+// cloneRedirectionHost creates a copy of a redirection host with Enabled=false
+// and a "(copy)" suffix on each domain, then redirects to its edit page.
+func (s *Server) cloneRedirectionHost(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	src, err := models.GetRedirectionHost(s.DB, id)
+	if err != nil || src == nil {
+		http.NotFound(w, r)
+		return
+	}
+	// Append "(copy)" to each domain.
+	domains := src.DomainList()
+	cloned := make([]string, len(domains))
+	for i, d := range domains {
+		cloned[i] = d + " (copy)"
+	}
+	clone := *src
+	clone.ID = 0
+	clone.Domains = strings.Join(cloned, ",")
+	clone.Enabled = false
+	clone.MaintenanceMode = false
+	clone.CreatedAt = time.Time{}
+	clone.UpdatedAt = time.Time{}
+
+	cu := s.currentUser(r)
+	var ownerID int64
+	if cu != nil {
+		ownerID = cu.ID
+	}
+	newID, err := models.CreateRedirectionHost(s.DB, s.currentServerID(r), ownerID, &clone)
+	if err != nil {
+		http.Error(w, "clone failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, fmt.Sprintf("/redirection-hosts/%d/edit", newID), http.StatusSeeOther)
 }
 
 func (s *Server) reloadCaddy(w http.ResponseWriter, r *http.Request) {
@@ -2683,6 +4023,59 @@ func (s *Server) pushAutomationPolicies(r *http.Request, incoming []map[string]a
 // don't want a snapshot every sync filling the DB.
 const settingAutoSnapshots = "auto_snapshots_enabled"
 
+// settingRequire2FA gates 2FA enforcement: when "1", users without TOTP enabled
+// are redirected to /totp/setup before accessing any page.
+const settingRequire2FA = "require_2fa"
+
+// settingRequireTOTP forces all users to enroll TOTP before accessing protected pages.
+const settingRequireTOTP = "require_totp"
+
+// settingSessionDays is the admin-configured session lifetime in days.
+// Default is 7 days when empty or invalid.
+const settingSessionDays = "session_duration_days"
+
+// settingCatchAll404HTML holds optional HTML for a global catch-all 404 route
+// appended last in the merged Caddy config so it fires only when no
+// proxy/redirect/raw route matched.
+const settingCatchAll404HTML = "catch_all_404_html"
+
+// settingGlobalMaintenance puts ALL proxy hosts into maintenance mode when "1".
+// A catch-all 503 route is prepended to the Caddy routes list so every request
+// gets a maintenance page regardless of individual host settings.
+const settingGlobalMaintenance = "global_maintenance"
+
+// settingAutoSyncHours is the interval (in hours) for automatic periodic Caddy
+// re-syncs. 0 or empty = disabled. The background loop checks once per hour
+// and re-syncs if the elapsed time since the last sync_applied log entry
+// exceeds this value.
+const settingAutoSyncHours = "auto_sync_hours"
+
+// settingTrustedProxies holds newline or comma-separated CIDRs/IPs of trusted
+// reverse-proxies (e.g. Cloudflare, load balancers). When non-empty, CaddyUI
+// injects trusted_proxies into the Caddy HTTP server config so that the real
+// client IP is extracted from X-Forwarded-For.
+const settingTrustedProxies = "trusted_proxies"
+
+// settingSiteTitle is the custom display name shown in the browser tab title
+// and the sidebar logo area. Falls back to "CaddyUI" when empty.
+const settingSiteTitle = "site_title"
+
+// settingFaviconURL is an optional URL for a custom favicon. When set, the
+// layout <head> will use it instead of the default inline SVG favicon.
+const settingFaviconURL = "favicon_url"
+
+// settingAdminAllowlist holds newline or comma-separated IPs/CIDRs that are
+// permitted to access the CaddyUI admin panel. When empty, all IPs are allowed.
+const settingAdminAllowlist = "admin_allowlist"
+
+// settingActivityLogDays specifies how many days to keep activity log entries.
+// 0 or empty = keep forever (default).
+const settingActivityLogDays = "activity_log_days"
+
+// settingMaxLoginAttempts limits consecutive failed login attempts per IP within
+// a 15-minute window. 0 or empty = no limit (default).
+const settingMaxLoginAttempts = "max_login_attempts"
+
 func (s *Server) autoSnapshotsEnabled() bool {
 	v, err := models.GetSetting(s.DB, settingAutoSnapshots)
 	if err != nil || v == "" {
@@ -2852,6 +4245,121 @@ func (s *Server) downloadSnapshot(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(snap.ConfigJSON))
 }
 
+// DiffLine represents a single line in a unified diff view.
+type DiffLine struct {
+	Type    string // "same", "add", "remove"
+	Content string
+	LineA   int // 1-based line number in snapshot (0 if added)
+	LineB   int // 1-based line number in live config (0 if removed)
+}
+
+// diffLines performs a simple line-by-line diff between two strings.
+// It zips the two line slices and marks each position as same/add/remove.
+// This is not a full LCS diff but is effective for JSON config comparisons.
+func diffLines(a, b string) []DiffLine {
+	aLines := strings.Split(a, "\n")
+	bLines := strings.Split(b, "\n")
+	max := len(aLines)
+	if len(bLines) > max {
+		max = len(bLines)
+	}
+	var out []DiffLine
+	for i := 0; i < max; i++ {
+		la, lb := "", ""
+		if i < len(aLines) {
+			la = aLines[i]
+		}
+		if i < len(bLines) {
+			lb = bLines[i]
+		}
+		if la == lb {
+			out = append(out, DiffLine{Type: "same", Content: la, LineA: i + 1, LineB: i + 1})
+		} else {
+			if la != "" {
+				out = append(out, DiffLine{Type: "remove", Content: la, LineA: i + 1})
+			}
+			if lb != "" {
+				out = append(out, DiffLine{Type: "add", Content: lb, LineB: i + 1})
+			}
+		}
+	}
+	return out
+}
+
+// getSnapshotDiff shows a unified diff between a stored snapshot and the
+// current live Caddy config. Admin-only: non-admin callers get 403.
+func (s *Server) getSnapshotDiff(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil || cu.Role != models.RoleAdmin {
+		http.Error(w, "admin access required", http.StatusForbidden)
+		return
+	}
+	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	snap, err := models.GetSnapshot(s.DB, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	// Pretty-print the snapshot JSON.
+	var snapObj any
+	if err := json.Unmarshal([]byte(snap.ConfigJSON), &snapObj); err != nil {
+		http.Error(w, "snapshot is corrupted: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	snapPretty, err := json.MarshalIndent(snapObj, "", "  ")
+	if err != nil {
+		http.Error(w, "marshal snapshot: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	snapJSON := string(snapPretty)
+
+	// Fetch and pretty-print the live config.
+	var liveJSON string
+	_, raw, fetchErr := s.caddyForRequest(r).FetchConfig()
+	if fetchErr != nil || raw == "" || raw == "null" {
+		liveJSON = ""
+	} else {
+		var liveObj any
+		if err := json.Unmarshal([]byte(raw), &liveObj); err == nil {
+			if b, err := json.MarshalIndent(liveObj, "", "  "); err == nil {
+				liveJSON = string(b)
+			} else {
+				liveJSON = raw
+			}
+		} else {
+			liveJSON = raw
+		}
+	}
+
+	hasDiff := snapJSON != liveJSON
+	var diffs []DiffLine
+	addCount, removeCount := 0, 0
+	if hasDiff {
+		diffs = diffLines(snapJSON, liveJSON)
+		for _, dl := range diffs {
+			switch dl.Type {
+			case "add":
+				addCount++
+			case "remove":
+				removeCount++
+			}
+		}
+	}
+
+	s.render(w, r, "snapshot_diff.html", map[string]any{
+		"User":        cu,
+		"Snapshot":    snap,
+		"SnapJSON":    snapJSON,
+		"LiveJSON":    liveJSON,
+		"DiffLines":   diffs,
+		"HasDiff":     hasDiff,
+		"AddCount":    addCount,
+		"RemoveCount": removeCount,
+		"Section":     "snapshots",
+	})
+}
+
 // uploadSnapshot accepts a JSON file (typically a previously-downloaded
 // snapshot, or any Caddy /config/ export) and stores it as a manual snapshot.
 // The config is validated as JSON here but not run through Caddy — users
@@ -2903,17 +4411,73 @@ func (s *Server) getDocs(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// getAPIDocs renders the v1 REST API reference page.
+func (s *Server) getAPIDocs(w http.ResponseWriter, r *http.Request) {
+	s.render(w, r, "api_docs.html", map[string]any{
+		"User":    s.currentUser(r),
+		"Section": "api_docs",
+	})
+}
+
 func (s *Server) listActivityLog(w http.ResponseWriter, r *http.Request) {
-	entries, err := models.ListActivity(s.DB, s.currentServerID(r), 500)
+	search := strings.TrimSpace(r.URL.Query().Get("search"))
+	actionFilter := strings.TrimSpace(r.URL.Query().Get("action"))
+	entries, err := models.ListActivitySearch(s.DB, s.currentServerID(r), 500, search)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	if actionFilter != "" {
+		filtered := entries[:0]
+		for _, a := range entries {
+			if strings.Contains(a.Action, actionFilter) {
+				filtered = append(filtered, a)
+			}
+		}
+		entries = filtered
+	}
 	s.render(w, r, "activity.html", map[string]any{
-		"User":    s.currentUser(r),
-		"Entries": entries,
-		"Section": "activity",
+		"User":         s.currentUser(r),
+		"Entries":      entries,
+		"Section":      "activity",
+		"Search":       search,
+		"ActionFilter": actionFilter,
 	})
+}
+
+func (s *Server) exportActivityCSV(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	sid := s.currentServerID(r)
+	search := strings.TrimSpace(r.URL.Query().Get("search"))
+	entries, err := models.ListActivitySearch(s.DB, sid, 10000, search)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="activity.csv"`)
+	cw := csv.NewWriter(w)
+	_ = cw.Write([]string{"ID", "Actor", "Action", "Target", "Detail", "Success", "Created At"})
+	for _, a := range entries {
+		succ := "false"
+		if a.Success {
+			succ = "true"
+		}
+		_ = cw.Write([]string{
+			strconv.FormatInt(a.ID, 10),
+			a.Actor,
+			a.Action,
+			a.Target,
+			a.Detail,
+			succ,
+			a.CreatedAt.Format(time.RFC3339),
+		})
+	}
+	cw.Flush()
 }
 
 // --- Certificates ---
@@ -3060,6 +4624,102 @@ func (s *Server) listCertificates(w http.ResponseWriter, r *http.Request) {
 		"AutoDomains": autoDomains,
 		"Section":     "certs",
 	})
+}
+
+// getCertificateInspect parses the stored PEM and renders detailed certificate
+// information (subject, issuer, SANs, validity window, key type, serial,
+// SHA-256 fingerprint). Accessible to all authenticated users, not just admins,
+// so each user can inspect certs they uploaded.
+func (s *Server) getCertificateInspect(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	cert, err := models.GetCertificate(s.DB, id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	data := map[string]any{
+		"User":    s.currentUser(r),
+		"Cert":    cert,
+		"Section": "certs",
+	}
+
+	pemData := cert.CertPEM
+	if pemData == "" && cert.Source == models.CertSourcePath {
+		// Path-based cert: try reading the file so we can still parse it.
+		if raw, readErr := os.ReadFile(cert.CertPath); readErr == nil {
+			pemData = string(raw)
+		}
+	}
+
+	if pemData == "" {
+		s.render(w, r, "certificate_inspect.html", data)
+		return
+	}
+
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		s.render(w, r, "certificate_inspect.html", data)
+		return
+	}
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		s.render(w, r, "certificate_inspect.html", data)
+		return
+	}
+
+	// Subject / Issuer
+	data["Subject"] = parsed.Subject.String()
+	data["Issuer"] = parsed.Issuer.String()
+
+	// SANs: DNS names, IPs, URIs
+	sans := make([]string, 0, len(parsed.DNSNames)+len(parsed.IPAddresses)+len(parsed.URIs))
+	sans = append(sans, parsed.DNSNames...)
+	for _, ip := range parsed.IPAddresses {
+		sans = append(sans, ip.String())
+	}
+	for _, uri := range parsed.URIs {
+		sans = append(sans, uri.String())
+	}
+	data["SANs"] = sans
+
+	// Validity window
+	data["NotBefore"] = parsed.NotBefore
+	data["NotAfter"] = parsed.NotAfter
+	data["DaysLeft"] = int(time.Until(parsed.NotAfter).Hours() / 24)
+
+	// Key type and bits
+	keyType := "Unknown"
+	keyBits := 0
+	switch k := parsed.PublicKey.(type) {
+	case *rsa.PublicKey:
+		keyType = "RSA"
+		keyBits = k.N.BitLen()
+	case *ecdsa.PublicKey:
+		keyType = "ECDSA"
+		keyBits = k.Curve.Params().BitSize
+	case ed25519.PublicKey:
+		keyType = "Ed25519"
+	}
+	data["KeyType"] = keyType
+	data["KeyBits"] = keyBits
+
+	// Serial number (hex)
+	data["SerialNumber"] = parsed.SerialNumber.Text(16)
+
+	// SHA-256 fingerprint over the raw DER bytes
+	fp := sha256.Sum256(parsed.Raw)
+	fpParts := make([]string, len(fp))
+	for i, b := range fp {
+		fpParts[i] = fmt.Sprintf("%02X", b)
+	}
+	data["Fingerprint"] = strings.Join(fpParts[:], ":")
+
+	s.render(w, r, "certificate_inspect.html", data)
 }
 
 func (s *Server) newCertificate(w http.ResponseWriter, r *http.Request) {
@@ -3493,6 +5153,8 @@ func (s *Server) previewRawRouteValidate(serverID int64, rr *models.RawRoute) st
 	loadPEM, loadFiles := buildCertLoaders(certs)
 	applyCertLoaders(proposed, loadPEM, loadFiles)
 	applySkipCertificates(proposed, buildSkipCertificates(proxies, redirs, raws))
+	applySkipRedirects(proposed, buildSkipRedirects(proxies, redirs))
+	applySkipAccessLogs(proposed, buildSkipAccessLogs(proxies))
 	// Mirror syncCaddy: preview-validation must match the config we'd push
 	// for real, otherwise a raw_route edit could validate clean here but
 	// fail with errors.routes rejection at sync time.
@@ -3781,6 +5443,128 @@ func newCaddyClient(adminURL, username, password string) *caddy.Client {
 // It syncs the currently-selected server; serverID 1 is the safe default.
 func (s *Server) SyncCaddy() error { return s.syncCaddy(1, false) }
 
+// runAutoSyncLoop fires once per hour, checks the auto_sync_hours setting, and
+// re-syncs all servers when the configured interval has elapsed since the last
+// sync_applied activity log entry. Setting value 0 or empty = disabled.
+func (s *Server) runAutoSyncLoop() {
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+	for range ticker.C {
+		v, _ := models.GetSetting(s.DB, settingAutoSyncHours)
+		hours, err := strconv.Atoi(strings.TrimSpace(v))
+		if err != nil || hours <= 0 {
+			continue // disabled
+		}
+		// Check when any server was last synced.
+		var lastSync time.Time
+		_ = s.DB.QueryRow(
+			`SELECT created_at FROM activity_log WHERE action = 'sync_applied' ORDER BY id DESC LIMIT 1`,
+		).Scan(&lastSync)
+		if time.Since(lastSync) < time.Duration(hours)*time.Hour {
+			continue // synced recently enough
+		}
+		// Re-sync all registered servers.
+		servers, err := models.ListCaddyServers(s.DB)
+		if err != nil {
+			log.Printf("auto-sync: list servers: %v", err)
+			continue
+		}
+		for _, srv := range servers {
+			if err := s.syncCaddy(srv.ID, false); err != nil {
+				log.Printf("auto-sync: server %d (%s): %v", srv.ID, srv.Name, err)
+			} else {
+				log.Printf("auto-sync: synced server %d (%s)", srv.ID, srv.Name)
+			}
+		}
+	}
+}
+
+// isMaintWindowDay reports whether t's day-of-week is in the comma-separated
+// abbreviated day list (e.g. "mon,wed,fri"). An empty days string means every day.
+func isMaintWindowDay(days string, t time.Time) bool {
+	if days == "" {
+		return true
+	}
+	abbr := strings.ToLower(t.Weekday().String()[:3])
+	for _, d := range strings.Split(strings.ToLower(days), ",") {
+		if strings.TrimSpace(d) == abbr {
+			return true
+		}
+	}
+	return false
+}
+
+// runMaintenanceWindowLoop wakes at every minute boundary and triggers a Caddy
+// sync for any server whose proxy hosts have a scheduled maintenance window
+// starting or ending at that exact minute. This keeps the scheduled state in
+// sync without requiring continuous full re-syncs.
+func (s *Server) runMaintenanceWindowLoop() {
+	for {
+		now := time.Now()
+		// Sleep until 2 seconds past the next minute boundary to avoid edge-case
+		// early fires when the goroutine starts right on the minute.
+		nextFire := now.Truncate(time.Minute).Add(time.Minute + 2*time.Second)
+		time.Sleep(time.Until(nextFire))
+
+		now = time.Now()
+		hhmm := now.Format("15:04")
+
+		hosts, err := models.ListProxyHostsWithMaintenanceWindow(s.DB)
+		if err != nil {
+			log.Printf("maintenance-window loop: list hosts: %v", err)
+			continue
+		}
+
+		serverSet := map[int64]bool{}
+		for _, h := range hosts {
+			if (h.MaintenanceWindowStart == hhmm || h.MaintenanceWindowEnd == hhmm) &&
+				isMaintWindowDay(h.MaintenanceWindowDays, now) {
+				serverSet[h.ServerID] = true
+			}
+		}
+		for srvID := range serverSet {
+			if err := s.syncCaddy(srvID, false); err != nil {
+				log.Printf("maintenance-window sync: server %d: %v", srvID, err)
+			} else {
+				log.Printf("maintenance-window sync: server %d at window boundary %s", srvID, hhmm)
+			}
+		}
+	}
+}
+
+// runActivityLogCleanup wakes once every 24 hours and purges activity_log rows
+// older than the configured retention window (settingActivityLogDays). Disabled
+// when the setting is 0 or empty.
+func (s *Server) runActivityLogCleanup() {
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+	// Run once on startup, then every 24 h.
+	s.pruneActivityLog()
+	for range ticker.C {
+		s.pruneActivityLog()
+	}
+}
+
+func (s *Server) pruneActivityLog() {
+	v, _ := models.GetSetting(s.DB, settingActivityLogDays)
+	days, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil || days <= 0 {
+		return // disabled
+	}
+	res, err := s.DB.Exec(
+		`DELETE FROM activity_log WHERE created_at < datetime('now', ?)`,
+		fmt.Sprintf("-%d days", days),
+	)
+	if err != nil {
+		log.Printf("activity log cleanup: %v", err)
+		return
+	}
+	n, _ := res.RowsAffected()
+	if n > 0 {
+		log.Printf("activity log cleanup: deleted %d entries older than %d days", n, days)
+	}
+}
+
 // syncCaddy applies CaddyUI's managed state to Caddy:
 //
 //  1. Reads the current live config and builds a "proposed" config with our routes,
@@ -3841,6 +5625,10 @@ func (s *Server) syncCaddy(serverID int64, forceTLS bool) error {
 	routes := s.buildMergedRoutes(proxies, redirs, raws)
 	loadPEM, loadFiles := buildCertLoaders(certs)
 	skipList := buildSkipCertificates(proxies, redirs, raws)
+	// SSLForced=false + SSLEnabled=true → add to skip_redirects so Caddy
+	// doesn't force HTTP→HTTPS for hosts that explicitly allow plain HTTP.
+	skipRedirects := buildSkipRedirects(proxies, redirs)
+	skipAccessLogs := buildSkipAccessLogs(proxies)
 	// v2.9.0: per-SNI TLS minimum-version connection policies. nil when no
 	// host has a min version configured — writeTLSConnectionPoliciesSubtree
 	// handles the nil case by clearing stale policies that may exist.
@@ -3860,7 +5648,10 @@ func (s *Server) syncCaddy(serverID int64, forceTLS bool) error {
 	applyListen(proposed)
 	applyCertLoaders(proposed, loadPEM, loadFiles)
 	applySkipCertificates(proposed, skipList)
+	applySkipRedirects(proposed, skipRedirects)
+	applySkipAccessLogs(proposed, skipAccessLogs)
 	applyTLSConnectionPolicies(proposed, tlsConnPolicies)
+	applyTrustedProxies(proposed, s.DB, serverID)
 	// v2.4.12: branded 404/502/503/504 pages with error ID + timestamp so
 	// users hitting a restart window see something nicer than Caddy's
 	// plaintext fallback and ops can correlate to access logs via {err.id}.
@@ -3895,7 +5686,7 @@ func (s *Server) syncCaddy(serverID int64, forceTLS bool) error {
 		_ = models.LogActivity(s.DB, serverID, "system", "sync_apply_tls_failed", "", err.Error(), false)
 		return err
 	}
-	if err := s.writeAutomaticHTTPSSubtree(skipList, forceTLS); err != nil {
+	if err := s.writeAutomaticHTTPSSubtree(skipList, skipRedirects, forceTLS); err != nil {
 		_ = models.LogActivity(s.DB, serverID, "system", "sync_apply_autohttps_failed", "", err.Error(), false)
 		return err
 	}
@@ -3905,6 +5696,11 @@ func (s *Server) syncCaddy(serverID int64, forceTLS bool) error {
 		// failure here shouldn't roll back the primary route push.
 		log.Printf("caddy sync: tls_connection_policies write failed (non-fatal): %v", err)
 		_ = models.LogActivity(s.DB, serverID, "system", "sync_apply_tls_policies_failed", "", err.Error(), false)
+	}
+	if err := s.writeAccessLogsSubtree(skipAccessLogs); err != nil {
+		// Non-fatal: access log skip is a UX feature; a failure here
+		// shouldn't roll back the primary sync.
+		log.Printf("caddy sync: access_logs write failed (non-fatal): %v", err)
 	}
 
 	detail := fmt.Sprintf("proxies=%d redirects=%d passthrough=%d certs=%d",
@@ -4044,7 +5840,11 @@ func (s *Server) buildMergedRoutes(proxies []models.ProxyHost, redirs []models.R
 		var preHandlers []any
 		if p.BasicAuthEnabled {
 			if baUsers := p.BasicAuthUserList(); len(baUsers) > 0 {
-				if h := s.buildBasicAuthHandler(s.Caddy, baUsers); h != nil {
+				realm := p.BasicAuthRealm
+				if realm == "" {
+					realm = "Restricted"
+				}
+				if h := s.buildBasicAuthHandler(s.Caddy, baUsers, realm); h != nil {
 					preHandlers = []any{h}
 				}
 			}
@@ -4102,6 +5902,44 @@ func (s *Server) buildMergedRoutes(proxies []models.ProxyHost, redirs []models.R
 			log.Printf("caddy sync: skipping raw_route id=%d label=%q: unexpected JSON shape %T", rr.ID, rr.Label, decoded)
 		}
 	}
+
+	// Append a catch-all 404 route when the admin has configured custom HTML.
+	// This appears last so it only fires for requests that didn't match any
+	// proxy/redirect/raw route above.
+	if html, _ := models.GetSetting(s.DB, settingCatchAll404HTML); strings.TrimSpace(html) != "" {
+		routes = append(routes, map[string]any{
+			"handle": []any{map[string]any{
+				"handler":     "static_response",
+				"status_code": 404,
+				"headers": map[string]any{
+					"Content-Type": []any{"text/html; charset=utf-8"},
+				},
+				"body": html,
+			}},
+			"terminal": true,
+		})
+	}
+
+	// Global maintenance mode: prepend a catch-all 503 before all routes so
+	// every incoming request receives the maintenance page regardless of which
+	// virtual host it targets. The route has no host matcher (catches all),
+	// and it's prepended so it fires before any per-host route.
+	if gm, _ := models.GetSetting(s.DB, settingGlobalMaintenance); gm == "1" {
+		globalMaintenanceBody := `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Maintenance</title><style>*{box-sizing:border-box}body{font-family:system-ui,sans-serif;background:#f8fafc;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}.card{background:#fff;border-radius:16px;padding:40px 48px;text-align:center;box-shadow:0 4px 32px rgba(0,0,0,.08);max-width:480px}h1{font-size:1.5rem;color:#1e293b;margin:16px 0 8px}p{color:#64748b;font-size:.95rem;line-height:1.6;margin:0}</style></head><body><div class="card"><svg width="48" height="48" fill="none" stroke="#f59e0b" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg><h1>Down for Maintenance</h1><p>We're making improvements and will be back shortly. Thank you for your patience.</p></div></body></html>`
+		routes = append([]any{map[string]any{
+			"handle": []any{map[string]any{
+				"handler":     "static_response",
+				"status_code": 503,
+				"headers": map[string]any{
+					"Content-Type": []any{"text/html; charset=utf-8"},
+					"Retry-After":  []any{"3600"},
+				},
+				"body": globalMaintenanceBody,
+			}},
+			"terminal": true,
+		}}, routes...)
+	}
+
 	return routes
 }
 
@@ -4239,6 +6077,47 @@ func applyListen(cfg map[string]any) {
 	srv["listen"] = []any{":443"}
 }
 
+// applyTrustedProxies injects the trusted_proxies list into the Caddy HTTP
+// server config. This allows Caddy to extract the real client IP from
+// X-Forwarded-For when requests arrive via a trusted load balancer or CDN.
+// No-op when the setting is empty.
+func applyTrustedProxies(cfg map[string]any, db *sql.DB, serverID int64) {
+	raw, _ := models.GetSetting(db, settingTrustedProxies)
+	if raw == "" {
+		return
+	}
+	var ranges []any
+	for _, line := range strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == '\n' }) {
+		if cidr := strings.TrimSpace(line); cidr != "" {
+			ranges = append(ranges, cidr)
+		}
+	}
+	if len(ranges) == 0 {
+		return
+	}
+	// Navigate to apps.http.servers.srv0 and set trusted_proxies.
+	apps, _ := cfg["apps"].(map[string]any)
+	if apps == nil {
+		return
+	}
+	httpApp, _ := apps["http"].(map[string]any)
+	if httpApp == nil {
+		return
+	}
+	servers, _ := httpApp["servers"].(map[string]any)
+	if servers == nil {
+		return
+	}
+	srv, _ := servers["srv0"].(map[string]any)
+	if srv == nil {
+		return
+	}
+	srv["trusted_proxies"] = map[string]any{
+		"source": "static",
+		"ranges": ranges,
+	}
+}
+
 func applyCertLoaders(cfg map[string]any, loadPEM, loadFiles []any) {
 	apps := ensureMap(cfg, "apps")
 	tlsBlock := ensureMap(apps, "tls")
@@ -4280,6 +6159,90 @@ func applySkipCertificates(cfg map[string]any, skipList []any) {
 	}
 	if len(auto) == 0 {
 		delete(srv, "automatic_https")
+	}
+}
+
+// buildSkipRedirects collects domains from hosts where SSL is enabled but
+// Force SSL is OFF. Those domains get added to automatic_https.skip_redirects
+// in Caddy, meaning HTTP traffic is not automatically redirected to HTTPS.
+// Hosts with SSL fully disabled don't need an entry here — they're already
+// in skip_certificates which also suppresses redirects.
+func buildSkipRedirects(proxies []models.ProxyHost, redirs []models.RedirectionHost) []any {
+	set := map[string]struct{}{}
+	for _, p := range proxies {
+		if !p.SSLEnabled || p.SSLForced {
+			continue // SSL off or force-redirect on — default Caddy behavior
+		}
+		for _, d := range p.DomainList() {
+			set[d] = struct{}{}
+		}
+	}
+	for _, rd := range redirs {
+		if !rd.SSLEnabled || rd.SSLForced {
+			continue
+		}
+		for _, d := range rd.DomainList() {
+			set[d] = struct{}{}
+		}
+	}
+	out := make([]any, 0, len(set))
+	for d := range set {
+		out = append(out, d)
+	}
+	return out
+}
+
+func applySkipRedirects(cfg map[string]any, skipList []any) {
+	apps := ensureMap(cfg, "apps")
+	httpApp := ensureMap(apps, "http")
+	servers := ensureMap(httpApp, "servers")
+	srv := ensureMap(servers, "srv0")
+	auto := ensureMap(srv, "automatic_https")
+	if len(skipList) > 0 {
+		auto["skip_redirects"] = skipList
+	} else {
+		delete(auto, "skip_redirects")
+	}
+	if len(auto) == 0 {
+		delete(srv, "automatic_https")
+	}
+}
+
+// buildSkipAccessLogs collects domains from enabled proxy hosts where
+// DisableAccessLog=true. These are written to srv0.logs.skip_hosts so Caddy
+// omits access-log entries for those virtual hosts.
+func buildSkipAccessLogs(proxies []models.ProxyHost) []any {
+	set := map[string]struct{}{}
+	for _, p := range proxies {
+		if !p.Enabled || !p.DisableAccessLog {
+			continue
+		}
+		for _, d := range p.DomainList() {
+			set[d] = struct{}{}
+		}
+	}
+	out := make([]any, 0, len(set))
+	for d := range set {
+		out = append(out, d)
+	}
+	return out
+}
+
+func applySkipAccessLogs(cfg map[string]any, skipHosts []any) {
+	apps := ensureMap(cfg, "apps")
+	httpApp := ensureMap(apps, "http")
+	servers := ensureMap(httpApp, "servers")
+	srv := ensureMap(servers, "srv0")
+	if len(skipHosts) > 0 {
+		logsM := ensureMap(srv, "logs")
+		logsM["skip_hosts"] = skipHosts
+	} else {
+		if logsM, ok := srv["logs"].(map[string]any); ok {
+			delete(logsM, "skip_hosts")
+			if len(logsM) == 0 {
+				delete(srv, "logs")
+			}
+		}
 	}
 }
 
@@ -4412,7 +6375,7 @@ func (s *Server) writeTLSSubtree(loadPEM, loadFiles []any, force bool) error {
 	return s.Caddy.PutPath("/config/apps/tls", tlsMap)
 }
 
-func (s *Server) writeAutomaticHTTPSSubtree(skipList []any, force bool) error {
+func (s *Server) writeAutomaticHTTPSSubtree(skipCerts []any, skipRedirects []any, force bool) error {
 	raw, err := s.Caddy.FetchPath("/config/apps/http/servers/srv0/automatic_https")
 	if err != nil {
 		return err
@@ -4422,17 +6385,22 @@ func (s *Server) writeAutomaticHTTPSSubtree(skipList []any, force bool) error {
 	if autoMap == nil {
 		autoMap = map[string]any{}
 	}
-	existingSkip, _ := autoMap["skip_certificates"].([]any)
-	// Skip the write when the effective skip list is unchanged. Writing it otherwise
-	// reprovisions the server module and can interrupt in-flight ACME work. Caller
-	// can force the write when a cert-touching mutation demands Caddy re-evaluate.
-	if !force && stringListsEqual(existingSkip, skipList) {
+	existingSkipCerts, _ := autoMap["skip_certificates"].([]any)
+	existingSkipRedir, _ := autoMap["skip_redirects"].([]any)
+	// Skip the write when the effective lists are unchanged. Writing otherwise
+	// reprovisions the server module and can interrupt in-flight ACME work.
+	if !force && stringListsEqual(existingSkipCerts, skipCerts) && stringListsEqual(existingSkipRedir, skipRedirects) {
 		return nil
 	}
-	if len(skipList) > 0 {
-		autoMap["skip_certificates"] = skipList
+	if len(skipCerts) > 0 {
+		autoMap["skip_certificates"] = skipCerts
 	} else {
 		delete(autoMap, "skip_certificates")
+	}
+	if len(skipRedirects) > 0 {
+		autoMap["skip_redirects"] = skipRedirects
+	} else {
+		delete(autoMap, "skip_redirects")
 	}
 	if !existed && len(autoMap) == 0 {
 		return nil
@@ -4462,6 +6430,34 @@ func (s *Server) writeTLSConnectionPoliciesSubtree(policies []any) error {
 		return s.Caddy.PutPath(path, policies)
 	}
 	return s.Caddy.PatchPath(path, policies)
+}
+
+// writeAccessLogsSubtree updates srv0.logs.skip_hosts to suppress access-log
+// entries for proxy hosts with DisableAccessLog=true.
+func (s *Server) writeAccessLogsSubtree(skipHosts []any) error {
+	path := "/config/apps/http/servers/srv0/logs"
+	raw, err := s.Caddy.FetchPath(path)
+	if err != nil {
+		return err
+	}
+	logsMap, _ := raw.(map[string]any)
+	existed := logsMap != nil
+	if logsMap == nil {
+		logsMap = map[string]any{}
+	}
+	existingSkip, _ := logsMap["skip_hosts"].([]any)
+	if stringListsEqual(existingSkip, skipHosts) {
+		return nil
+	}
+	if len(skipHosts) > 0 {
+		logsMap["skip_hosts"] = skipHosts
+	} else {
+		delete(logsMap, "skip_hosts")
+	}
+	if !existed && len(logsMap) == 0 {
+		return nil
+	}
+	return s.Caddy.PutPath(path, logsMap)
 }
 
 // certsEqual compares two cert-loader arrays for semantic equality via JSON normalization.
@@ -4526,11 +6522,18 @@ func (s *Server) listUsers(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	s.render(w, r, "users.html", map[string]any{
+	data := map[string]any{
 		"User":    s.currentUser(r),
 		"Users":   users,
 		"Section": "users",
-	})
+	}
+	if r.URL.Query().Get("invited") == "1" {
+		data["Invited"] = true
+	}
+	if e := r.URL.Query().Get("error"); e != "" {
+		data["Error"] = e
+	}
+	s.render(w, r, "users.html", data)
 }
 
 func (s *Server) newUser(w http.ResponseWriter, r *http.Request) {
@@ -5061,10 +7064,82 @@ func fetchCaddyUpstreams(adminURL string) map[string]caddyUpstreamInfo {
 	return out
 }
 
+// apiCaddyUpstreams proxies Caddy's /reverse_proxy/upstreams endpoint, returning
+// raw upstream health data from Caddy's admin API.
+// Returns JSON: {"upstreams": [...], "error": "..."}
+func (s *Server) apiCaddyUpstreams(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	sid := s.currentServerID(r)
+	srv, err := models.GetCaddyServer(s.DB, sid)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		_ = json.NewEncoder(w).Encode(map[string]any{"upstreams": nil, "error": err.Error()})
+		return
+	}
+	cl := caddy.New(srv.AdminURL, srv.AdminUsername, srv.AdminPassword)
+	upstreams, err := cl.GetUpstreamHealth(ctx)
+	if err != nil {
+		_ = json.NewEncoder(w).Encode(map[string]any{"upstreams": nil, "error": err.Error()})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"upstreams": upstreams})
+}
+
+// apiTestUpstream checks whether a given upstream host:port is reachable.
+// Accepts POST with form fields: host, port, scheme (http/https).
+// Returns JSON: {ok: bool, status: int, latency_ms: int, error: string}.
+func (s *Server) apiTestUpstream(w http.ResponseWriter, r *http.Request) {
+	if s.currentUser(r) == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	_ = r.ParseForm()
+	host := strings.TrimSpace(r.FormValue("host"))
+	port := strings.TrimSpace(r.FormValue("port"))
+	scheme := strings.TrimSpace(r.FormValue("scheme"))
+	if host == "" || port == "" {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "host and port are required"})
+		return
+	}
+	if scheme != "https" {
+		scheme = "http"
+	}
+	targetURL := fmt.Sprintf("%s://%s:%s/", scheme, host, port)
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	start := time.Now()
+	resp, err := client.Get(targetURL)
+	latencyMs := time.Since(start).Milliseconds()
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":         false,
+			"latency_ms": latencyMs,
+			"error":      err.Error(),
+		})
+		return
+	}
+	resp.Body.Close()
+	json.NewEncoder(w).Encode(map[string]any{
+		"ok":         resp.StatusCode < 500,
+		"status":     resp.StatusCode,
+		"latency_ms": latencyMs,
+		"error":      "",
+	})
+}
+
 // --- Feature F: Notifications (webhook + SMTP email) ---
 
 const (
 	settingNotifyWebhookURL    = "notify_webhook_url"
+	settingNotifyWebhookSecret = "notify_webhook_secret" // v2.9.12: HMAC-SHA256 signing secret
 	settingNotifyDaysBefore    = "notify_days_before"
 	defaultNotifyDaysBefore    = 14
 
@@ -5233,6 +7308,416 @@ func sendEmail(db *sql.DB, subject, body string) error {
 	}
 }
 
+// sendEmailTo is like sendEmail but sends to a specific address rather than
+// the configured notification recipients.
+func sendEmailTo(db *sql.DB, to, subject, body string) error {
+	host, _ := models.GetSetting(db, settingSMTPHost)
+	if host == "" {
+		return fmt.Errorf("SMTP not configured (no host)")
+	}
+	portStr, _ := models.GetSetting(db, settingSMTPPort)
+	port := 587
+	if p, err := strconv.Atoi(portStr); err == nil && p > 0 {
+		port = p
+	}
+	username, _ := models.GetSetting(db, settingSMTPUsername)
+	password, _ := models.GetSetting(db, settingSMTPPassword)
+	from, _ := models.GetSetting(db, settingSMTPFrom)
+	security, _ := models.GetSetting(db, settingSMTPSecurity)
+	skipVerifyStr, _ := models.GetSetting(db, settingSMTPSkipVerify)
+	skipVerify := skipVerifyStr == "1"
+
+	if from == "" {
+		from = "caddyui@localhost"
+	}
+
+	serverAddr := fmt.Sprintf("%s:%d", host, port)
+	msg := []byte(
+		"From: CaddyUI <" + from + ">\r\n" +
+			"To: " + to + "\r\n" +
+			"Subject: " + subject + "\r\n" +
+			"MIME-Version: 1.0\r\n" +
+			"Content-Type: text/plain; charset=utf-8\r\n" +
+			"\r\n" +
+			body,
+	)
+
+	tlsCfg := &tls.Config{ServerName: host, InsecureSkipVerify: skipVerify} //nolint:gosec
+
+	var authCfg smtp.Auth
+	if username != "" {
+		authCfg = smtp.PlainAuth("", username, password, host)
+	}
+
+	switch security {
+	case "tls":
+		conn, err := tls.Dial("tcp", serverAddr, tlsCfg)
+		if err != nil {
+			return fmt.Errorf("SMTP TLS dial: %w", err)
+		}
+		c, err := smtp.NewClient(conn, host)
+		if err != nil {
+			return fmt.Errorf("SMTP client: %w", err)
+		}
+		defer c.Quit()
+		if authCfg != nil {
+			if err = c.Auth(authCfg); err != nil {
+				return fmt.Errorf("SMTP auth: %w", err)
+			}
+		}
+		if err = c.Mail(from); err != nil {
+			return fmt.Errorf("SMTP MAIL FROM: %w", err)
+		}
+		if err = c.Rcpt(to); err != nil {
+			return fmt.Errorf("SMTP RCPT TO: %w", err)
+		}
+		wc, err := c.Data()
+		if err != nil {
+			return fmt.Errorf("SMTP DATA: %w", err)
+		}
+		_, _ = wc.Write(msg)
+		_ = wc.Close()
+	default: // "none" or "starttls"
+		if err := smtp.SendMail(serverAddr, authCfg, from, []string{to}, msg); err != nil {
+			return fmt.Errorf("SMTP SendMail: %w", err)
+		}
+	}
+	return nil
+}
+
+// --- Password reset ---
+
+// getForgotPassword renders the "forgot password" form.
+func (s *Server) getForgotPassword(w http.ResponseWriter, r *http.Request) {
+	s.render(w, r, "forgot_password.html", map[string]any{
+		"Section": "",
+		"Sent":    r.URL.Query().Get("sent") == "1",
+		"Error":   r.URL.Query().Get("error"),
+	})
+}
+
+// postForgotPassword processes the forgot-password form submission.
+// Always shows the "check your email" message even if the address doesn't
+// exist (prevents email enumeration).
+func (s *Server) postForgotPassword(w http.ResponseWriter, r *http.Request) {
+	email := strings.TrimSpace(strings.ToLower(r.FormValue("email")))
+	if email == "" {
+		http.Redirect(w, r, "/forgot-password?error=Enter+your+email+address", http.StatusSeeOther)
+		return
+	}
+	// Look up user — don't reveal if email exists.
+	u, _ := models.GetUserByEmail(s.DB, email)
+	if u != nil {
+		// Generate token.
+		raw := make([]byte, 32)
+		_, _ = rand.Read(raw)
+		token := hex.EncodeToString(raw)
+		hash := fmt.Sprintf("%x", sha256.Sum256([]byte(token)))
+		expires := time.Now().Add(time.Hour).Unix()
+		// Store token hash in settings: key=pw_reset_<hash>, value=<userID>:<expires>
+		_ = models.SetSetting(s.DB, "pw_reset_"+hash, fmt.Sprintf("%d:%d", u.ID, expires))
+		// Determine base URL for the reset link.
+		scheme := "https"
+		if r.TLS == nil {
+			scheme = "http"
+		}
+		resetURL := fmt.Sprintf("%s://%s/reset-password?token=%s", scheme, r.Host, token)
+		body := fmt.Sprintf(
+			"Hello %s,\n\nA password reset was requested for your CaddyUI account.\n\n"+
+				"Click the link below to set a new password (expires in 1 hour):\n\n"+
+				"%s\n\n"+
+				"If you did not request this, you can safely ignore this email.\n\n"+
+				"— CaddyUI", u.Name, resetURL)
+		if err := sendEmailTo(s.DB, email, "CaddyUI password reset", body); err != nil {
+			log.Printf("forgot-password: sendEmail to %s: %v", email, err)
+		}
+	}
+	http.Redirect(w, r, "/forgot-password?sent=1", http.StatusSeeOther)
+}
+
+// getResetPassword renders the new-password form for a valid reset token.
+func (s *Server) getResetPassword(w http.ResponseWriter, r *http.Request) {
+	token := strings.TrimSpace(r.URL.Query().Get("token"))
+	if token == "" {
+		http.Redirect(w, r, "/forgot-password?error=Invalid+reset+link", http.StatusSeeOther)
+		return
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(token)))
+	val, _ := models.GetSetting(s.DB, "pw_reset_"+hash)
+	if val == "" || !validResetToken(val) {
+		s.render(w, r, "reset_password.html", map[string]any{"Section": "", "Invalid": true})
+		return
+	}
+	s.render(w, r, "reset_password.html", map[string]any{
+		"Section": "",
+		"Token":   token,
+		"Error":   r.URL.Query().Get("error"),
+	})
+}
+
+// postResetPassword validates the token and sets the new password.
+func (s *Server) postResetPassword(w http.ResponseWriter, r *http.Request) {
+	token := strings.TrimSpace(r.FormValue("token"))
+	newPwd := r.FormValue("password")
+	confirmPwd := r.FormValue("confirm_password")
+
+	if token == "" {
+		http.Redirect(w, r, "/forgot-password?error=Invalid+token", http.StatusSeeOther)
+		return
+	}
+	if len(newPwd) < 8 {
+		http.Redirect(w, r, "/reset-password?token="+url.QueryEscape(token)+"&error=Password+must+be+at+least+8+characters", http.StatusSeeOther)
+		return
+	}
+	if newPwd != confirmPwd {
+		http.Redirect(w, r, "/reset-password?token="+url.QueryEscape(token)+"&error=Passwords+do+not+match", http.StatusSeeOther)
+		return
+	}
+
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(token)))
+	val, _ := models.GetSetting(s.DB, "pw_reset_"+hash)
+	if val == "" || !validResetToken(val) {
+		s.render(w, r, "reset_password.html", map[string]any{"Section": "", "Invalid": true})
+		return
+	}
+
+	// Parse userID from stored value.
+	parts := strings.SplitN(val, ":", 2)
+	userID, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		s.render(w, r, "reset_password.html", map[string]any{"Section": "", "Invalid": true})
+		return
+	}
+
+	// Hash new password.
+	pwHash, err := auth.HashPassword(newPwd)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if err := models.UpdateUserPassword(s.DB, userID, pwHash); err != nil {
+		http.Error(w, "failed to update password", http.StatusInternalServerError)
+		return
+	}
+	// Consume the token.
+	_ = models.SetSetting(s.DB, "pw_reset_"+hash, "")
+	http.Redirect(w, r, "/login?reset=1", http.StatusSeeOther)
+}
+
+// postInviteUser creates a stub user account and sends an invite email.
+func (s *Server) postInviteUser(w http.ResponseWriter, r *http.Request) {
+	email := strings.TrimSpace(strings.ToLower(r.FormValue("invite_email")))
+	role := r.FormValue("invite_role")
+	if email == "" {
+		http.Redirect(w, r, "/users?error=Email+required", http.StatusSeeOther)
+		return
+	}
+	if role != models.RoleAdmin && role != models.RoleUser && role != models.RoleView {
+		role = models.RoleUser
+	}
+	// Check not already registered.
+	if u, _ := models.GetUserByEmail(s.DB, email); u != nil {
+		http.Redirect(w, r, "/users?error=User+already+exists", http.StatusSeeOther)
+		return
+	}
+	// Create disabled stub user with empty password hash.
+	userID, err := models.CreateUser(s.DB, email, "", email, role)
+	if err != nil {
+		http.Error(w, "create user: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Generate invite token.
+	raw := make([]byte, 32)
+	_, _ = rand.Read(raw)
+	token := hex.EncodeToString(raw)
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(token)))
+	expires := time.Now().Add(7 * 24 * time.Hour).Unix()
+	_ = models.SetSetting(s.DB, "invite_"+hash, fmt.Sprintf("%d:%d", userID, expires))
+
+	scheme := "https"
+	if r.TLS == nil {
+		scheme = "http"
+	}
+	acceptURL := fmt.Sprintf("%s://%s/accept-invite?token=%s", scheme, r.Host, token)
+	body := fmt.Sprintf(
+		"You've been invited to CaddyUI.\n\n"+
+			"Click the link below to set your password and activate your account (link expires in 7 days):\n\n"+
+			"%s\n\n"+
+			"— CaddyUI", acceptURL)
+	if err := sendEmailTo(s.DB, email, "You're invited to CaddyUI", body); err != nil {
+		log.Printf("invite: sendEmail to %s: %v", email, err)
+	}
+	http.Redirect(w, r, "/users?invited=1", http.StatusSeeOther)
+}
+
+// getAcceptInvite renders the accept-invite form.
+func (s *Server) getAcceptInvite(w http.ResponseWriter, r *http.Request) {
+	token := strings.TrimSpace(r.URL.Query().Get("token"))
+	if token == "" {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(token)))
+	val, _ := models.GetSetting(s.DB, "invite_"+hash)
+	if val == "" || !validResetToken(val) {
+		s.render(w, r, "accept_invite.html", map[string]any{"Section": "", "Invalid": true})
+		return
+	}
+	s.render(w, r, "accept_invite.html", map[string]any{
+		"Section": "",
+		"Token":   token,
+		"Error":   r.URL.Query().Get("error"),
+	})
+}
+
+// postAcceptInvite validates the invite token and activates the account.
+func (s *Server) postAcceptInvite(w http.ResponseWriter, r *http.Request) {
+	token := strings.TrimSpace(r.FormValue("token"))
+	newPwd := r.FormValue("password")
+	confirmPwd := r.FormValue("confirm_password")
+	if token == "" {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+	if len(newPwd) < 8 {
+		http.Redirect(w, r, "/accept-invite?token="+url.QueryEscape(token)+"&error=Password+must+be+at+least+8+characters", http.StatusSeeOther)
+		return
+	}
+	if newPwd != confirmPwd {
+		http.Redirect(w, r, "/accept-invite?token="+url.QueryEscape(token)+"&error=Passwords+do+not+match", http.StatusSeeOther)
+		return
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(token)))
+	val, _ := models.GetSetting(s.DB, "invite_"+hash)
+	if val == "" || !validResetToken(val) {
+		s.render(w, r, "accept_invite.html", map[string]any{"Section": "", "Invalid": true})
+		return
+	}
+	parts := strings.SplitN(val, ":", 2)
+	userID, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		http.Error(w, "invalid token", http.StatusBadRequest)
+		return
+	}
+	pwHash, err := auth.HashPassword(newPwd)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if err := models.UpdateUserPassword(s.DB, userID, pwHash); err != nil {
+		http.Error(w, "update password: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = models.SetSetting(s.DB, "invite_"+hash, "")
+	http.Redirect(w, r, "/login?invited=1", http.StatusSeeOther)
+}
+
+// exportProxyHost returns a proxy host's configuration as a JSON file download.
+func (s *Server) exportProxyHost(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	ph, err := models.GetProxyHost(s.DB, id)
+	if err != nil || ph == nil {
+		http.NotFound(w, r)
+		return
+	}
+	// Strip runtime fields before export.
+	ph.ID = 0
+	ph.OwnerID = sql.NullInt64{}
+	ph.OwnerEmail = ""
+	ph.DNSRecordID = ""
+	ph.CreatedAt = time.Time{}
+	ph.UpdatedAt = time.Time{}
+
+	data, err := json.MarshalIndent(ph, "", "  ")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	fname := strings.ReplaceAll(strings.SplitN(ph.Domains, ",", 2)[0], "*", "_")
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.json"`, strings.TrimSpace(fname)))
+	_, _ = w.Write(data)
+}
+
+// exportAllProxyHosts downloads all proxy hosts for the current server as a JSON array.
+// Admin exports the full list; non-admin exports only their own hosts.
+func (s *Server) exportAllProxyHosts(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	isAdmin := cu.Role == models.RoleAdmin
+	var viewerID int64
+	if !isAdmin {
+		viewerID = cu.ID
+	}
+	sid := s.currentServerID(r)
+	hosts, err := models.ListProxyHosts(s.DB, sid, viewerID, isAdmin, s.groupPeerIDs(r))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	ts := time.Now().Format("20060102-150405")
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="proxy-hosts-%s.json"`, ts))
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(hosts)
+}
+
+// importProxyHost creates a new proxy host from an uploaded JSON file.
+func (s *Server) importProxyHost(w http.ResponseWriter, r *http.Request) {
+	r.ParseMultipartForm(1 << 20) // 1 MiB
+	f, _, err := r.FormFile("config_file")
+	if err != nil {
+		http.Error(w, "no file: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, 1<<20))
+	if err != nil {
+		http.Error(w, "read: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	var ph models.ProxyHost
+	if err := json.Unmarshal(data, &ph); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	// Force safe defaults.
+	ph.ID = 0
+	ph.Enabled = false
+	cu := s.currentUser(r)
+	var ownerID int64
+	if cu != nil {
+		ownerID = cu.ID
+	}
+	newID, err := models.CreateProxyHost(s.DB, s.currentServerID(r), ownerID, &ph)
+	if err != nil {
+		http.Error(w, "create: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, fmt.Sprintf("/proxy-hosts/%d/edit", newID), http.StatusSeeOther)
+}
+
+// validResetToken checks the token value (format: "userID:expiresUnix") is still valid.
+func validResetToken(val string) bool {
+	parts := strings.SplitN(val, ":", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	exp, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return false
+	}
+	return time.Now().Unix() < exp
+}
+
 // --- Upstream health notifier ---
 
 // upstreamAlertEntry records a single upstream state-change notification.
@@ -5250,6 +7735,70 @@ var upstreamNotifyState struct {
 	prevFails map[string]bool // key "serverID:address" → was failing on last check?
 	lastCheck time.Time
 	recent    []upstreamAlertEntry
+}
+
+// runHealthChecker polls each enabled proxy host every 5 minutes and records
+// the result in proxy_health. It checks the first domain of each host via HTTPS
+// (falling back to HTTP if ssl_enabled is false). Runs until the process exits.
+func (s *Server) runHealthChecker() {
+	// Stagger the first check by 30 seconds so startup load doesn't spike.
+	time.Sleep(30 * time.Second)
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	s.checkAllProxyHosts()
+	for range ticker.C {
+		s.checkAllProxyHosts()
+	}
+}
+
+func (s *Server) checkAllProxyHosts() {
+	servers, err := models.ListCaddyServers(s.DB)
+	if err != nil {
+		log.Printf("health checker: list servers: %v", err)
+		return
+	}
+	for _, srv := range servers {
+		hosts, err := models.ListProxyHosts(s.DB, srv.ID, 0, true, nil)
+		if err != nil {
+			log.Printf("health checker: list hosts for server %d: %v", srv.ID, err)
+			continue
+		}
+		for _, h := range hosts {
+			if !h.Enabled {
+				continue
+			}
+			domains := h.DomainList()
+			if len(domains) == 0 {
+				continue
+			}
+			domain := domains[0]
+			scheme := "https"
+			if !h.SSLEnabled {
+				scheme = "http"
+			}
+			targetURL := scheme + "://" + domain + "/"
+			s.checkProxyHost(h.ID, targetURL)
+		}
+	}
+}
+
+func (s *Server) checkProxyHost(hostID int64, targetURL string) {
+	start := time.Now()
+	resp, err := s.healthClient.Get(targetURL)
+	latencyMs := time.Since(start).Milliseconds()
+	if err != nil {
+		errMsg := err.Error()
+		if len(errMsg) > 200 {
+			errMsg = errMsg[:200]
+		}
+		_ = models.InsertProxyHealth(s.DB, hostID, false, 0, latencyMs, errMsg)
+		return
+	}
+	defer resp.Body.Close()
+	// Drain body to free connection.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	ok := resp.StatusCode < 400 || resp.StatusCode == 401 || resp.StatusCode == 403
+	_ = models.InsertProxyHealth(s.DB, hostID, ok, resp.StatusCode, latencyMs, "")
 }
 
 // StartUpstreamNotifier launches a goroutine that checks upstream health every 5 minutes.
@@ -5325,9 +7874,7 @@ func runUpstreamCheck(db *sql.DB) {
 					"server":   srv.Name,
 					"upstream": addr,
 				})
-				if resp, err := http.Post(webhookURL, "application/json", bytes.NewReader(payload)); err == nil {
-					_ = resp.Body.Close()
-				}
+				sendWebhookPayload(db, webhookURL, payload)
 			}
 			// Send email.
 			if emailOK {
@@ -5454,13 +8001,8 @@ func runNotifierCheck(db *sql.DB) {
 				"domain":    domain,
 				"days_left": daysLeft,
 			})
-			resp, err := http.Post(webhookURL, "application/json", bytes.NewReader(payload))
-			if err != nil {
-				log.Printf("notifier: webhook POST failed: %v", err)
-			} else {
-				_ = resp.Body.Close()
-				sent = true
-			}
+			sendWebhookPayload(db, webhookURL, payload)
+			sent = true
 		}
 
 		// Email notification.
@@ -5486,6 +8028,30 @@ func runNotifierCheck(db *sql.DB) {
 			log.Printf("notifier: sent cert-expiry notification for %q (%d days left)", domain, daysLeft)
 		}
 	}
+}
+
+// sendWebhookPayload POSTs a JSON payload to webhookURL. If a secret is configured
+// in the DB (settingNotifyWebhookSecret), it adds an X-Signature-256 header
+// containing the HMAC-SHA256 of the payload body in hex, prefixed "sha256=".
+// The format is compatible with GitHub's webhook delivery signature.
+func sendWebhookPayload(db *sql.DB, webhookURL string, payload []byte) {
+	req, err := http.NewRequest(http.MethodPost, webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		log.Printf("sendWebhook: create request: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if secret, _ := models.GetSetting(db, settingNotifyWebhookSecret); secret != "" {
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write(payload)
+		req.Header.Set("X-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("sendWebhook: POST %s: %v", webhookURL, err)
+		return
+	}
+	_ = resp.Body.Close()
 }
 
 func (s *Server) apiNotifierStatus(w http.ResponseWriter, r *http.Request) {
@@ -5596,6 +8162,19 @@ func (s *Server) apiSystemStats(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(stats)
+}
+
+// apiCaddyVersion returns the running Caddy version from the admin API.
+func (s *Server) apiCaddyVersion(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+	defer cancel()
+	version, err := s.Caddy.GetVersion(ctx)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		json.NewEncoder(w).Encode(map[string]any{"version": "unknown", "error": err.Error()})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]any{"version": version})
 }
 
 // apiVersionCheck returns the running version and the latest Docker Hub tag,
@@ -6762,6 +9341,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	s.render(w, r, "settings.html", map[string]any{
 		"User":               s.currentUser(r),
 		"WebhookURL":         webhookURL,
+		"WebhookSecret":      mustGetSetting(s.DB, settingNotifyWebhookSecret),
 		"DaysBefore":         daysBefore,
 		"SMTPHost":           smtpHost,
 		"SMTPPort":           smtpPort,
@@ -6804,13 +9384,30 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		"AnalyticsTargetPlaceholder": defaultAnalyticsIngestTarget,
 		"AnalyticsExcludeRaw":   analyticsCfg.ExcludeRaw,
 		"AnalyticsIngestStats":  analyticsIngestSnap,
-		"Section":     "settings",
+		// v2.9.5: 2FA enforcement policy
+		"Require2FA":      mustGetSetting(s.DB, settingRequire2FA),
+		"RequireTOTP":     mustGetSetting(s.DB, settingRequireTOTP),
+		// v2.10.0: trusted proxies + custom site title
+		"TrustedProxies":  mustGetSetting(s.DB, settingTrustedProxies),
+		"SiteTitle":       mustGetSetting(s.DB, settingSiteTitle),
+		// v2.11.0: custom favicon + admin IP allowlist
+		"FaviconURL":      mustGetSetting(s.DB, settingFaviconURL),
+		"AdminAllowlist":  mustGetSetting(s.DB, settingAdminAllowlist),
+		// v2.12.0: configurable session duration + global catch-all 404
+		"SessionDays":        mustGetSetting(s.DB, settingSessionDays),
+		"CatchAll404HTML":    mustGetSetting(s.DB, settingCatchAll404HTML),
+		"GlobalMaintenance":    mustGetSetting(s.DB, settingGlobalMaintenance),
+		"AutoSyncHours":        mustGetSetting(s.DB, settingAutoSyncHours),
+		"ActivityLogDays":      mustGetSetting(s.DB, settingActivityLogDays),
+		"MaxLoginAttempts":     mustGetSetting(s.DB, settingMaxLoginAttempts),
+		"Section":              "settings",
 	})
 }
 
 func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 	_ = r.ParseForm()
 	webhookURL := strings.TrimSpace(r.FormValue("webhook_url"))
+	webhookSecret := strings.TrimSpace(r.FormValue("webhook_secret"))
 	daysBeforeStr := strings.TrimSpace(r.FormValue("days_before"))
 	daysBefore := defaultNotifyDaysBefore
 	if d, err := strconv.Atoi(daysBeforeStr); err == nil && d > 0 {
@@ -6925,9 +9522,24 @@ func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 	oldServerIP := s.serverIP()
 
 	kv := map[string]string{
-		settingNotifyWebhookURL:   webhookURL,
-		settingNotifyDaysBefore:   strconv.Itoa(daysBefore),
+		settingNotifyWebhookURL:    webhookURL,
+		settingNotifyWebhookSecret: webhookSecret,
+		settingNotifyDaysBefore:    strconv.Itoa(daysBefore),
 		settingSMTPHost:           smtpHost,
+		// v2.9.5: 2FA enforcement policy (checkbox → "on" when checked).
+		settingRequire2FA: func() string {
+			if r.FormValue("require_2fa") == "on" {
+				return "1"
+			}
+			return "0"
+		}(),
+		// require_totp toggle uses value="1" checkbox pattern.
+		settingRequireTOTP: func() string {
+			if r.FormValue("require_totp") == "1" {
+				return "1"
+			}
+			return "0"
+		}(),
 		settingSMTPPort:           smtpPort,
 		settingSMTPUsername:       smtpUsername,
 		settingSMTPFrom:           smtpFrom,
@@ -6947,6 +9559,48 @@ func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 		settingAnalyticsEnabled:      analyticsEnabled,
 		settingAnalyticsIngestTarget: analyticsTarget,
 		settingAnalyticsExcludeIPs:   analyticsExclude,
+		// v2.10.0: trusted proxies + custom site title
+		settingTrustedProxies: strings.TrimSpace(r.FormValue("trusted_proxies")),
+		settingSiteTitle:      strings.TrimSpace(r.FormValue("site_title")),
+		// v2.11.0: custom favicon + admin IP allowlist
+		settingFaviconURL:     strings.TrimSpace(r.FormValue("favicon_url")),
+		settingAdminAllowlist: strings.TrimSpace(r.FormValue("admin_allowlist")),
+		// v2.12.0: configurable session duration + global catch-all 404
+		settingCatchAll404HTML: strings.TrimSpace(r.FormValue("catch_all_404_html")),
+		// Global maintenance mode: checkbox → "1"/"0"
+		settingGlobalMaintenance: func() string {
+			if r.FormValue("global_maintenance") == "1" {
+				return "1"
+			}
+			return "0"
+		}(),
+	}
+	if sessionDays := strings.TrimSpace(r.FormValue("session_duration_days")); sessionDays != "" {
+		kv[settingSessionDays] = sessionDays
+	}
+	// Auto-sync hours: "0" or empty = disabled.
+	if autoSyncHours := strings.TrimSpace(r.FormValue("auto_sync_hours")); autoSyncHours != "" {
+		if h, err := strconv.Atoi(autoSyncHours); err == nil && h >= 0 {
+			kv[settingAutoSyncHours] = strconv.Itoa(h)
+		}
+	} else {
+		kv[settingAutoSyncHours] = "0"
+	}
+	// Activity log retention days: 0 = keep forever.
+	if aldStr := strings.TrimSpace(r.FormValue("activity_log_days")); aldStr != "" {
+		if d, err := strconv.Atoi(aldStr); err == nil && d >= 0 {
+			kv[settingActivityLogDays] = strconv.Itoa(d)
+		}
+	} else {
+		kv[settingActivityLogDays] = "0"
+	}
+	// Max login attempts per IP: 0 = no limit.
+	if mlaStr := strings.TrimSpace(r.FormValue("max_login_attempts")); mlaStr != "" {
+		if n, err := strconv.Atoi(mlaStr); err == nil && n >= 0 {
+			kv[settingMaxLoginAttempts] = strconv.Itoa(n)
+		}
+	} else {
+		kv[settingMaxLoginAttempts] = "0"
 	}
 
 	// Walk every registered DNS provider and pick up credential fields
@@ -7140,3 +9794,841 @@ func (s *Server) postTestEmail(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 }
+
+// --- API Tokens ---
+
+func (s *Server) listAPITokens(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	isAdmin := cu != nil && cu.Role == models.RoleAdmin
+	tokens, err := models.ListAPITokens(s.DB, cu.ID, isAdmin)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	createdToken := r.URL.Query().Get("created")
+	s.render(w, r, "api_tokens.html", map[string]any{
+		"User":         cu,
+		"Tokens":       tokens,
+		"IsAdmin":      isAdmin,
+		"Section":      "api_tokens",
+		"CreatedToken": createdToken,
+	})
+}
+
+func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	_ = r.ParseForm()
+	name := strings.TrimSpace(r.FormValue("name"))
+	if name == "" {
+		name = "My token"
+	}
+	// Generate 32 random bytes → base64url → prefix "cadu_"
+	rawBytes := make([]byte, 32)
+	if _, err := rand.Read(rawBytes); err != nil {
+		http.Error(w, "could not generate token", http.StatusInternalServerError)
+		return
+	}
+	rawToken := "cadu_" + base64.RawURLEncoding.EncodeToString(rawBytes)
+	h := sha256.Sum256([]byte(rawToken))
+	hash := fmt.Sprintf("%x", h)
+	// Optional expiry
+	var expiresAt *time.Time
+	if exp := strings.TrimSpace(r.FormValue("expires_at")); exp != "" {
+		t, err := time.ParseInLocation("2006-01-02", exp, time.UTC)
+		if err == nil {
+			expiresAt = &t
+		}
+	}
+	scopes := strings.TrimSpace(r.FormValue("scopes"))
+	switch scopes {
+	case models.TokenScopeReadOnly, models.TokenScopeProxyWrite:
+		// valid
+	default:
+		scopes = models.TokenScopeFull
+	}
+	_, err := models.CreateAPIToken(s.DB, cu.ID, name, hash, scopes, expiresAt)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = models.LogActivity(s.DB, s.currentServerID(r), cu.Email, "api_token_create", "token", name, true)
+	// Show the token once via a query param on redirect to the list page
+	// (only used once, HTTPS only).
+	http.Redirect(w, r, "/api-tokens?created="+url.QueryEscape(rawToken), http.StatusSeeOther)
+}
+
+func (s *Server) revokeAPIToken(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	// Admin can revoke any token; user can only revoke their own.
+	ownerID := cu.ID
+	if cu.Role == models.RoleAdmin {
+		ownerID = 0 // skip ownership check
+	}
+	if err := models.DeleteAPIToken(s.DB, id, ownerID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = models.LogActivity(s.DB, s.currentServerID(r), cu.Email, "api_token_revoke", fmt.Sprintf("token:%d", id), "", true)
+	http.Redirect(w, r, "/api-tokens", http.StatusSeeOther)
+}
+
+// getLiveTraffic renders the live traffic feed page.
+func (s *Server) getLiveTraffic(w http.ResponseWriter, r *http.Request) {
+	u := s.currentUser(r)
+	// Seed with last 50 events for initial load.
+	events, err := models.RecentAccessEvents(s.DB, 0, 50)
+	if err != nil {
+		log.Printf("live-traffic: query: %v", err)
+	}
+	s.render(w, r, "live_traffic.html", map[string]any{
+		"User":    u,
+		"Events":  events,
+		"Section": "live_traffic",
+	})
+}
+
+// liveTrafficStream is an SSE endpoint that pushes new access events as they
+// arrive. The client sends a ?since=<id> query param (the highest ID it has
+// seen); the server polls every 2s and emits any rows with id > since as a
+// JSON array in the SSE "data" field. The client advances its cursor.
+func (s *Server) liveTrafficStream(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering
+	w.Header().Set("Connection", "keep-alive")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "SSE not supported", http.StatusInternalServerError)
+		return
+	}
+
+	var cursor int64
+	if raw := r.URL.Query().Get("since"); raw != "" {
+		if n, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			cursor = n
+		}
+	}
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			events, err := models.RecentAccessEvents(s.DB, cursor, 100)
+			if err != nil {
+				log.Printf("live-traffic SSE: %v", err)
+				continue
+			}
+			if len(events) == 0 {
+				// heartbeat
+				fmt.Fprintf(w, ": ping\n\n")
+				flusher.Flush()
+				continue
+			}
+			// Advance cursor to highest ID seen.
+			for _, e := range events {
+				if e.ID > cursor {
+					cursor = e.ID
+				}
+			}
+			// Events come newest-first; reverse so the client appends in order.
+			for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
+				events[i], events[j] = events[j], events[i]
+			}
+			type wireEvent struct {
+				ID         int64  `json:"id"`
+				TS         string `json:"ts"`
+				Host       string `json:"host"`
+				Path       string `json:"path"`
+				Method     string `json:"method"`
+				Status     int    `json:"status"`
+				ClientIP   string `json:"client_ip"`
+				DurationMs int64  `json:"duration_ms"`
+				BytesOut   int64  `json:"bytes_out"`
+			}
+			wire := make([]wireEvent, len(events))
+			for i, e := range events {
+				wire[i] = wireEvent{
+					ID:         e.ID,
+					TS:         e.TS.Format(time.RFC3339),
+					Host:       e.Host,
+					Path:       e.Path,
+					Method:     e.Method,
+					Status:     e.Status,
+					ClientIP:   e.ClientIP,
+					DurationMs: e.DurationMs,
+					BytesOut:   e.BytesOut,
+				}
+			}
+			data, _ := json.Marshal(wire)
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		}
+	}
+}
+
+// getProfile renders the logged-in user's profile page (name + password change).
+func (s *Server) getProfile(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil {
+		http.Redirect(w, r, "/login", http.StatusFound)
+		return
+	}
+	s.render(w, r, "profile.html", map[string]any{
+		"User":  cu,
+		"Flash": r.URL.Query().Get("flash"),
+		"Error": r.URL.Query().Get("error"),
+	})
+}
+
+// postProfile handles name update and password change on the profile page.
+func (s *Server) postProfile(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil {
+		http.Redirect(w, r, "/login", http.StatusFound)
+		return
+	}
+	action := r.FormValue("action")
+	switch action {
+	case "update_name":
+		name := strings.TrimSpace(r.FormValue("name"))
+		if name == "" {
+			http.Redirect(w, r, "/profile?error=Name+cannot+be+empty", http.StatusFound)
+			return
+		}
+		if _, err := s.DB.Exec(`UPDATE users SET name=? WHERE id=?`, name, cu.ID); err != nil {
+			log.Printf("profile update_name: %v", err)
+			http.Redirect(w, r, "/profile?error=Failed+to+update+name", http.StatusFound)
+			return
+		}
+		_ = models.LogActivity(s.DB, s.currentServerID(r), cu.Email, "profile_update_name", "", "", true)
+		http.Redirect(w, r, "/profile?flash=Name+updated+successfully", http.StatusFound)
+	case "change_password":
+		currentPw := r.FormValue("current_password")
+		newPw := r.FormValue("new_password")
+		confirmPw := r.FormValue("confirm_password")
+		if newPw != confirmPw {
+			http.Redirect(w, r, "/profile?error=New+passwords+do+not+match", http.StatusFound)
+			return
+		}
+		if len(newPw) < 8 {
+			http.Redirect(w, r, "/profile?error=Password+must+be+at+least+8+characters", http.StatusFound)
+			return
+		}
+		u, err := models.GetUserByEmail(s.DB, cu.Email)
+		if err != nil || !auth.CheckPassword(u.PasswordHash, currentPw) {
+			http.Redirect(w, r, "/profile?error=Current+password+is+incorrect", http.StatusFound)
+			return
+		}
+		hash, err := auth.HashPassword(newPw)
+		if err != nil {
+			http.Redirect(w, r, "/profile?error=Failed+to+hash+password", http.StatusFound)
+			return
+		}
+		if _, err := s.DB.Exec(`UPDATE users SET password_hash=? WHERE id=?`, hash, cu.ID); err != nil {
+			log.Printf("profile change_password: %v", err)
+			http.Redirect(w, r, "/profile?error=Failed+to+update+password", http.StatusFound)
+			return
+		}
+		_ = models.LogActivity(s.DB, s.currentServerID(r), cu.Email, "profile_change_password", "", "", true)
+		http.Redirect(w, r, "/profile?flash=Password+changed+successfully", http.StatusFound)
+	default:
+		http.Redirect(w, r, "/profile", http.StatusFound)
+	}
+}
+
+// getCaddyConfig fetches the live Caddy JSON config and renders it in a
+// read-only prettified code block. Available to all authenticated users.
+func (s *Server) getCaddyConfig(w http.ResponseWriter, r *http.Request) {
+	_, rawJSON, err := s.caddyForRequest(r).FetchConfig()
+	if err != nil {
+		s.render(w, r, "caddy_config.html", map[string]any{
+			"User":    s.currentUser(r),
+			"Section": "caddy_config",
+			"Error":   "Could not fetch Caddy config: " + err.Error(),
+		})
+		return
+	}
+	// Pretty-print the JSON for readability.
+	var v any
+	if err := json.Unmarshal([]byte(rawJSON), &v); err == nil {
+		if b, err := json.MarshalIndent(v, "", "  "); err == nil {
+			rawJSON = string(b)
+		}
+	}
+	s.render(w, r, "caddy_config.html", map[string]any{
+		"User":       s.currentUser(r),
+		"Section":    "caddy_config",
+		"ConfigJSON": rawJSON,
+	})
+}
+
+// ─── REST JSON API v1 ─────────────────────────────────────────────────────────
+//
+// All endpoints are under /api/v1/ and live inside the requireAuth middleware
+// group, so both session cookies and Bearer API tokens are accepted.
+// Write endpoints (POST/PUT/DELETE) additionally require a write-scoped token
+// or an admin/write role — the requireWrite middleware enforces that at the
+// chi group level.
+
+// apiProxyHostInput is the JSON request body for create / update.
+type apiProxyHostInput struct {
+	Domains                string `json:"domains"`
+	ForwardScheme          string `json:"forward_scheme"`
+	ForwardHost            string `json:"forward_host"`
+	ForwardPort            int    `json:"forward_port"`
+	WebsocketSupport       bool   `json:"websocket_support"`
+	BlockCommonExploits    bool   `json:"block_common_exploits"`
+	SSLEnabled             bool   `json:"ssl_enabled"`
+	SSLForced              bool   `json:"ssl_forced"`
+	HTTP2Support           bool   `json:"http2_support"`
+	Enabled                bool   `json:"enabled"`
+	CertificateID          int64  `json:"certificate_id"`
+	BasicAuthEnabled       bool   `json:"basicauth_enabled"`
+	AccessList             string `json:"access_list"`
+	IPBlocklist            string `json:"ip_blocklist"`
+	ExtraUpstreams         string `json:"extra_upstreams"`
+	CompressionEnabled     bool   `json:"compression_enabled"`
+	SecurityHeadersEnabled bool   `json:"security_headers_enabled"`
+	TLSMinVersion          string `json:"tls_min_version"`
+	MaintenanceMode        bool   `json:"maintenance_mode"`
+	MaintenanceMsg         string `json:"maintenance_msg"`
+	MaxRequestBodyMB       int    `json:"max_request_body_mb"`
+	StickySessions         bool   `json:"sticky_sessions"`
+	LBPolicy               string `json:"lb_policy"`
+	UpstreamTimeoutSec     int    `json:"upstream_timeout_sec"`
+	CORSEnabled            bool   `json:"cors_enabled"`
+	CORSOrigins            string `json:"cors_origins"`
+	HealthCheckURI         string `json:"health_check_uri"`
+	HealthCheckIntervalSec int    `json:"health_check_interval_sec"`
+	HealthCheckMethod      string `json:"health_check_method"`
+	KeepaliveConns         int    `json:"keepalive_conns"`
+	Tags                   string `json:"tags"`
+	Notes                  string `json:"notes"`
+	DisableAccessLog       bool   `json:"disable_access_log"`
+	AddRequestID           bool   `json:"add_request_id"`
+	StripRespHeaders       string `json:"strip_resp_headers"`
+	BlockedAgents          string `json:"blocked_agents"`
+	UpstreamSNI            string `json:"upstream_sni"`
+	HSTSPreload            bool   `json:"hsts_preload"`
+	MaxConnsPerHost        int    `json:"max_conns_per_host"`
+	UpstreamRetries        int    `json:"upstream_retries"`
+	ForceHTTP1             bool   `json:"force_http1"`
+	ProxyProtocol          string `json:"proxy_protocol"`
+}
+
+// proxyHostToAPIMap converts a ProxyHost to a JSON-serialisable map.
+func proxyHostToAPIMap(p *models.ProxyHost) map[string]any {
+	return map[string]any{
+		"id":                       p.ID,
+		"server_id":                p.ServerID,
+		"domains":                  p.Domains,
+		"forward_scheme":           p.ForwardScheme,
+		"forward_host":             p.ForwardHost,
+		"forward_port":             p.ForwardPort,
+		"websocket_support":        p.WebsocketSupport,
+		"block_common_exploits":    p.BlockCommonExploits,
+		"ssl_enabled":              p.SSLEnabled,
+		"ssl_forced":               p.SSLForced,
+		"http2_support":            p.HTTP2Support,
+		"enabled":                  p.Enabled,
+		"certificate_id":           p.CertificateID,
+		"basicauth_enabled":        p.BasicAuthEnabled,
+		"access_list":              p.AccessList,
+		"ip_blocklist":             p.IPBlocklist,
+		"extra_upstreams":          p.ExtraUpstreams,
+		"compression_enabled":      p.CompressionEnabled,
+		"security_headers_enabled": p.SecurityHeadersEnabled,
+		"tls_min_version":          p.TLSMinVersion,
+		"maintenance_mode":         p.MaintenanceMode,
+		"maintenance_msg":          p.MaintenanceMsg,
+		"max_request_body_mb":      p.MaxRequestBodyMB,
+		"sticky_sessions":          p.StickySessions,
+		"lb_policy":                p.LBPolicy,
+		"upstream_timeout_sec":     p.UpstreamTimeoutSec,
+		"cors_enabled":             p.CORSEnabled,
+		"cors_origins":             p.CORSOrigins,
+		"health_check_uri":         p.HealthCheckURI,
+		"health_check_interval_sec": p.HealthCheckIntervalSec,
+		"health_check_method":      p.HealthCheckMethod,
+		"keepalive_conns":          p.KeepaliveConns,
+		"tags":                     p.Tags,
+		"notes":                    p.Notes,
+		"disable_access_log":       p.DisableAccessLog,
+		"add_request_id":           p.AddRequestID,
+		"strip_resp_headers":       p.StripRespHeaders,
+		"blocked_agents":           p.BlockedAgents,
+		"upstream_sni":             p.UpstreamSNI,
+		"hsts_preload":             p.HSTSPreload,
+		"max_conns_per_host":       p.MaxConnsPerHost,
+		"upstream_retries":         p.UpstreamRetries,
+		"force_http1":              p.ForceHTTP1,
+		"proxy_protocol":           p.ProxyProtocol,
+		"owner_email":              p.OwnerEmail,
+		"created_at":               p.CreatedAt,
+		"updated_at":               p.UpdatedAt,
+	}
+}
+
+// writeJSON is a convenience wrapper that sets Content-Type and encodes v as JSON.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// GET /api/v1/proxy-hosts
+func (s *Server) apiV1ListProxyHosts(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil {
+		writeJSONError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	serverID := s.currentServerID(r)
+	hosts, err := models.ListProxyHosts(s.DB, serverID, cu.ID, cu.IsAdmin, nil)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	out := make([]map[string]any, 0, len(hosts))
+	for i := range hosts {
+		out = append(out, proxyHostToAPIMap(&hosts[i]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// GET /api/v1/proxy-hosts/{id}
+func (s *Server) apiV1GetProxyHost(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	ph, err := models.GetProxyHost(s.DB, id)
+	if err != nil || ph == nil {
+		writeJSONError(w, http.StatusNotFound, "not found")
+		return
+	}
+	if cu == nil || (!cu.IsAdmin && ph.OwnerID.Valid && ph.OwnerID.Int64 != cu.ID) {
+		writeJSONError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+	writeJSON(w, http.StatusOK, proxyHostToAPIMap(ph))
+}
+
+// POST /api/v1/proxy-hosts
+func (s *Server) apiV1CreateProxyHost(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil {
+		writeJSONError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var inp apiProxyHostInput
+	if err := json.NewDecoder(r.Body).Decode(&inp); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if inp.Domains == "" || inp.ForwardHost == "" || inp.ForwardPort == 0 {
+		writeJSONError(w, http.StatusBadRequest, "domains, forward_host, and forward_port are required")
+		return
+	}
+	if inp.ForwardScheme == "" {
+		inp.ForwardScheme = "http"
+	}
+	if inp.HealthCheckMethod == "" {
+		inp.HealthCheckMethod = "GET"
+	}
+	ph := &models.ProxyHost{
+		Domains: inp.Domains, ForwardScheme: inp.ForwardScheme,
+		ForwardHost: inp.ForwardHost, ForwardPort: inp.ForwardPort,
+		WebsocketSupport: inp.WebsocketSupport, BlockCommonExploits: inp.BlockCommonExploits,
+		SSLEnabled: inp.SSLEnabled, SSLForced: inp.SSLForced, HTTP2Support: inp.HTTP2Support,
+		Enabled: inp.Enabled, CertificateID: inp.CertificateID,
+		BasicAuthEnabled: inp.BasicAuthEnabled, BasicAuthUsers: "[]",
+		AccessList: inp.AccessList, IPBlocklist: inp.IPBlocklist,
+		ExtraUpstreams: func() string {
+			if inp.ExtraUpstreams == "" {
+				return "[]"
+			}
+			return inp.ExtraUpstreams
+		}(),
+		CompressionEnabled: inp.CompressionEnabled, SecurityHeadersEnabled: inp.SecurityHeadersEnabled,
+		TLSMinVersion: inp.TLSMinVersion,
+		MaintenanceMode: inp.MaintenanceMode, MaintenanceMsg: inp.MaintenanceMsg,
+		MaxRequestBodyMB: inp.MaxRequestBodyMB, StickySessions: inp.StickySessions,
+		LBPolicy: inp.LBPolicy, UpstreamTimeoutSec: inp.UpstreamTimeoutSec,
+		CORSEnabled: inp.CORSEnabled, CORSOrigins: func() string {
+			if inp.CORSOrigins == "" { return "*" }; return inp.CORSOrigins
+		}(),
+		HealthCheckURI: inp.HealthCheckURI, HealthCheckIntervalSec: func() int {
+			if inp.HealthCheckIntervalSec <= 0 { return 30 }; return inp.HealthCheckIntervalSec
+		}(),
+		HealthCheckMethod: inp.HealthCheckMethod, KeepaliveConns: inp.KeepaliveConns,
+		Tags: inp.Tags, Notes: inp.Notes,
+		DisableAccessLog: inp.DisableAccessLog, AddRequestID: inp.AddRequestID,
+		StripRespHeaders: inp.StripRespHeaders, BlockedAgents: inp.BlockedAgents,
+		UpstreamSNI: inp.UpstreamSNI, HSTSPreload: inp.HSTSPreload,
+		MaxConnsPerHost: inp.MaxConnsPerHost, UpstreamRetries: inp.UpstreamRetries,
+		ForceHTTP1: inp.ForceHTTP1, ProxyProtocol: inp.ProxyProtocol,
+		BasicAuthRealm: "Restricted", CustomReqHeaders: "{}", CustomRespHeaders: "{}",
+		URLRewrites: "[]",
+	}
+	serverID := s.currentServerID(r)
+	ownerID := cu.ID
+	if cu.IsAdmin {
+		ownerID = 0
+	}
+	newID, err := models.CreateProxyHost(s.DB, serverID, ownerID, ph)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	ph.ID = newID
+	ph.ServerID = serverID
+	_ = models.LogActivity(s.DB, serverID, cu.Email, "proxy_create", fmt.Sprintf("proxy:%d", newID), ph.Domains, true)
+	s.syncCaddy(serverID, false)
+	created, _ := models.GetProxyHost(s.DB, newID)
+	if created == nil {
+		created = ph
+	}
+	writeJSON(w, http.StatusCreated, proxyHostToAPIMap(created))
+}
+
+// PUT /api/v1/proxy-hosts/{id}
+func (s *Server) apiV1UpdateProxyHost(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	existing, err := models.GetProxyHost(s.DB, id)
+	if err != nil || existing == nil {
+		writeJSONError(w, http.StatusNotFound, "not found")
+		return
+	}
+	if cu != nil && !cu.IsAdmin && existing.OwnerID.Valid && existing.OwnerID.Int64 != cu.ID {
+		writeJSONError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+	var inp apiProxyHostInput
+	if err := json.NewDecoder(r.Body).Decode(&inp); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	// Merge: any field not supplied keeps the existing value.
+	if inp.Domains != "" { existing.Domains = inp.Domains }
+	if inp.ForwardScheme != "" { existing.ForwardScheme = inp.ForwardScheme }
+	if inp.ForwardHost != "" { existing.ForwardHost = inp.ForwardHost }
+	if inp.ForwardPort != 0 { existing.ForwardPort = inp.ForwardPort }
+	existing.WebsocketSupport = inp.WebsocketSupport
+	existing.BlockCommonExploits = inp.BlockCommonExploits
+	existing.SSLEnabled = inp.SSLEnabled
+	existing.SSLForced = inp.SSLForced
+	existing.HTTP2Support = inp.HTTP2Support
+	existing.Enabled = inp.Enabled
+	existing.MaintenanceMode = inp.MaintenanceMode
+	if inp.Tags != "" { existing.Tags = inp.Tags }
+	if inp.Notes != "" { existing.Notes = inp.Notes }
+	if inp.AccessList != "" { existing.AccessList = inp.AccessList }
+	if inp.IPBlocklist != "" { existing.IPBlocklist = inp.IPBlocklist }
+	if inp.LBPolicy != "" { existing.LBPolicy = inp.LBPolicy }
+	if err := models.UpdateProxyHost(s.DB, existing); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	_ = models.LogActivity(s.DB, existing.ServerID, s.currentUserEmail(r), "proxy_update", fmt.Sprintf("proxy:%d", id), existing.Domains, true)
+	s.syncCaddy(existing.ServerID, existing.CertificateID != 0)
+	updated, _ := models.GetProxyHost(s.DB, id)
+	if updated == nil { updated = existing }
+	writeJSON(w, http.StatusOK, proxyHostToAPIMap(updated))
+}
+
+// DELETE /api/v1/proxy-hosts/{id}
+func (s *Server) apiV1DeleteProxyHost(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	ph, err := models.GetProxyHost(s.DB, id)
+	if err != nil || ph == nil {
+		writeJSONError(w, http.StatusNotFound, "not found")
+		return
+	}
+	if cu != nil && !cu.IsAdmin && ph.OwnerID.Valid && ph.OwnerID.Int64 != cu.ID {
+		writeJSONError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+	if ph.DNSRecordID != "" {
+		s.dnsDeleteRecord(ph.DNSProvider, ph.DNSZoneID, ph.DNSZoneName, ph.DNSRecordID)
+	}
+	if err := models.DeleteProxyHost(s.DB, id); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	_ = models.LogActivity(s.DB, ph.ServerID, s.currentUserEmail(r), "proxy_delete", fmt.Sprintf("proxy:%d", id), ph.Domains, true)
+	s.syncCaddy(ph.ServerID, false)
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": true, "id": id})
+}
+
+// POST /api/v1/proxy-hosts/{id}/toggle
+func (s *Server) apiV1ToggleProxyHost(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	ph, err := models.GetProxyHost(s.DB, id)
+	if err != nil || ph == nil {
+		writeJSONError(w, http.StatusNotFound, "not found")
+		return
+	}
+	ph.Enabled = !ph.Enabled
+	if err := models.UpdateProxyHost(s.DB, ph); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.syncCaddy(ph.ServerID, false)
+	writeJSON(w, http.StatusOK, map[string]any{"id": id, "enabled": ph.Enabled})
+}
+
+// POST /api/v1/proxy-hosts/{id}/maintenance
+func (s *Server) apiV1ToggleMaintenanceProxyHost(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	ph, err := models.GetProxyHost(s.DB, id)
+	if err != nil || ph == nil {
+		writeJSONError(w, http.StatusNotFound, "not found")
+		return
+	}
+	// Accept optional JSON body {"maintenance": true/false}; default = toggle.
+	var body struct {
+		Maintenance *bool `json:"maintenance"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	if body.Maintenance != nil {
+		ph.MaintenanceMode = *body.Maintenance
+	} else {
+		ph.MaintenanceMode = !ph.MaintenanceMode
+	}
+	if err := models.UpdateProxyHost(s.DB, ph); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.syncCaddy(ph.ServerID, false)
+	writeJSON(w, http.StatusOK, map[string]any{"id": id, "maintenance_mode": ph.MaintenanceMode})
+}
+
+// ─── Redirection Host REST API ────────────────────────────────────────────────
+
+func redirectionHostToAPIMap(r *models.RedirectionHost) map[string]any {
+	return map[string]any{
+		"id":                r.ID,
+		"domains":           r.Domains,
+		"forward_scheme":    r.ForwardScheme,
+		"forward_domain":    r.ForwardDomain,
+		"forward_http_code": r.ForwardHTTPCode,
+		"preserve_path":     r.PreservePath,
+		"ssl_enabled":       r.SSLEnabled,
+		"ssl_forced":        r.SSLForced,
+		"enabled":           r.Enabled,
+		"certificate_id":    r.CertificateID,
+		"tags":              r.Tags,
+		"notes":             r.Notes,
+		"owner_email":       r.OwnerEmail,
+		"created_at":        r.CreatedAt,
+		"updated_at":        r.UpdatedAt,
+	}
+}
+
+// GET /api/v1/redirection-hosts
+func (s *Server) apiV1ListRedirectionHosts(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil {
+		writeJSONError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	hosts, err := models.ListRedirectionHosts(s.DB, s.currentServerID(r), cu.ID, cu.IsAdmin, nil)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	out := make([]map[string]any, 0, len(hosts))
+	for i := range hosts {
+		out = append(out, redirectionHostToAPIMap(&hosts[i]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// GET /api/v1/redirection-hosts/{id}
+func (s *Server) apiV1GetRedirectionHost(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	rh, err := models.GetRedirectionHost(s.DB, id)
+	if err != nil || rh == nil {
+		writeJSONError(w, http.StatusNotFound, "not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, redirectionHostToAPIMap(rh))
+}
+
+// POST /api/v1/redirection-hosts
+func (s *Server) apiV1CreateRedirectionHost(w http.ResponseWriter, r *http.Request) {
+	cu := s.currentUser(r)
+	if cu == nil {
+		writeJSONError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var inp struct {
+		Domains         string `json:"domains"`
+		ForwardScheme   string `json:"forward_scheme"`
+		ForwardDomain   string `json:"forward_domain"`
+		ForwardHTTPCode int    `json:"forward_http_code"`
+		PreservePath    bool   `json:"preserve_path"`
+		SSLEnabled      bool   `json:"ssl_enabled"`
+		SSLForced       bool   `json:"ssl_forced"`
+		Enabled         bool   `json:"enabled"`
+		CertificateID   int64  `json:"certificate_id"`
+		Tags            string `json:"tags"`
+		Notes           string `json:"notes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&inp); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if inp.Domains == "" || inp.ForwardDomain == "" {
+		writeJSONError(w, http.StatusBadRequest, "domains and forward_domain are required")
+		return
+	}
+	if inp.ForwardScheme == "" { inp.ForwardScheme = "auto" }
+	if inp.ForwardHTTPCode == 0 { inp.ForwardHTTPCode = 301 }
+	rh := &models.RedirectionHost{
+		Domains: inp.Domains, ForwardScheme: inp.ForwardScheme,
+		ForwardDomain: inp.ForwardDomain, ForwardHTTPCode: inp.ForwardHTTPCode,
+		PreservePath: inp.PreservePath, SSLEnabled: inp.SSLEnabled, SSLForced: inp.SSLForced,
+		Enabled: inp.Enabled, CertificateID: inp.CertificateID,
+		Tags: inp.Tags, Notes: inp.Notes,
+	}
+	serverID := s.currentServerID(r)
+	ownerID := int64(0)
+	if !cu.IsAdmin { ownerID = cu.ID }
+	newID, err := models.CreateRedirectionHost(s.DB, serverID, ownerID, rh)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	_ = models.LogActivity(s.DB, serverID, cu.Email, "redirect_create", fmt.Sprintf("redir:%d", newID), rh.Domains, true)
+	s.syncCaddy(serverID, false)
+	created, _ := models.GetRedirectionHost(s.DB, newID)
+	if created == nil { created = rh; created.ID = newID }
+	writeJSON(w, http.StatusCreated, redirectionHostToAPIMap(created))
+}
+
+// PUT /api/v1/redirection-hosts/{id}
+func (s *Server) apiV1UpdateRedirectionHost(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	existing, err := models.GetRedirectionHost(s.DB, id)
+	if err != nil || existing == nil {
+		writeJSONError(w, http.StatusNotFound, "not found")
+		return
+	}
+	var inp struct {
+		Domains         string `json:"domains"`
+		ForwardScheme   string `json:"forward_scheme"`
+		ForwardDomain   string `json:"forward_domain"`
+		ForwardHTTPCode int    `json:"forward_http_code"`
+		PreservePath    bool   `json:"preserve_path"`
+		SSLEnabled      bool   `json:"ssl_enabled"`
+		SSLForced       bool   `json:"ssl_forced"`
+		Enabled         bool   `json:"enabled"`
+		Tags            string `json:"tags"`
+		Notes           string `json:"notes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&inp); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if inp.Domains != "" { existing.Domains = inp.Domains }
+	if inp.ForwardScheme != "" { existing.ForwardScheme = inp.ForwardScheme }
+	if inp.ForwardDomain != "" { existing.ForwardDomain = inp.ForwardDomain }
+	if inp.ForwardHTTPCode != 0 { existing.ForwardHTTPCode = inp.ForwardHTTPCode }
+	existing.PreservePath = inp.PreservePath
+	existing.SSLEnabled = inp.SSLEnabled
+	existing.SSLForced = inp.SSLForced
+	existing.Enabled = inp.Enabled
+	if inp.Tags != "" { existing.Tags = inp.Tags }
+	if inp.Notes != "" { existing.Notes = inp.Notes }
+	if err := models.UpdateRedirectionHost(s.DB, existing); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r), "redirect_update", fmt.Sprintf("redir:%d", id), existing.Domains, true)
+	s.syncCaddy(s.currentServerID(r), false)
+	updated, _ := models.GetRedirectionHost(s.DB, id)
+	if updated == nil { updated = existing }
+	writeJSON(w, http.StatusOK, redirectionHostToAPIMap(updated))
+}
+
+// DELETE /api/v1/redirection-hosts/{id}
+func (s *Server) apiV1DeleteRedirectionHost(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	if err := models.DeleteRedirectionHost(s.DB, id); err != nil {
+		writeJSONError(w, http.StatusNotFound, "not found")
+		return
+	}
+	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r), "redirect_delete", fmt.Sprintf("redir:%d", id), "", true)
+	s.syncCaddy(s.currentServerID(r), false)
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": true, "id": id})
+}
+
+// POST /api/v1/redirection-hosts/{id}/toggle
+func (s *Server) apiV1ToggleRedirectionHost(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	enabled, err := models.ToggleRedirectionHost(s.DB, id)
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "not found or error: "+err.Error())
+		return
+	}
+	rh, _ := models.GetRedirectionHost(s.DB, id)
+	if rh != nil { s.syncCaddy(s.currentServerID(r), false) }
+	writeJSON(w, http.StatusOK, map[string]any{"id": id, "enabled": enabled})
+}
+
+

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -13,9 +13,142 @@
 {{end}}
 
 <form method="post" action="{{if .Host.ID}}/proxy-hosts/{{.Host.ID}}{{else}}/proxy-hosts{{end}}" class="bg-white border border-ink-200 rounded-xl shadow-card p-6 space-y-5 max-w-3xl">
+  <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 items-end">
+    <div class="sm:col-span-2">
+      <label class="block text-sm font-medium text-ink-800 mb-1.5">Domain names <span class="text-ink-400 font-normal">(comma separated)</span></label>
+      <input name="domains" value="{{.Host.Domains}}" required placeholder="example.com, www.example.com" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-ink-800 mb-1.5">www redirect</label>
+      <select name="www_redirect" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+        <option value="" {{if eq .Host.WWWRedirect ""}}selected{{end}}>Disabled</option>
+        <option value="to_www" {{if eq .Host.WWWRedirect "to_www"}}selected{{end}}>Bare → www</option>
+        <option value="to_bare" {{if eq .Host.WWWRedirect "to_bare"}}selected{{end}}>www → Bare</option>
+      </select>
+      <p class="text-xs text-ink-400 mt-1">Automatically 301 redirect between www and bare domain variants.</p>
+    </div>
+    <!-- v2.9.61: trailing_slash_redirect -->
+<div class="mb-4">
+  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Trailing Slash Redirect</label>
+  <select name="trailing_slash_redirect"
+    class="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm">
+    <option value="" {{if eq .Host.TrailingSlashRedirect ""}}selected{{end}}>Off</option>
+    <option value="add" {{if eq .Host.TrailingSlashRedirect "add"}}selected{{end}}>Add trailing slash (/path → /path/)</option>
+    <option value="remove" {{if eq .Host.TrailingSlashRedirect "remove"}}selected{{end}}>Remove trailing slash (/path/ → /path)</option>
+  </select>
+  <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Automatically redirect to normalize trailing slashes (301 redirect).</p>
+</div>
+  </div>
+
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 items-end">
+    <div>
+      <label class="block text-xs font-medium text-ink-700 mb-1">Path prefix <span class="text-ink-400 font-normal">(optional — leave blank to match all paths)</span></label>
+      <input type="text" name="path_matcher" value="{{.Host.PathMatcher}}"
+        placeholder="/api"
+        class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+      <p class="text-xs text-ink-400 mt-1">Restricts this route to requests whose path starts with the given prefix (e.g. <code class="bg-ink-100 px-1 rounded">/api</code>). Matches both exact and sub-paths.</p>
+    </div>
+    <div class="pb-6">
+      <label class="flex items-center gap-2.5 cursor-pointer">
+        <input type="checkbox" name="strip_path_prefix" {{if .Host.StripPathPrefix}}checked{{end}}
+          class="rounded border-ink-300 text-brand-600 focus:ring-brand-500">
+        <span class="text-sm text-ink-700">Strip prefix before forwarding</span>
+      </label>
+      <p class="text-xs text-ink-400 mt-1 ml-6.5">Removes the path prefix before sending the request to the upstream (requires Path prefix to be set).</p>
+    </div>
+  </div>
+
+      <div>
+        <label class="flex items-center gap-2.5 cursor-pointer select-none">
+          <input type="checkbox" name="strip_query_string" {{if .Host.StripQueryString}}checked{{end}} class="h-4 w-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
+          <span class="text-sm font-medium text-ink-800">Strip query string</span>
+        </label>
+        <p class="text-xs text-ink-400 mt-1.5 ml-6.5">Remove the entire query string from requests before forwarding to the upstream. Useful when the backend doesn't support or should not see query parameters.</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Delete query params <span class="text-ink-400 font-normal">(optional)</span></label>
+        <input type="text" name="delete_query_params" value="{{.Host.DeleteQueryParams}}" placeholder="utm_source,utm_medium,fbclid,gclid" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">Comma-separated query parameter names to remove before forwarding. Ignored when "Strip query string" is checked.</p>
+      </div>
+
+<!-- v2.9.57: add_req_query_params -->
+<div class="mb-4">
+  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Add Query Params</label>
+  <input type="text" name="add_req_query_params" value="{{.Host.AddReqQueryParams}}"
+    class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+    placeholder="key=value,key2=value2">
+  <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated <code>key=value</code> pairs appended to the upstream query string. Useful for adding API version markers or tracking params.</p>
+</div>
+
   <div>
-    <label class="block text-sm font-medium text-ink-800 mb-1.5">Domain names <span class="text-ink-400 font-normal">(comma separated)</span></label>
-    <input name="domains" value="{{.Host.Domains}}" required placeholder="example.com, www.example.com" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+    <label class="block text-sm font-medium text-ink-800 mb-1.5">Tags <span class="text-ink-400 font-normal">(optional, comma-separated)</span></label>
+    <input type="text" name="tags" value="{{.Host.Tags}}"
+      placeholder="production, api, wordpress"
+      class="w-full text-sm px-3 py-2 rounded-lg border border-ink-200 bg-white text-ink-900 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+  </div>
+
+  <div>
+    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Notes
+      <span class="text-gray-400 font-normal">(optional, internal only)</span>
+    </label>
+    <textarea name="notes" rows="2"
+      placeholder="Internal documentation, deployment notes, etc."
+      class="w-full text-sm px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none">{{.Host.Notes}}</textarea>
+  </div>
+
+  <div>
+    <label class="block text-sm font-medium text-ink-800 mb-2">Color label <span class="text-ink-400 font-normal">(optional, for visual grouping)</span></label>
+    <div class="flex items-center gap-2 flex-wrap">
+      <label class="cursor-pointer" title="No color">
+        <input type="radio" name="color" value="" {{if eq .Host.Color ""}}checked{{end}} class="sr-only peer" />
+        <span class="inline-flex items-center justify-center w-7 h-7 rounded-full border-2 border-ink-300 peer-checked:border-brand-600 peer-checked:ring-2 peer-checked:ring-brand-400 bg-white text-ink-400 text-xs transition">✕</span>
+      </label>
+      <label class="cursor-pointer" title="Red">
+        <input type="radio" name="color" value="red" {{if eq .Host.Color "red"}}checked{{end}} class="sr-only peer" />
+        <span class="inline-block w-7 h-7 rounded-full border-2 border-transparent peer-checked:border-brand-600 peer-checked:ring-2 peer-checked:ring-brand-400 transition bg-red-400"></span>
+      </label>
+      <label class="cursor-pointer" title="Orange">
+        <input type="radio" name="color" value="orange" {{if eq .Host.Color "orange"}}checked{{end}} class="sr-only peer" />
+        <span class="inline-block w-7 h-7 rounded-full border-2 border-transparent peer-checked:border-brand-600 peer-checked:ring-2 peer-checked:ring-brand-400 transition bg-orange-400"></span>
+      </label>
+      <label class="cursor-pointer" title="Yellow">
+        <input type="radio" name="color" value="yellow" {{if eq .Host.Color "yellow"}}checked{{end}} class="sr-only peer" />
+        <span class="inline-block w-7 h-7 rounded-full border-2 border-transparent peer-checked:border-brand-600 peer-checked:ring-2 peer-checked:ring-brand-400 transition bg-yellow-400"></span>
+      </label>
+      <label class="cursor-pointer" title="Green">
+        <input type="radio" name="color" value="green" {{if eq .Host.Color "green"}}checked{{end}} class="sr-only peer" />
+        <span class="inline-block w-7 h-7 rounded-full border-2 border-transparent peer-checked:border-brand-600 peer-checked:ring-2 peer-checked:ring-brand-400 transition bg-green-400"></span>
+      </label>
+      <label class="cursor-pointer" title="Teal">
+        <input type="radio" name="color" value="teal" {{if eq .Host.Color "teal"}}checked{{end}} class="sr-only peer" />
+        <span class="inline-block w-7 h-7 rounded-full border-2 border-transparent peer-checked:border-brand-600 peer-checked:ring-2 peer-checked:ring-brand-400 transition bg-teal-400"></span>
+      </label>
+      <label class="cursor-pointer" title="Blue">
+        <input type="radio" name="color" value="blue" {{if eq .Host.Color "blue"}}checked{{end}} class="sr-only peer" />
+        <span class="inline-block w-7 h-7 rounded-full border-2 border-transparent peer-checked:border-brand-600 peer-checked:ring-2 peer-checked:ring-brand-400 transition bg-blue-400"></span>
+      </label>
+      <label class="cursor-pointer" title="Purple">
+        <input type="radio" name="color" value="purple" {{if eq .Host.Color "purple"}}checked{{end}} class="sr-only peer" />
+        <span class="inline-block w-7 h-7 rounded-full border-2 border-transparent peer-checked:border-brand-600 peer-checked:ring-2 peer-checked:ring-brand-400 transition bg-purple-400"></span>
+      </label>
+      <label class="cursor-pointer" title="Pink">
+        <input type="radio" name="color" value="pink" {{if eq .Host.Color "pink"}}checked{{end}} class="sr-only peer" />
+        <span class="inline-block w-7 h-7 rounded-full border-2 border-transparent peer-checked:border-brand-600 peer-checked:ring-2 peer-checked:ring-brand-400 transition bg-pink-400"></span>
+      </label>
+      <label class="cursor-pointer" title="Gray">
+        <input type="radio" name="color" value="gray" {{if eq .Host.Color "gray"}}checked{{end}} class="sr-only peer" />
+        <span class="inline-block w-7 h-7 rounded-full border-2 border-transparent peer-checked:border-brand-600 peer-checked:ring-2 peer-checked:ring-brand-400 transition bg-gray-400"></span>
+      </label>
+    </div>
+  </div>
+
+  <!-- v2.9.39: sort order -->
+  <div class="mb-4">
+    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Sort Order</label>
+    <input type="number" name="sort_order" value="{{.Host.SortOrder}}"
+      class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+      min="0" max="9999" placeholder="0">
+    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Lower values appear first in the list (0 = default).</p>
   </div>
 
   <div class="grid grid-cols-1 sm:grid-cols-12 gap-3">
@@ -36,15 +169,387 @@
     </div>
   </div>
 
+  <div class="flex items-center gap-2 mt-2">
+    <button type="button" id="test-upstream-btn"
+      class="inline-flex items-center gap-1.5 text-xs bg-ink-50 hover:bg-ink-100 border border-ink-200 text-ink-700 font-medium px-3 py-1.5 rounded-lg transition">
+      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      </svg>
+      Test upstream
+    </button>
+    <span id="test-upstream-result" class="text-xs"></span>
+  </div>
+  <script>
+  document.getElementById('test-upstream-btn').addEventListener('click', function() {
+    var btn = this;
+    var result = document.getElementById('test-upstream-result');
+    var host = document.querySelector('[name="forward_host"]')?.value?.trim();
+    var port = document.querySelector('[name="forward_port"]')?.value?.trim();
+    var scheme = document.querySelector('[name="forward_scheme"]')?.value?.trim() || 'http';
+    if (!host || !port) { result.textContent = 'Enter host and port first.'; return; }
+    btn.disabled = true;
+    result.textContent = 'Testing…';
+    result.className = 'text-xs text-ink-500';
+    var form = new FormData();
+    form.append('host', host);
+    form.append('port', port);
+    form.append('scheme', scheme);
+    fetch('/api/proxy-hosts/test-upstream', {method:'POST', body: form})
+      .then(function(r){ return r.json(); })
+      .then(function(d){
+        if(d.ok){
+          result.textContent = '✓ Reachable' + (d.status ? ' · HTTP '+d.status : '') + ' · '+d.latency_ms+'ms';
+          result.className = 'text-xs text-green-600 font-medium';
+        } else {
+          result.textContent = '✗ ' + (d.error || 'Unreachable' + (d.status ? ' ('+d.status+')' : ''));
+          result.className = 'text-xs text-red-600 font-medium';
+        }
+      })
+      .catch(function(e){ result.textContent = '✗ Request failed'; result.className = 'text-xs text-red-600'; })
+      .finally(function(){ btn.disabled = false; });
+  });
+  </script>
+
+  <div id="upstream-sni-row">
+    <label class="block text-xs font-medium text-ink-700 mb-1">Upstream TLS SNI <span class="text-ink-400 font-normal">(only for HTTPS upstream with different hostname)</span></label>
+    <input type="text" name="upstream_sni" value="{{.Host.UpstreamSNI}}"
+      placeholder="e.g. internal.example.com"
+      class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+  </div>
+
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Upstream TLS minimum version</label>
+        <select name="upstream_tls_min_version" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <option value="" {{if eq .Host.UpstreamTLSMinVersion ""}}selected{{end}}>Use default</option>
+          <option value="1.2" {{if eq .Host.UpstreamTLSMinVersion "1.2"}}selected{{end}}>TLS 1.2+</option>
+          <option value="1.3" {{if eq .Host.UpstreamTLSMinVersion "1.3"}}selected{{end}}>TLS 1.3 only</option>
+        </select>
+        <p class="text-xs text-ink-400 mt-1.5">Minimum TLS protocol version for connections <em>to</em> the upstream. Only applies when the upstream scheme is <span class="font-mono">https</span>.</p>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Forward proxy URL <span class="text-ink-400 font-normal">(optional)</span></label>
+        <input type="text" name="forward_proxy_url" value="{{.Host.ForwardProxyURL}}" placeholder="http://squid.internal:3128" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">Route upstream requests through this HTTP proxy (e.g. a corporate Squid proxy). Leave blank to connect directly.</p>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Upstream path prefix</label>
+        <input type="text" name="upstream_path_prefix" value="{{.Host.UpstreamPathPrefix}}" placeholder="/v2" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">Prepend this path prefix to every upstream request. Example: prefix <code class="bg-ink-100 px-1 rounded">/v2</code> converts <code class="bg-ink-100 px-1 rounded">/users</code> → <code class="bg-ink-100 px-1 rounded">/v2/users</code>.</p>
+      </div>
+
+<!-- v2.9.56: strip_path_suffix -->
+<div class="mb-4">
+  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Strip Path Suffix</label>
+  <input type="text" name="strip_path_suffix" value="{{.Host.StripPathSuffix}}"
+    class="w-48 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+    placeholder="e.g. .html">
+  <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Strip this static suffix from the request path before proxying (e.g. <code>.html</code> enables extensionless URLs).</p>
+</div>
+
+  <div>
+    <label class="block text-xs font-medium text-ink-700 mb-1">Upstream Host Header</label>
+    <input type="text" name="upstream_host_override" value="{{.Host.UpstreamHostOverride}}"
+      placeholder="backend.internal.example.com"
+      class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+    <p class="text-xs text-ink-500 mt-1">Override the Host header sent to the upstream (leave blank to forward the original)</p>
+  </div>
+
   <div class="pt-2">
     <div class="text-xs uppercase tracking-wider text-ink-500 font-medium mb-3">Options</div>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
       <label class="flex items-center gap-2.5 text-sm text-ink-700 cursor-pointer"><input type="checkbox" name="enabled" {{if .Host.Enabled}}checked{{end}} class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" /> Enabled</label>
       <label class="flex items-center gap-2.5 text-sm text-ink-700 cursor-pointer"><input type="checkbox" name="ssl_enabled" {{if .Host.SSLEnabled}}checked{{end}} class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" /> Auto SSL (Let's Encrypt)</label>
       <label class="flex items-center gap-2.5 text-sm text-ink-700 cursor-pointer"><input type="checkbox" name="ssl_forced" {{if .Host.SSLForced}}checked{{end}} class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" /> Force SSL (HTTPS redirect)</label>
+      <label class="flex items-start gap-2.5 text-sm text-ink-700 cursor-pointer sm:col-span-2">
+        <input type="checkbox" name="ssl_verify_upstream" {{if .Host.SSLVerifyUpstream}}checked{{end}} class="mt-0.5 rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
+        <span>Verify Upstream TLS Certificate<span class="block text-xs text-ink-500 mt-0.5 font-normal">When enabled, validates the upstream TLS certificate against the system trust store (only applies when Forward Scheme is HTTPS)</span></span>
+      </label>
+      <!-- v2.9.59: upstream_tls_ca_pem_file -->
+<div class="mb-4">
+  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream TLS CA Bundle File</label>
+  <input type="text" name="upstream_tls_ca_pem_file" value="{{.Host.UpstreamTLSCAPEMFile}}"
+    class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+    placeholder="/etc/ssl/certs/internal-ca.pem">
+  <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Path to a PEM CA bundle for verifying the upstream TLS certificate. Leave empty to use the system trust store. Only active when "Verify Upstream SSL" is enabled.</p>
+</div>
+      <!-- v2.9.160: upstream_tls_ca_pem_inline -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream TLS CA Certificate (inline PEM)</label>
+        <textarea name="upstream_tls_ca_pem_inline" rows="4"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="-----BEGIN CERTIFICATE-----&#10;...">{{.Host.UpstreamTLSCAPEMInline}}</textarea>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Inline PEM-encoded CA certificate for verifying the upstream TLS connection. Alternative to the file-path option above.</p>
+      </div>
+      <!-- v2.9.86: upstream_tls_client_cert_file -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream mTLS Client Certificate File</label>
+        <input type="text" name="upstream_tls_client_cert_file" value="{{.Host.UpstreamTLSClientCertFile}}"
+          class="w-full max-w-lg rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="/etc/ssl/client.crt">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Path to the PEM-encoded client certificate for mutual TLS (mTLS) to the upstream. Leave empty to disable client-certificate authentication.</p>
+      </div>
+      <!-- v2.9.87: upstream_tls_client_key_file -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream mTLS Client Key File</label>
+        <input type="text" name="upstream_tls_client_key_file" value="{{.Host.UpstreamTLSClientKeyFile}}"
+          class="w-full max-w-lg rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="/etc/ssl/client.key">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Path to the PEM-encoded private key matching the Client Certificate above.</p>
+      </div>
+      <!-- v2.9.95: upstream_tls_renegotiation -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream TLS Renegotiation</label>
+        <select name="upstream_tls_renegotiation"
+          class="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm">
+          <option value="" {{if eq .Host.UpstreamTLSRenegotiation ""}}selected{{end}}>Never (default)</option>
+          <option value="once" {{if eq .Host.UpstreamTLSRenegotiation "once"}}selected{{end}}>Once</option>
+          <option value="freely" {{if eq .Host.UpstreamTLSRenegotiation "freely"}}selected{{end}}>Freely</option>
+        </select>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">TLS renegotiation policy for upstream connections. <em>Once</em> allows the server to request renegotiation once per connection; <em>Freely</em> allows unlimited renegotiations (legacy compatibility only).</p>
+      </div>
+      <!-- v2.9.96: upstream_tls_curves -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream TLS Curves</label>
+        <input type="text" name="upstream_tls_curves" value="{{.Host.UpstreamTLSCurves}}"
+          class="w-full max-w-md rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="x25519, p256, p384">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated TLS curve preferences for upstream connections (e.g. <code>x25519, p256</code>). Leave empty to use Caddy's defaults.</p>
+      </div>
+      <!-- v2.9.97: upstream_tls_max_version -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream TLS Maximum Version</label>
+        <select name="upstream_tls_max_version"
+          class="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm">
+          <option value="" {{if eq .Host.UpstreamTLSMaxVersion ""}}selected{{end}}>No limit (default)</option>
+          <option value="1.2" {{if eq .Host.UpstreamTLSMaxVersion "1.2"}}selected{{end}}>TLS 1.2</option>
+          <option value="1.3" {{if eq .Host.UpstreamTLSMaxVersion "1.3"}}selected{{end}}>TLS 1.3</option>
+        </select>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Maximum TLS protocol version for upstream connections. Leave as default unless the upstream doesn't support TLS 1.3.</p>
+      </div>
+      <!-- v2.9.98: upstream_tls_pins -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream TLS Certificate Pins</label>
+        <textarea name="upstream_tls_pins" rows="3"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="One SHA-256 SPKI fingerprint per line">{{.Host.UpstreamTLSPins}}</textarea>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">One Base64-encoded SHA-256 SPKI fingerprint per line to pin the upstream certificate. Requests to upstreams whose certificate does not match will fail. Leave empty to disable pinning.</p>
+      </div>
+      <!-- v2.9.119: upstream_tls_cipher_suites -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">TLS Cipher Suites</label>
+        <input type="text" name="upstream_tls_cipher_suites" value="{{.Host.UpstreamTLSCipherSuites}}" placeholder="TLS_AES_128_GCM_SHA256, TLS_CHACHA20_POLY1305_SHA256" class="mt-1 block w-full rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm text-sm">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated TLS cipher suite names for upstream connections. Leave empty to use defaults.</p>
+      </div>
+      <!-- v2.9.153: upstream_tls_alpn -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream TLS ALPN Protocols</label>
+        <input type="text" name="upstream_tls_alpn" value="{{.Host.UpstreamTLSALPN}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. h2,http/1.1">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated list of ALPN protocols advertised to the upstream during TLS handshake. Leave empty for defaults.</p>
+      </div>
+      <!-- v2.9.166: upstream_tls_server_name_from_host -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="upstream_tls_server_name_from_host" {{if .Host.UpstreamTLSServerNameFromHost}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">TLS SNI from Host Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Uses the incoming Host header value as the upstream TLS server name (SNI), instead of a static name.</p>
+      </div>
+      <!-- v2.9.125: upstream_tls_early_data -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="upstream_tls_early_data" value="on" {{if .Host.UpstreamTLSEarlyData}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">TLS Early Data (0-RTT)</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Enable TLS 1.3 early data (0-RTT) for upstream connections. May reduce latency for repeated connections.</p>
+      </div>
       <label class="flex items-center gap-2.5 text-sm text-ink-700 cursor-pointer"><input type="checkbox" name="http2_support" {{if .Host.HTTP2Support}}checked{{end}} class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" /> HTTP/2</label>
       <label class="flex items-center gap-2.5 text-sm text-ink-700 cursor-pointer"><input type="checkbox" name="websocket_support" {{if .Host.WebsocketSupport}}checked{{end}} class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" /> WebSocket support</label>
+      <label class="flex items-start gap-2.5 text-sm text-ink-700 cursor-pointer sm:col-span-2"><input type="checkbox" name="forward_client_ip" {{if .Host.ForwardClientIP}}checked{{end}} class="mt-0.5 rounded border-ink-300 text-brand-600 focus:ring-brand-500" /> <span>Forward client IP (X-Real-IP)<span class="block text-xs text-ink-500 mt-0.5 font-normal">Adds an X-Real-IP header with the actual client IP address to every upstream request</span></span></label>
+      <!-- v2.9.82: add_forwarded_header -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_forwarded_header" {{if .Host.AddForwardedHeader}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add Forwarded Header (RFC 7239)</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Inject the standard <code>Forwarded: for=…;proto=…;host=…</code> header on upstream requests (RFC 7239 complement to <code>X-Forwarded-For</code>).</p>
+      </div>
+      <!-- v2.9.110: real_ip_from_header -->
+      <div class="mb-4 sm:col-span-2">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Real IP Source Header <span class="text-gray-400 font-normal">(optional)</span></label>
+        <input type="text" name="real_ip_from_header" value="{{.Host.RealIPFromHeader}}"
+          class="w-56 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="CF-Connecting-IP">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">When set, copy the value of this request header into <code>X-Real-IP</code> before forwarding. Useful behind Cloudflare (<code>CF-Connecting-IP</code>) or other CDNs that supply the real client IP in a custom header.</p>
+      </div>
+      <!-- v2.9.112: add_x_forwarded_port -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_forwarded_port" {{if .Host.AddXForwardedPort}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add X-Forwarded-Port Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Inject <code>X-Forwarded-Port</code> with the port of the incoming request (e.g. <code>443</code>). Helps backends reconstruct the original URL for redirects and absolute links.</p>
+      </div>
+      <!-- v2.9.117: add_x_forwarded_host -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_forwarded_host" {{if .Host.AddXForwardedHost}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add X-Forwarded-Host</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Inject <code>X-Forwarded-Host</code> request header with the original Host value before proxying.</p>
+      </div>
+      <!-- v2.9.143: add_x_forwarded_scheme -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_forwarded_scheme" {{if .Host.AddXForwardedScheme}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add X-Forwarded-Scheme Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Inject <code>X-Forwarded-Scheme</code> request header (<code>http</code> or <code>https</code>) showing the client-facing scheme.</p>
+      </div>
+      <!-- v2.9.199: add_x_forwarded_uri -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_forwarded_uri" {{if .Host.AddXForwardedURI}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Forward X-Forwarded-URI Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Adds an <code>X-Forwarded-URI</code> request header containing the full request URI (path + query) when forwarding to the upstream.</p>
+      </div>
+      <!-- v2.9.149: add_x_real_ip -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_real_ip" {{if .Host.AddXRealIP}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add X-Real-IP Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Inject <code>X-Real-IP</code> request header with the direct client IP address (useful for backends that read this header instead of <code>X-Forwarded-For</code>).</p>
+      </div>
+      <!-- v2.9.150: strip_incoming_x_forwarded_for -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="strip_incoming_x_forwarded_for" {{if .Host.StripIncomingXForwardedFor}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Strip Incoming X-Forwarded-For</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Delete the <code>X-Forwarded-For</code> header from incoming requests before proxying. Prevents clients from spoofing their IP when the proxy is directly internet-facing.</p>
+      </div>
+      <!-- v2.9.181: add_x_request_path -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_request_path" {{if .Host.AddXRequestPath}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Forward X-Request-Path Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Adds an <code>X-Request-Path</code> request header containing the request URI path when forwarding to the upstream.</p>
+      </div>
+      <!-- v2.9.188: add_x_request_method -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_request_method" {{if .Host.AddXRequestMethod}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Forward X-Request-Method Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Adds an <code>X-Request-Method</code> request header containing the HTTP method (GET/POST/etc.) when forwarding to the upstream.</p>
+      </div>
+      <!-- v2.9.189: add_x_request_query -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_request_query" {{if .Host.AddXRequestQuery}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Forward X-Request-Query Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Adds an <code>X-Request-Query</code> request header containing the original query string when forwarding to the upstream.</p>
+      </div>
+      <!-- v2.9.201: add_x_request_hostname -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_request_hostname" {{if .Host.AddXRequestHostname}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Forward X-Request-Hostname Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Adds an <code>X-Request-Hostname</code> request header containing the request hostname when forwarding to the upstream.</p>
+      </div>
+      <!-- v2.9.191: add_x_real_scheme -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_real_scheme" {{if .Host.AddXRealScheme}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Forward X-Real-Scheme Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Adds an <code>X-Real-Scheme</code> request header containing the request scheme (<code>http</code> or <code>https</code>) when forwarding to the upstream.</p>
+      </div>
+      <!-- v2.9.197: add_x_request_referer -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_request_referer" {{if .Host.AddXRequestReferer}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Forward X-Request-Referer Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Adds an <code>X-Request-Referer</code> request header containing the original Referer header value when forwarding to the upstream.</p>
+      </div>
+      <!-- v2.9.198: add_x_request_origin -->
+      <div class="mb-4 flex items-center gap-3 sm:col-span-2">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_request_origin" {{if .Host.AddXRequestOrigin}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Forward X-Request-Origin Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Adds an <code>X-Request-Origin</code> request header containing the original Origin header value when forwarding to the upstream.</p>
+      </div>
+      <!-- v2.9.190: add_x_forwarded_user -->
+      <div class="mb-4 sm:col-span-2">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">X-Forwarded-User Header</label>
+        <input type="text" name="add_x_forwarded_user" value="{{.Host.AddXForwardedUser}}"
+          placeholder="e.g. service-account-name"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets a static <code>X-Forwarded-User</code> request header value forwarded to the upstream (useful for impersonation in trusted networks).</p>
+      </div>
+      <!-- v2.9.193: add_x_forwarded_groups -->
+      <div class="mb-4 sm:col-span-2">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">X-Forwarded-Groups Header</label>
+        <input type="text" name="add_x_forwarded_groups" value="{{.Host.AddXForwardedGroups}}"
+          placeholder="e.g. admins,operators"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets a static <code>X-Forwarded-Groups</code> request header value forwarded to the upstream.</p>
+      </div>
+      <!-- v2.9.194: add_x_forwarded_email -->
+      <div class="mb-4 sm:col-span-2">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">X-Forwarded-Email Header</label>
+        <input type="text" name="add_x_forwarded_email" value="{{.Host.AddXForwardedEmail}}"
+          placeholder="e.g. user@example.com"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets a static <code>X-Forwarded-Email</code> request header value forwarded to the upstream.</p>
+      </div>
+      <!-- v2.9.195: add_x_forwarded_roles -->
+      <div class="mb-4 sm:col-span-2">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">X-Forwarded-Roles Header</label>
+        <input type="text" name="add_x_forwarded_roles" value="{{.Host.AddXForwardedRoles}}"
+          placeholder="e.g. admin,editor"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets a static <code>X-Forwarded-Roles</code> request header value forwarded to the upstream.</p>
+      </div>
+      <!-- v2.9.159: add_origin_header -->
+      <div class="mb-4 sm:col-span-2">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Add Origin Header</label>
+        <input type="text" name="add_origin_header" value="{{.Host.AddOriginHeader}}"
+          placeholder="https://example.com"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Set the <code>Origin</code> request header to this value before forwarding. Useful for upstream APIs that require a specific origin.</p>
+      </div>
       <label class="flex items-center gap-2.5 text-sm text-ink-700 cursor-pointer"><input type="checkbox" name="block_common_exploits" {{if .Host.BlockCommonExploits}}checked{{end}} class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" /> Block common exploits</label>
+      <label class="flex items-start gap-2.5 text-sm text-ink-700 cursor-pointer sm:col-span-2">
+        <input type="checkbox" name="deny_dotfiles" {{if .Host.DenyDotfiles}}checked{{end}} class="mt-0.5 rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
+        <span>Block Dotfiles (403)<span class="block text-xs text-ink-500 mt-0.5 font-normal">Block requests to hidden files and directories (paths starting with a dot, e.g. .env, .git)</span></span>
+      </label>
     </div>
   </div>
 
@@ -178,7 +683,7 @@
   </details>
 
   {{/* v2.9.0: Security — compression + response headers + TLS min version */}}
-  <details class="pt-4 border-t border-ink-100"{{if or .Host.CompressionEnabled .Host.SecurityHeadersEnabled .Host.TLSMinVersion}} open{{end}}>
+  <details class="pt-4 border-t border-ink-100"{{if or .Host.CompressionEnabled .Host.SecurityHeadersEnabled .Host.TLSMinVersion .Host.MaintenanceMode .Host.MaxRequestBodyMB .Host.StickySessions .Host.CORSEnabled .Host.HealthCheckURI .Host.KeepaliveConns .Host.DisableAccessLog .Host.AddRequestID .Host.BlockedAgents .Host.ForceHTTP1 .Host.ProxyProtocol .Host.H2CEnabled .Host.FlushImmediate .Host.BufferResponses .Host.APIKeyHeader .Host.APIKeyValue .Host.BlockEmptyUserAgent .Host.MaxConnDurationSec .Host.DecompressResponse .Host.StripReqHeaders .Host.UpstreamPathPrefix .Host.CompressionLevel .Host.CompressionPreferGzip}} open{{end}}>
     <summary class="cursor-pointer select-none text-xs uppercase tracking-wider text-ink-500 hover:text-ink-700 font-medium transition">
       Security &amp; Performance <span class="font-normal normal-case">(compression, headers, TLS)</span>
     </summary>
@@ -193,6 +698,115 @@
             <span class="block text-xs text-ink-500 mt-0.5">Caddy compresses responses before sending to the browser. Reduces bandwidth for text assets (HTML, CSS, JS, JSON) by ~70%. Skipped for already-compressed types (images, video).</span>
           </span>
         </label>
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">Minimum response size to compress <span class="text-ink-400 font-normal">(KB, 0 = always compress)</span></label>
+          <input type="number" name="compression_min_size_kb" min="0" value="{{.Host.CompressionMinSizeKB}}"
+            class="w-32 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Skip compression for responses smaller than this. Saves CPU when serving tiny API responses.</p>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 items-start">
+        <div>
+          <label class="block text-sm font-medium text-ink-800 mb-1.5">Gzip level <span class="text-ink-400 font-normal">(0 = default)</span></label>
+          <input type="number" name="compression_level" value="{{.Host.CompressionLevel}}" min="0" max="9" placeholder="0" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+          <p class="text-xs text-ink-400 mt-1">0 = Caddy default. 1 = fastest, 9 = best compression. Requires Gzip/Zstd enabled above.</p>
+        </div>
+        <div class="flex items-center gap-3 pt-7">
+          <label class="inline-flex items-center gap-2 cursor-pointer select-none">
+            <input type="checkbox" name="compression_prefer_gzip" {{if .Host.CompressionPreferGzip}}checked{{end}} class="h-4 w-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
+            <span class="text-sm font-medium text-ink-800">Prefer gzip over zstd</span>
+          </label>
+          <span class="text-xs text-ink-400">Use gzip as the default when the client supports both. Better for caching proxies or older browsers.</span>
+        </div>
+      </div>
+
+      <!-- v2.9.138: compression_exclude_regexp -->
+      <div class="mb-4 mt-3">
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Compression Exclude Regexp</label>
+        <input type="text" name="compression_exclude_regexp" value="{{.Host.CompressionExcludeRegexp}}"
+          class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition"
+          placeholder="\.(jpg|png|gif|mp4|zip)$">
+        <p class="text-xs text-ink-400 mt-1">Go regexp of request paths to exclude from compression. Matched paths bypass the encode handler.</p>
+      </div>
+
+      <!-- v2.9.89: enable_brotli -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="enable_brotli" {{if .Host.EnableBrotli}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Enable Brotli Compression</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Include the <code>br</code> (brotli) encoding in the compression handler alongside gzip and zstd. Brotli typically achieves better compression ratios than gzip. Requires <strong>Compression</strong> to be enabled.</p>
+      </div>
+
+      <!-- v2.9.104: strip_accept_encoding -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="strip_accept_encoding" {{if .Host.StripAcceptEncoding}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Strip Accept-Encoding</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Delete the <code>Accept-Encoding</code> request header before forwarding to the upstream, preventing the upstream from compressing responses. Useful when the upstream serves pre-compressed content that Caddy cannot further process.</p>
+      </div>
+
+      <!-- v2.9.129: force_upstream_encoding -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Force Upstream Encoding</label>
+        <input type="text" name="force_upstream_encoding" value="{{.Host.ForceUpstreamEncoding}}"
+          class="w-48 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="gzip">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Override the Accept-Encoding header sent to upstream. Options: gzip, br, identity, or a comma-separated list. Leave empty to pass through the client's value.</p>
+      </div>
+
+      <!-- v2.9.108: add_content_type_nosniff -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_content_type_nosniff" {{if .Host.AddContentTypeNosniff}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add X-Content-Type-Options: nosniff</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Append <code>X-Content-Type-Options: nosniff</code> to every response, preventing browsers from MIME-sniffing the content type. This is already included in the full Security Headers bundle.</p>
+      </div>
+
+      <!-- v2.9.177: add_x_download_options -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_download_options" {{if .Host.AddXDownloadOptions}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add X-Download-Options: noopen</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Sets X-Download-Options: noopen to prevent Internet Explorer from auto-opening downloaded files.</p>
+      </div>
+
+      <!-- v2.9.202: add_x_xss_protection_disabled -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_xss_protection_disabled" {{if .Host.AddXXSSProtectionDisabled}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add X-XSS-Protection: 0 (Disable Legacy Filter)</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Sets <code>X-XSS-Protection: 0</code> to disable the legacy browser XSS auditor (recommended for modern apps using CSP).</p>
+      </div>
+
+      <!-- v2.9.128: add_expect_ct_header -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_expect_ct_header" {{if .Host.AddExpectCTHeader}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add Expect-CT Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Add "Expect-CT: enforce" response header for certificate transparency enforcement.</p>
+      </div>
+
+      <!-- v2.9.109: strip_authorization_header -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="strip_authorization_header" {{if .Host.StripAuthorizationHeader}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Strip Authorization Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Delete the incoming <code>Authorization</code> request header before forwarding to the upstream. Useful when the proxy handles authentication and you don't want to pass credentials downstream.</p>
       </div>
 
       {{/* Security headers */}}
@@ -211,6 +825,722 @@
             </span>
           </span>
         </label>
+        <label class="flex items-center gap-3 cursor-pointer ml-6 mt-2">
+          <input type="checkbox" name="hsts_preload" value="on" {{if .Host.HSTSPreload}}checked{{end}}
+            class="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+          <span class="text-sm text-ink-700">Add <code class="text-xs bg-ink-100 px-1 rounded">; preload</code> to HSTS header</span>
+        </label>
+        <label class="flex items-center gap-3 cursor-pointer ml-6 mt-2">
+          <input type="checkbox" name="hsts_include_subdomains" value="on" {{if .Host.HSTSIncludeSubdomains}}checked{{end}}
+            class="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+          <span class="text-sm text-ink-700">Include <code class="text-xs bg-ink-100 px-1 rounded">; includeSubDomains</code> in HSTS header</span>
+        </label>
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">HSTS max-age (seconds)</label>
+          <input type="number" name="hsts_max_age_sec" min="0"
+            value="{{.Host.HSTSMaxAgeSec}}"
+            placeholder="0 = default (31536000)"
+            class="w-52 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Custom Strict-Transport-Security max-age in seconds. Requires Security Headers enabled. 0 uses the default 1-year period.</p>
+        </div>
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">Content-Security-Policy</label>
+          <input type="text" name="csp_header"
+            value="{{.Host.CSPHeader}}"
+            placeholder="default-src 'self'; img-src *"
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">When set, injects a Content-Security-Policy response header. Injected independently of Security Headers.</p>
+        </div>
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">CSP Report-Only</label>
+          <input type="text" name="csp_report_only"
+            value="{{.Host.CSPReportOnly}}"
+            placeholder="default-src 'self'"
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Injects a <code class="bg-ink-100 px-1 rounded text-xs">Content-Security-Policy-Report-Only</code> header — reports violations without blocking. Useful for testing a new policy.</p>
+        </div>
+        {{/* v2.9.169: add_report_to */}}
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">Report-To Header</label>
+          <input type="text" name="add_report_to"
+            value="{{.Host.AddReportTo}}"
+            placeholder='{"group":"default","max_age":86400,"endpoints":[{"url":"https://..."}]}'
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Sets the Report-To response header with a JSON endpoint group for CSP/NEL violation reporting.</p>
+        </div>
+        {{/* v2.9.170: add_nel_header */}}
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">NEL Header</label>
+          <input type="text" name="add_nel_header"
+            value="{{.Host.AddNELHeader}}"
+            placeholder='{"report_to":"default","max_age":86400}'
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Sets the NEL (Network Error Logging) response header with a JSON configuration object.</p>
+        </div>
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">Permissions-Policy</label>
+          <input type="text" name="permissions_policy"
+            value="{{.Host.PermissionsPolicy}}"
+            placeholder="geolocation=(), microphone=()"
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Restrict browser feature access; added independently of the security headers toggle</p>
+        </div>
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">X-Frame-Options Override</label>
+          <input type="text" name="x_frame_options"
+            value="{{.Host.XFrameOptions}}"
+            placeholder="SAMEORIGIN"
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Override X-Frame-Options header (leave blank for SAMEORIGIN when security headers enabled)</p>
+        </div>
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">Referrer-Policy Override</label>
+          <input type="text" name="referrer_policy"
+            value="{{.Host.ReferrerPolicy}}"
+            placeholder="strict-origin-when-cross-origin"
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Override the Referrer-Policy header value (leave blank for default)</p>
+        </div>
+        {{/* v2.9.134: cross_origin_opener_policy */}}
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">Cross-Origin-Opener-Policy</label>
+          <select name="cross_origin_opener_policy" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+            <option value="" {{if eq .Host.CrossOriginOpenerPolicy ""}}selected{{end}}>Not Set</option>
+            <option value="unsafe-none" {{if eq .Host.CrossOriginOpenerPolicy "unsafe-none"}}selected{{end}}>unsafe-none</option>
+            <option value="same-origin-allow-popups" {{if eq .Host.CrossOriginOpenerPolicy "same-origin-allow-popups"}}selected{{end}}>same-origin-allow-popups</option>
+            <option value="same-origin" {{if eq .Host.CrossOriginOpenerPolicy "same-origin"}}selected{{end}}>same-origin</option>
+          </select>
+          <p class="text-xs text-ink-500 mt-1">COOP header isolates the browsing context from cross-origin documents. Required for SharedArrayBuffer.</p>
+        </div>
+        {{/* v2.9.135: cross_origin_resource_policy */}}
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">Cross-Origin-Resource-Policy</label>
+          <select name="cross_origin_resource_policy" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+            <option value="" {{if eq .Host.CrossOriginResourcePolicy ""}}selected{{end}}>Not Set</option>
+            <option value="same-site" {{if eq .Host.CrossOriginResourcePolicy "same-site"}}selected{{end}}>same-site</option>
+            <option value="same-origin" {{if eq .Host.CrossOriginResourcePolicy "same-origin"}}selected{{end}}>same-origin</option>
+            <option value="cross-origin" {{if eq .Host.CrossOriginResourcePolicy "cross-origin"}}selected{{end}}>cross-origin</option>
+          </select>
+          <p class="text-xs text-ink-500 mt-1">CORP header controls which origins can include this resource via &lt;script&gt;, &lt;img&gt;, fetch, etc.</p>
+        </div>
+        {{/* v2.9.136: cross_origin_embedder_policy */}}
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">Cross-Origin-Embedder-Policy</label>
+          <select name="cross_origin_embedder_policy" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+            <option value="" {{if eq .Host.CrossOriginEmbedderPolicy ""}}selected{{end}}>Not Set</option>
+            <option value="unsafe-none" {{if eq .Host.CrossOriginEmbedderPolicy "unsafe-none"}}selected{{end}}>unsafe-none</option>
+            <option value="require-corp" {{if eq .Host.CrossOriginEmbedderPolicy "require-corp"}}selected{{end}}>require-corp</option>
+            <option value="credentialless" {{if eq .Host.CrossOriginEmbedderPolicy "credentialless"}}selected{{end}}>credentialless</option>
+          </select>
+          <p class="text-xs text-ink-500 mt-1">COEP header requires all sub-resources to have CORP headers. Needed for cross-origin isolation.</p>
+        </div>
+        {{/* v2.9.156: add_document_policy */}}
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">Document-Policy Header</label>
+          <input type="text" name="add_document_policy"
+            value="{{.Host.AddDocumentPolicy}}"
+            placeholder="e.g. force-load-at-top"
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Set the Document-Policy response header to control browser feature behavior.</p>
+        </div>
+        {{/* v2.9.167: add_x_permitted_cross_domain_policies */}}
+        <div class="ml-6 mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">X-Permitted-Cross-Domain-Policies</label>
+          <input type="text" name="add_x_permitted_cross_domain_policies"
+            value="{{.Host.AddXPermittedCrossDomainPolicies}}"
+            placeholder="e.g. none, master-only, by-content-type, all"
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Sets the X-Permitted-Cross-Domain-Policies response header to restrict Adobe Flash/PDF cross-domain access.</p>
+        </div>
+        {{/* v2.9.192: add_origin_agent_cluster */}}
+        <div class="ml-6 mt-3">
+          <label class="flex items-start gap-2 cursor-pointer">
+            <input type="checkbox" name="add_origin_agent_cluster" {{if .Host.AddOriginAgentCluster}}checked{{end}}
+              class="mt-0.5 w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500">
+            <span class="text-xs font-medium text-ink-700">Add Origin-Agent-Cluster: ?1</span>
+          </label>
+          <p class="text-xs text-ink-500 mt-1 ml-6">Sets the <code>Origin-Agent-Cluster: ?1</code> response header to request origin-keyed agent cluster isolation in browsers.</p>
+        </div>
+      </div>
+
+      {{/* v2.9.3: Maintenance mode */}}
+      <div>
+        <label class="flex items-center gap-3 cursor-pointer group">
+          <input type="checkbox" name="maintenance_mode" {{if .Host.MaintenanceMode}}checked{{end}}
+            class="w-4 h-4 text-amber-600 border-gray-300 rounded focus:ring-amber-500">
+          <span class="text-sm text-gray-700 dark:text-gray-300">Maintenance mode
+            <span class="text-xs text-gray-400 ml-1">(serves 503 page instead of proxying)</span>
+          </span>
+        </label>
+      </div>
+      <div class="mt-3" id="maintenance-msg-row" style="{{if not .Host.MaintenanceMode}}display:none{{end}}">
+        <label class="block text-xs font-medium text-ink-700 mb-1">Custom maintenance message <span class="text-ink-400 font-normal">(optional)</span></label>
+        <textarea name="maintenance_msg" rows="2" placeholder="We're making improvements and will be back shortly."
+          class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition resize-none">{{.Host.MaintenanceMsg}}</textarea>
+      </div>
+      <div class="mt-3">
+        <label class="block text-xs font-medium text-ink-700 mb-1">Maintenance response code</label>
+        <select name="maintenance_status_code" class="w-48 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <option value="503" {{if or (eq .Host.MaintenanceStatusCode 503) (eq .Host.MaintenanceStatusCode 0)}}selected{{end}}>503 Service Unavailable</option>
+          <option value="429" {{if eq .Host.MaintenanceStatusCode 429}}selected{{end}}>429 Too Many Requests</option>
+          <option value="502" {{if eq .Host.MaintenanceStatusCode 502}}selected{{end}}>502 Bad Gateway</option>
+          <option value="520" {{if eq .Host.MaintenanceStatusCode 520}}selected{{end}}>520 Unknown Error</option>
+        </select>
+      </div>
+
+      <!-- v2.9.68: maintenance_retry_after_sec -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Maintenance Retry-After (s)</label>
+        <input type="number" name="maintenance_retry_after_sec" min="0"
+          value="{{.Host.MaintenanceRetryAfterSec}}"
+          placeholder="0 = default 3600"
+          class="w-36 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Value for the <code>Retry-After</code> header on maintenance 503 responses. 0 = use default of 3600 seconds (1 hour).</p>
+      </div>
+      <!-- v2.9.100: maintenance_custom_headers -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Maintenance Extra Headers</label>
+        <textarea name="maintenance_custom_headers" rows="3"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="X-Maintenance-Contact: ops@example.com">{{.Host.MaintenanceCustomHeaders}}</textarea>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Additional <code>Name: Value</code> headers included in the maintenance 503 response. One header per line. Lines beginning with <code>#</code> are ignored.</p>
+      </div>
+
+      <!-- v2.9.118: maintenance_allowed_ips -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Maintenance Bypass IPs</label>
+        <input type="text" name="maintenance_allowed_ips" value="{{.Host.MaintenanceAllowedIPs}}"
+          placeholder="192.168.1.0/24, 10.0.0.1"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated IP addresses or CIDR ranges that bypass maintenance mode and reach the upstream.</p>
+      </div>
+
+      <!-- v2.9.157: maintenance_redirect_url -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Maintenance Redirect URL</label>
+        <input type="text" name="maintenance_redirect_url" value="{{.Host.MaintenanceRedirectURL}}"
+          placeholder="https://status.example.com"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">When set, redirect to this URL instead of showing the inline maintenance page. Overrides the maintenance message.</p>
+      </div>
+
+      {{/* Scheduled Maintenance Window */}}
+      <div class="mt-3 pt-3 border-t border-ink-100">
+        <div class="flex items-center gap-1.5 mb-3">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5 text-ink-500" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"/>
+            <polyline points="12 6 12 12 16 14"/>
+          </svg>
+          <span class="text-xs font-medium text-ink-700">Scheduled Window</span>
+        </div>
+        <div class="grid grid-cols-2 gap-3 mb-3">
+          <div>
+            <label class="block text-xs text-ink-500 mb-1">Start (HH:MM)</label>
+            <input type="time" name="maintenance_window_start" value="{{.Host.MaintenanceWindowStart}}"
+              class="w-full rounded-lg border border-ink-200 px-3 py-1.5 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          </div>
+          <div>
+            <label class="block text-xs text-ink-500 mb-1">End (HH:MM)</label>
+            <input type="time" name="maintenance_window_end" value="{{.Host.MaintenanceWindowEnd}}"
+              class="w-full rounded-lg border border-ink-200 px-3 py-1.5 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-x-4 gap-y-2 mb-2" id="maint-days-row" data-days="{{.Host.MaintenanceWindowDays}}">
+          {{range $day := (splitDomains "mon,tue,wed,thu,fri,sat,sun")}}{{end}}
+          <label class="flex items-center gap-1.5 text-xs text-ink-700 cursor-pointer">
+            <input type="checkbox" name="maintenance_window_days" value="mon" class="rounded border-ink-300 text-amber-600 focus:ring-amber-500"> Mon
+          </label>
+          <label class="flex items-center gap-1.5 text-xs text-ink-700 cursor-pointer">
+            <input type="checkbox" name="maintenance_window_days" value="tue" class="rounded border-ink-300 text-amber-600 focus:ring-amber-500"> Tue
+          </label>
+          <label class="flex items-center gap-1.5 text-xs text-ink-700 cursor-pointer">
+            <input type="checkbox" name="maintenance_window_days" value="wed" class="rounded border-ink-300 text-amber-600 focus:ring-amber-500"> Wed
+          </label>
+          <label class="flex items-center gap-1.5 text-xs text-ink-700 cursor-pointer">
+            <input type="checkbox" name="maintenance_window_days" value="thu" class="rounded border-ink-300 text-amber-600 focus:ring-amber-500"> Thu
+          </label>
+          <label class="flex items-center gap-1.5 text-xs text-ink-700 cursor-pointer">
+            <input type="checkbox" name="maintenance_window_days" value="fri" class="rounded border-ink-300 text-amber-600 focus:ring-amber-500"> Fri
+          </label>
+          <label class="flex items-center gap-1.5 text-xs text-ink-700 cursor-pointer">
+            <input type="checkbox" name="maintenance_window_days" value="sat" class="rounded border-ink-300 text-amber-600 focus:ring-amber-500"> Sat
+          </label>
+          <label class="flex items-center gap-1.5 text-xs text-ink-700 cursor-pointer">
+            <input type="checkbox" name="maintenance_window_days" value="sun" class="rounded border-ink-300 text-amber-600 focus:ring-amber-500"> Sun
+          </label>
+        </div>
+        <p class="text-xs text-ink-400">If both Start and End are empty, no window is scheduled. Leave days unchecked for every day.</p>
+        <!-- v2.9.141: maintenance_window_timezone -->
+        <div class="mt-3">
+          <label class="block text-xs font-medium text-ink-700 mb-1">Maintenance Window Timezone</label>
+          <input type="text" name="maintenance_window_timezone" value="{{.Host.MaintenanceWindowTimezone}}"
+            class="w-56 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition"
+            placeholder="e.g. America/New_York">
+          <p class="text-xs text-ink-400 mt-1">IANA timezone for the scheduled maintenance window (leave blank to use server local time). Requires Maintenance Window Start/End to be set.</p>
+        </div>
+      </div>
+      <script>
+      (function(){
+        var row = document.getElementById('maint-days-row');
+        if (!row) return;
+        var saved = (row.getAttribute('data-days') || '').toLowerCase();
+        if (!saved) return;
+        row.querySelectorAll('input[type="checkbox"][name="maintenance_window_days"]').forEach(function(cb) {
+          if (saved.split(',').indexOf(cb.value) !== -1) cb.checked = true;
+        });
+      })();
+      </script>
+
+      <script>
+      (function(){
+        var cb = document.querySelector('[name="maintenance_mode"]');
+        var row = document.getElementById('maintenance-msg-row');
+        if(cb && row){ cb.addEventListener('change',function(){ row.style.display = this.checked ? '' : 'none'; }); }
+      })();
+      </script>
+
+      {{/* v2.9.3: Sticky sessions */}}
+      <div>
+        <label class="flex items-center gap-3 cursor-pointer group">
+          <input type="checkbox" name="sticky_sessions" {{if .Host.StickySessions}}checked{{end}}
+            class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500">
+          <span class="text-sm text-gray-700 dark:text-gray-300">Sticky sessions
+            <span class="text-xs text-gray-400 ml-1">(cookie-based affinity, requires multiple upstreams)</span>
+          </span>
+        </label>
+      </div>
+
+      {{/* LB Policy */}}
+      <div>
+        <label class="block text-xs font-medium text-ink-700 mb-1">LB Policy</label>
+        <select name="lb_policy" class="w-56 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <option value="" {{if eq .Host.LBPolicy ""}}selected{{end}}>Default (Caddy decides)</option>
+          <option value="round_robin" {{if eq .Host.LBPolicy "round_robin"}}selected{{end}}>Round Robin</option>
+          <option value="random" {{if eq .Host.LBPolicy "random"}}selected{{end}}>Random</option>
+          <option value="ip_hash" {{if eq .Host.LBPolicy "ip_hash"}}selected{{end}}>IP Hash</option>
+          <option value="least_conn" {{if eq .Host.LBPolicy "least_conn"}}selected{{end}}>Least Connections</option>
+          <option value="uri_hash" {{if eq .Host.LBPolicy "uri_hash"}}selected{{end}}>URI Hash</option>
+          <option value="cookie" {{if eq .Host.LBPolicy "cookie"}}selected{{end}}>Cookie</option>
+        </select>
+        <p class="text-xs text-ink-400 mt-1">Only applies when Extra Upstreams are configured. Note: 'Sticky Sessions' overrides this setting with cookie-based routing.</p>
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-ink-700 mb-1">Sticky session cookie name <span class="text-ink-400 font-normal">(optional)</span></label>
+        <input type="text" name="sticky_cookie_name" value="{{.Host.StickyCookieName}}"
+          placeholder="lb_backend"
+          class="w-48 rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+        <p class="text-xs text-ink-400 mt-1">Custom cookie name for sticky-session load balancing. Leave blank to use the default <code class="bg-ink-100 px-1 rounded">lb_backend</code>.</p>
+      </div>
+
+      <!-- v2.9.45: lb_cookie_path -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Sticky Session Cookie Path</label>
+        <input type="text" name="lb_cookie_path" value="{{.Host.LBCookiePath}}"
+          class="w-48 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="/ (default)">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Scope the sticky-session cookie to a sub-path (e.g. <code>/api</code>). Only applies when Sticky Sessions is enabled.</p>
+      </div>
+
+      <!-- v2.9.83: lb_cookie_secret -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">LB Cookie Secret (HMAC)</label>
+        <input type="password" name="lb_cookie_secret" value="{{.Host.LBCookieSecret}}"
+          class="w-64 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="(empty = unsigned cookies)">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">HMAC secret used to sign sticky-session cookie values, preventing clients from tampering with backend affinity. Only active when Sticky Sessions is enabled.</p>
+      </div>
+      <!-- v2.9.122: lb_cookie_httponly -->
+      <div class="mb-4">
+        <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+          <input type="checkbox" name="lb_cookie_httponly" {{if .Host.LBCookieHTTPOnly}}checked{{end}} class="rounded border-gray-300 dark:border-gray-600">
+          Cookie HttpOnly
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Set the HttpOnly flag on the sticky-session load-balancing cookie.</p>
+      </div>
+
+      <!-- v2.9.123: lb_cookie_secure -->
+      <div class="mb-4">
+        <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+          <input type="checkbox" name="lb_cookie_secure" {{if .Host.LBCookieSecure}}checked{{end}} class="rounded border-gray-300 dark:border-gray-600">
+          Cookie Secure
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Set the Secure flag on the sticky-session load-balancing cookie (only sent over HTTPS).</p>
+      </div>
+
+      <!-- v2.9.124: lb_cookie_same_site -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Cookie SameSite</label>
+        <select name="lb_cookie_same_site" class="mt-1 block w-full rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm text-sm">
+          <option value="" {{if eq .Host.LBCookieSameSite ""}}selected{{end}}>Default</option>
+          <option value="Strict" {{if eq .Host.LBCookieSameSite "Strict"}}selected{{end}}>Strict</option>
+          <option value="Lax" {{if eq .Host.LBCookieSameSite "Lax"}}selected{{end}}>Lax</option>
+          <option value="None" {{if eq .Host.LBCookieSameSite "None"}}selected{{end}}>None</option>
+        </select>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">SameSite attribute for the sticky-session cookie.</p>
+      </div>
+
+      <!-- v2.9.133: lb_cookie_max_age_sec -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Cookie Max-Age (sec)</label>
+        <input type="number" min="0" name="lb_cookie_max_age_sec" value="{{.Host.LBCookieMaxAgeSec}}"
+          class="w-56 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="0">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Max-Age of the sticky-session load-balancing cookie in seconds. 0 = session cookie.</p>
+      </div>
+
+      <!-- v2.9.99: lb_header_field -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">LB Header Field <span class="text-gray-400 font-normal">(for "header" policy)</span></label>
+        <input type="text" name="lb_header_field" value="{{.Host.LBHeaderField}}"
+          class="w-56 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="X-User-Id">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Request header name used for sticky routing when LB Policy is set to <em>Header</em>. The header's value is hashed to select the upstream backend.</p>
+      </div>
+
+      <!-- v2.9.113: lb_retry_on -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">LB Retry On</label>
+        <input type="text" name="lb_retry_on" value="{{.Host.LBRetryOn}}"
+          class="w-56 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="error,5xx,connect_error">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated retry trigger conditions. Options: error, 5xx, 4xx, connect_error, timeout, reset</p>
+      </div>
+
+      <div class="grid grid-cols-2 gap-3">
+        <div>
+          <label class="block text-xs font-medium text-ink-700 mb-1">LB try duration <span class="text-ink-400 font-normal">(seconds, 0 = default)</span></label>
+          <input type="number" name="lb_try_duration_sec" min="0" value="{{.Host.LBTryDurationSec}}"
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-400 mt-1">How long to keep retrying across upstreams before giving up.</p>
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-ink-700 mb-1">LB try interval <span class="text-ink-400 font-normal">(ms, 0 = default 250ms)</span></label>
+          <input type="number" name="lb_try_interval_ms" min="0" value="{{.Host.LBTryIntervalMS}}"
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-400 mt-1">Delay in milliseconds between upstream retry attempts.</p>
+        </div>
+      </div>
+
+      <!-- v2.9.142: lb_random_choose_count -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">LB Random Choose Count</label>
+        <input type="number" min="0" name="lb_random_choose_count" value="{{.Host.LBRandomChooseCount}}"
+          class="w-56 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="0">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Number of upstreams to randomly choose from for the 'random_choice' lb policy (0 = default)</p>
+      </div>
+
+      {{/* PROXY Protocol */}}
+      <div>
+        <label class="block text-xs font-medium text-ink-700 mb-1">PROXY Protocol</label>
+        <select name="proxy_protocol" class="w-56 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <option value="">Disabled</option>
+          <option value="v1" {{if eq .Host.ProxyProtocol "v1"}}selected{{end}}>PROXY v1</option>
+          <option value="v2" {{if eq .Host.ProxyProtocol "v2"}}selected{{end}}>PROXY v2</option>
+        </select>
+        <p class="text-xs text-ink-400 mt-1">Sends the client's real IP to the upstream using the PROXY protocol. The upstream must support it.</p>
+      </div>
+
+      {{/* v2.9.3: CORS */}}
+      <div class="border-t border-gray-100 dark:border-gray-800 pt-3 mt-3">
+        <label class="flex items-center gap-3 cursor-pointer group mb-2">
+          <input type="checkbox" name="cors_enabled" id="cors_enabled_toggle" {{if .Host.CORSEnabled}}checked{{end}}
+            class="w-4 h-4 text-purple-600 border-gray-300 rounded focus:ring-purple-500">
+          <span class="text-sm text-gray-700 dark:text-gray-300">Enable CORS
+            <span class="text-xs text-gray-400 ml-1">(injects Access-Control-Allow-* headers)</span>
+          </span>
+        </label>
+        <div id="cors_origins_row" class="flex items-center gap-3 ml-7" {{if not .Host.CORSEnabled}}style="display:none"{{end}}>
+          <label class="text-sm text-gray-500 dark:text-gray-400 shrink-0">Allowed origins</label>
+          <input type="text" name="cors_origins" value="{{if .Host.CORSOrigins}}{{.Host.CORSOrigins}}{{else}}*{{end}}"
+            placeholder="* or https://example.com,https://app.example.com"
+            class="flex-1 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500">
+        </div>
+        <div id="cors_credentials_row" class="ml-7 mt-2" {{if not .Host.CORSEnabled}}style="display:none"{{end}}>
+          <label class="flex items-center gap-3 cursor-pointer group">
+            <input type="checkbox" name="cors_allow_credentials" {{if .Host.CORSAllowCredentials}}checked{{end}}
+              class="w-4 h-4 text-purple-600 border-gray-300 rounded focus:ring-purple-500">
+            <span class="text-sm text-gray-700 dark:text-gray-300">Allow Credentials
+              <span class="text-xs text-gray-400 ml-1">(Add Access-Control-Allow-Credentials: true — required for cookies/auth in CORS requests)</span>
+            </span>
+          </label>
+        </div>
+        <div id="cors_expose_headers_row" class="flex items-center gap-3 ml-7 mt-2" {{if not .Host.CORSEnabled}}style="display:none"{{end}}>
+          <label class="text-sm text-gray-500 dark:text-gray-400 shrink-0">Expose Headers</label>
+          <input type="text" name="cors_expose_headers" value="{{.Host.CORSExposeHeaders}}"
+            placeholder="X-Custom-Header, X-Another-Header"
+            class="flex-1 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500">
+          <span class="text-xs text-gray-400">Comma-separated headers to expose to the browser via Access-Control-Expose-Headers</span>
+        </div>
+        <div id="cors_max_age_row" class="ml-7 mt-2 grid grid-cols-1 gap-2" {{if not .Host.CORSEnabled}}style="display:none"{{end}}>
+          <div class="flex items-center gap-3">
+            <label class="text-sm text-gray-500 dark:text-gray-400 shrink-0 w-36">Preflight max-age (s)</label>
+            <input type="number" name="cors_max_age_sec" min="0" value="{{.Host.CORSMaxAgeSec}}"
+              placeholder="86400"
+              class="w-28 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500">
+            <span class="text-xs text-gray-400">Seconds to cache preflight responses (0 = default 86400)</span>
+          </div>
+          <div class="flex items-center gap-3">
+            <label class="text-sm text-gray-500 dark:text-gray-400 shrink-0 w-36">Allow Methods</label>
+            <input type="text" name="cors_allow_methods" value="{{.Host.CORSAllowMethods}}"
+              placeholder="GET, POST, PUT, DELETE, PATCH, OPTIONS"
+              class="flex-1 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500">
+            <span class="text-xs text-gray-400">Override Access-Control-Allow-Methods (blank = use default)</span>
+          </div>
+          <div class="flex items-center gap-3">
+            <label class="text-sm text-gray-500 dark:text-gray-400 shrink-0 w-36">Allow Headers</label>
+            <input type="text" name="cors_allow_headers" value="{{.Host.CORSAllowHeaders}}"
+              placeholder="Content-Type, Authorization, X-Requested-With"
+              class="flex-1 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500">
+            <span class="text-xs text-gray-400">Override Access-Control-Allow-Headers (blank = use default)</span>
+          </div>
+        </div>
+      </div>
+      <script>
+      (function() {
+        var cb = document.getElementById('cors_enabled_toggle');
+        var rows = ['cors_origins_row', 'cors_credentials_row', 'cors_expose_headers_row', 'cors_max_age_row'].map(function(id) { return document.getElementById(id); });
+        if (cb) {
+          cb.addEventListener('change', function() {
+            rows.forEach(function(row) { if (row) row.style.display = cb.checked ? '' : 'none'; });
+          });
+        }
+      })();
+      </script>
+
+      {{/* v2.9.3: Max request body size */}}
+      <div class="flex items-center gap-3">
+        <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Max request body</label>
+        <div class="flex items-center gap-2">
+          <input type="number" name="max_request_body_mb" min="0" max="10240"
+            value="{{.Host.MaxRequestBodyMB}}"
+            class="w-28 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <span class="text-sm text-gray-500 dark:text-gray-400">MiB (0 = unlimited)</span>
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Request body read timeout <span class="text-ink-400 font-normal">(seconds, 0 = unlimited)</span></label>
+        <input type="number" name="request_body_read_timeout_sec" value="{{.Host.RequestBodyReadTimeoutSec}}" min="0" placeholder="0" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">How long to wait for the client to finish sending the request body. Guards against slow-body attacks. 0 means no limit.</p>
+      </div>
+
+      {{/* v2.9.3: Upstream response timeout */}}
+      <div class="flex items-center gap-3">
+        <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Upstream timeout</label>
+        <div class="flex items-center gap-2">
+          <input type="number" name="upstream_timeout_sec" min="0" max="3600"
+            value="{{.Host.UpstreamTimeoutSec}}"
+            class="w-28 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <span class="text-sm text-gray-500 dark:text-gray-400">seconds (0 = Caddy default)</span>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Dial Timeout (s)</label>
+        <div class="flex items-center gap-2">
+          <input type="number" name="dial_timeout_sec" min="0"
+            value="{{.Host.DialTimeoutSec}}"
+            placeholder="0 = use upstream timeout"
+            class="w-28 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <span class="text-sm text-gray-500 dark:text-gray-400">Override just the connection dial timeout (0 = same as upstream timeout)</span>
+        </div>
+      </div>
+
+      <!-- v2.9.62: dial_fallback_delay_ms -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Dial Fallback Delay (ms)</label>
+        <input type="number" name="dial_fallback_delay_ms" value="{{.Host.DialFallbackDelayMS}}"
+          class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+          min="0" placeholder="0 = default (300ms)">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Time in ms to wait before trying the next upstream after a dial failure (0 = Caddy default 300ms).</p>
+      </div>
+
+      <!-- v2.9.63: upstream_network -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream Network</label>
+        <select name="upstream_network"
+          class="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm">
+          <option value="" {{if eq .Host.UpstreamNetwork ""}}selected{{end}}>Default (tcp)</option>
+          <option value="tcp4" {{if eq .Host.UpstreamNetwork "tcp4"}}selected{{end}}>tcp4 (IPv4 only)</option>
+          <option value="tcp6" {{if eq .Host.UpstreamNetwork "tcp6"}}selected{{end}}>tcp6 (IPv6 only)</option>
+        </select>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Force IPv4 or IPv6 for upstream TCP connections. Useful in dual-stack environments.</p>
+      </div>
+
+      <!-- v2.9.64: dns_resolver -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">DNS Resolver</label>
+        <input type="text" name="dns_resolver" value="{{.Host.DNSResolver}}"
+          class="w-48 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="1.1.1.1:53 (empty = system)">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Custom DNS server for resolving upstream hostnames (e.g. <code>1.1.1.1:53</code>). Empty = use system resolver.</p>
+      </div>
+
+      <!-- v2.9.94: upstream_local_addr -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream Local Bind Address</label>
+        <input type="text" name="upstream_local_addr" value="{{.Host.UpstreamLocalAddr}}"
+          class="w-48 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="192.168.1.100 (empty = OS default)">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Local IP address to bind when dialing upstream connections. Useful on multi-homed servers to control which network interface is used for outbound traffic.</p>
+      </div>
+
+      <!-- v2.9.69: upstream_resolve_timeout_sec -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">DNS Resolve Timeout (s)</label>
+        <input type="number" name="upstream_resolve_timeout_sec" min="0"
+          value="{{.Host.UpstreamResolveTimeoutSec}}"
+          placeholder="0 = Caddy default"
+          class="w-36 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Timeout in seconds for DNS resolution when a custom DNS Resolver is configured. 0 = Caddy default.</p>
+      </div>
+
+      <!-- v2.9.65: path_matcher_type -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Path Matcher Type</label>
+        <select name="path_matcher_type"
+          class="w-40 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm">
+          <option value="" {{if eq .Host.PathMatcherType ""}}selected{{end}}>Prefix (default)</option>
+          <option value="exact" {{if eq .Host.PathMatcherType "exact"}}selected{{end}}>Exact</option>
+          <option value="regexp" {{if eq .Host.PathMatcherType "regexp"}}selected{{end}}>Regexp</option>
+        </select>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Controls how the Path Matcher field is interpreted. <strong>Prefix</strong> matches the path and any sub-paths. <strong>Exact</strong> matches only the exact path. <strong>Regexp</strong> treats the value as a Go regular expression.</p>
+      </div>
+
+      <!-- v2.9.66: cors_allow_private_network -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="cors_allow_private_network" {{if .Host.CORSAllowPrivateNetwork}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">CORS Allow Private Network</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Add <code>Access-Control-Allow-Private-Network: true</code> to CORS preflight responses (requires CORS enabled). Allows browser requests from public origins to this private-network host.</p>
+      </div>
+
+      <!-- v2.9.152: add_cors_vary_header -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_cors_vary_header" {{if .Host.AddCORSVaryHeader}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add Vary: Origin Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Append 'Origin' to the Vary response header so CDNs serve correct CORS responses per requesting origin.</p>
+      </div>
+
+      <!-- v2.9.67: robots_txt_disallow_all -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="robots_txt_disallow_all" {{if .Host.RobotsTxtDisallowAll}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Block All Robots (robots.txt)</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Intercept GET/HEAD <code>/robots.txt</code> and respond with <code>User-agent: *\nDisallow: /</code>, preventing all search-engine crawlers and bots from indexing this host.</p>
+      </div>
+
+      <!-- v2.9.76: add_canonical_link_header -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_canonical_link_header" {{if .Host.AddCanonicalLinkHeader}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add Canonical Link Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Inject <code>Link: &lt;https://primarydomain/&gt;; rel="canonical"</code> on every response, signalling the canonical URL to search engines and HTTP clients.</p>
+      </div>
+
+      <!-- v2.9.81: x_robots_tag -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">X-Robots-Tag</label>
+        <input type="text" name="x_robots_tag" value="{{.Host.XRobotsTag}}"
+          class="w-64 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="noindex, nofollow">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1"><code>X-Robots-Tag</code> response header for search-engine indexing control (e.g. <code>noindex</code>, <code>nofollow</code>, <code>noindex, nofollow</code>). Empty = omit header.</p>
+      </div>
+
+      <!-- v2.9.200: add_x_no_archive -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_no_archive" {{if .Host.AddXNoArchive}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add X-No-Archive: yes</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Sets the <code>X-No-Archive: yes</code> response header to discourage search engines from caching archived copies.</p>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Response Body Read Timeout (s)</label>
+        <div class="flex items-center gap-2">
+          <input type="number" name="read_timeout_sec" min="0"
+            value="{{.Host.ReadTimeoutSec}}"
+            placeholder="0 = no limit"
+            class="w-28 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <span class="text-sm text-gray-500 dark:text-gray-400">Max seconds to read the upstream response body (0 = unlimited)</span>
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Write timeout <span class="text-ink-400 font-normal">(seconds, 0 = unlimited)</span></label>
+        <input type="number" name="write_timeout_sec" value="{{.Host.WriteTimeoutSec}}" min="0" placeholder="0" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">Time allowed to transmit the request body to the upstream. Useful for slow-upload or large-body scenarios.</p>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Response header timeout <span class="text-ink-400 font-normal">(seconds, 0 = use upstream timeout)</span></label>
+        <input type="number" name="response_header_timeout_sec" value="{{.Host.ResponseHeaderTimeoutSec}}" min="0" placeholder="0" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">Overrides the upstream timeout specifically for waiting on response headers. Useful for long-polling backends where you want a generous response wait but a short dial timeout.</p>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Max connection duration <span class="text-ink-400 font-normal">(seconds, 0 = unlimited)</span></label>
+        <input type="number" name="max_conn_duration_sec" value="{{.Host.MaxConnDurationSec}}" min="0" placeholder="0" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">Maximum lifetime of an upstream TCP connection before Caddy replaces it. Useful with cloud load balancers (e.g. AWS ALB) that forcibly close long-lived idle connections.</p>
+      </div>
+
+      <!-- v2.9.42: upstream_max_resp_header_kb -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Max Upstream Response Header (KB)</label>
+        <input type="number" name="upstream_max_resp_header_kb" value="{{.Host.UpstreamMaxRespHeaderKB}}"
+          class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+          min="0" placeholder="0 = default">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Cap on upstream response header bytes (0 = Caddy default ~1 MB). Protects against header-flooding attacks.</p>
+      </div>
+
+      <!-- v2.9.47: tls_handshake_timeout_sec -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">TLS Handshake Timeout (s)</label>
+        <input type="number" name="tls_handshake_timeout_sec" value="{{.Host.TLSHandshakeTimeoutSec}}"
+          class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+          min="0" placeholder="0 = default">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Timeout for the TLS handshake with the upstream server (0 = Caddy default). Only applies when using HTTPS upstream.</p>
+      </div>
+
+      <!-- v2.9.48: expect_continue_timeout_sec -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Expect-Continue Timeout (s)</label>
+        <input type="number" name="expect_continue_timeout_sec" value="{{.Host.ExpectContinueTimeoutSec}}"
+          class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+          min="0" placeholder="0 = disabled">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Time to wait for an upstream 100-Continue response before sending the request body (0 = no wait). Useful for large file uploads.</p>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <label class="inline-flex items-center gap-2 cursor-pointer select-none">
+          <input type="checkbox" name="decompress_response" {{if .Host.DecompressResponse}}checked{{end}} class="h-4 w-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
+          <span class="text-sm font-medium text-ink-800">Decompress upstream responses</span>
+        </label>
+        <span class="text-xs text-ink-400">When enabled, Caddy decompresses gzip/brotli responses from the upstream before forwarding to the client. Useful when transforming response bodies.</span>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Request Body Buffer (KB)</label>
+        <div class="flex items-center gap-2">
+          <input type="number" name="request_buffers_kb" min="0"
+            value="{{.Host.RequestBuffersKB}}"
+            placeholder="0 = disabled"
+            class="w-28 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <span class="text-sm text-gray-500 dark:text-gray-400">Buffer this many KB of the request body before forwarding (0 = stream directly)</span>
+        </div>
       </div>
 
       {{/* TLS minimum version */}}
@@ -228,18 +1558,1117 @@
         <p class="text-xs text-ink-500 sm:pt-7">Sets a per-SNI TLS connection policy in Caddy. TLS 1.2+ is the modern standard. TLS 1.3 offers improved security and performance but drops support for some older clients.</p>
       </div>
 
+      {{/* v2.9.4: Active upstream health check */}}
+      <div class="border-t border-gray-100 dark:border-gray-800 pt-3 mt-3 space-y-3">
+        <p class="text-xs font-medium text-ink-700">Active upstream health check <span class="font-normal text-ink-400">(Caddy polls each upstream on this URI)</span></p>
+        <div class="flex items-center gap-3">
+          <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Health check URI</label>
+          <input type="text" name="health_check_uri" value="{{.Host.HealthCheckURI}}"
+            placeholder="/health or /ping"
+            class="flex-1 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+        </div>
+        <!-- v2.9.43: health_check_port -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Health Check Port</label>
+          <input type="number" name="health_check_port" value="{{.Host.HealthCheckPort}}"
+            class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+            min="0" max="65535" placeholder="0 = same port">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Run health probes on a different port than traffic (e.g. app serves /health on :8080 but traffic on :80). 0 = use same port as upstream.</p>
+        </div>
+        <!-- v2.9.55: health_check_max_size_kb -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Health Check Max Response (KB)</label>
+          <input type="number" name="health_check_max_size_kb" value="{{.Host.HealthCheckMaxSizeKB}}"
+            class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+            min="0" placeholder="0 = default">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Max response body size to read during health probes (0 = Caddy default). Limits memory use when health endpoints return large payloads.</p>
+        </div>
+        <div class="flex items-center gap-3">
+          <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Check interval</label>
+          <div class="flex items-center gap-2">
+            <input type="number" name="health_check_interval_sec" min="5" max="3600"
+              value="{{if .Host.HealthCheckIntervalSec}}{{.Host.HealthCheckIntervalSec}}{{else}}30{{end}}"
+              class="w-28 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <span class="text-sm text-gray-500 dark:text-gray-400">seconds</span>
+          </div>
+        </div>
+        <div class="flex items-center gap-3">
+          <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Method</label>
+          <div class="w-32">
+            <select name="health_check_method" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+              <option value="GET" {{if or (eq .Host.HealthCheckMethod "GET") (eq .Host.HealthCheckMethod "")}}selected{{end}}>GET</option>
+              <option value="HEAD" {{if eq .Host.HealthCheckMethod "HEAD"}}selected{{end}}>HEAD</option>
+              <option value="POST" {{if eq .Host.HealthCheckMethod "POST"}}selected{{end}}>POST</option>
+            </select>
+          </div>
+        </div>
+        <div class="flex items-center gap-3">
+          <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Timeout</label>
+          <div class="w-32">
+            <label class="block text-xs font-medium text-ink-700 mb-1">Timeout (s)</label>
+            <input type="number" name="health_check_timeout_sec" min="1" max="60"
+              value="{{if .Host.HealthCheckTimeoutSec}}{{.Host.HealthCheckTimeoutSec}}{{else}}5{{end}}"
+              class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          </div>
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-ink-700 mb-1">Health Check Headers</label>
+          <textarea name="health_check_headers" rows="2"
+            placeholder='{"Authorization":"Bearer token"}'
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition resize-none">{{.Host.HealthCheckHeaders}}</textarea>
+          <p class="text-xs text-ink-500 mt-1">JSON object of extra headers sent with each health-check probe (e.g. <code class="font-mono bg-ink-100 px-1 rounded">{"X-Health":"1"}</code>)</p>
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-ink-700 mb-1">Expected status code <span class="text-ink-400 font-normal">(0 = any 2xx)</span></label>
+          <input type="number" name="health_check_expect_status" min="0" max="599" value="{{.Host.HealthCheckExpectStatus}}"
+            class="w-32 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Require this exact HTTP status code from the health-check probe. 0 accepts any 2xx response.</p>
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-ink-700 mb-1">Expected body (regexp) <span class="text-ink-400 font-normal">(optional)</span></label>
+          <input type="text" name="health_check_expect_body" value="{{.Host.HealthCheckExpectBody}}"
+            placeholder="ok|healthy"
+            class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <p class="text-xs text-ink-500 mt-1">Go regexp that must match somewhere in the health-check response body. Leave blank to skip body check.</p>
+        </div>
+        <!-- v2.9.75: health_check_body -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Health Check Request Body</label>
+          <input type="text" name="health_check_body" value="{{.Host.HealthCheckBody}}"
+            class="w-full max-w-md rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+            placeholder='{"status":"ok"}  (empty = no request body)'>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Request body sent with each active health check probe. Useful for GraphQL introspection or JSON health APIs that require a POST body.</p>
+        </div>
+        <!-- v2.9.85: health_check_content_type -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Health Check Content-Type</label>
+          <input type="text" name="health_check_content_type" value="{{.Host.HealthCheckContentType}}"
+            class="w-64 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+            placeholder="application/json">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1"><code>Content-Type</code> header sent with health check probe requests. Useful when <strong>Health Check Body</strong> contains a JSON payload.</p>
+        </div>
+        <!-- v2.9.111: health_check_host_override -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Health Check Host Header</label>
+          <input type="text" name="health_check_host_override" value="{{.Host.HealthCheckHostOverride}}"
+            class="w-64 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+            placeholder="backend.internal.example.com">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Override the <code>Host</code> header sent during active health check probes. Leave blank to use the upstream address.</p>
+        </div>
+        <!-- v2.9.180: health_check_user_agent -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Health Check User-Agent</label>
+          <input type="text" name="health_check_user_agent" value="{{.Host.HealthCheckUserAgent}}"
+            class="w-64 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+            placeholder="e.g. CaddyHealthCheck/1.0">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Custom <code>User-Agent</code> header sent with active health check probes.</p>
+        </div>
+        <!-- v2.9.148: health_check_tls_server_name -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Health Check TLS Server Name</label>
+          <input type="text" name="health_check_tls_server_name" value="{{.Host.HealthCheckTLSServerName}}"
+            class="w-64 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+            placeholder="e.g. backend.internal">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">TLS SNI override used for active health check probe connections. Leave empty to use the upstream host.</p>
+        </div>
+        <!-- v2.9.151: health_check_tls_insecure_skip_verify -->
+        <div class="mb-4 flex items-center gap-3">
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" name="health_check_tls_insecure_skip_verify" {{if .Host.HealthCheckTLSInsecureSkipVerify}}checked{{end}}
+              class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Health Check: Skip TLS Verification</span>
+          </label>
+          <p class="text-xs text-gray-500 dark:text-gray-400">Skip TLS certificate verification for active health check probe connections. Useful when backend has a self-signed certificate.</p>
+        </div>
+        <label class="flex items-center gap-3 cursor-pointer">
+          <input type="checkbox" name="health_check_follow_redirects" value="on" {{if .Host.HealthCheckFollowRedirects}}checked{{end}}
+            class="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+          <span class="text-sm text-ink-700">Follow redirects during health check probes</span>
+        </label>
+      </div>
+
+      {{/* Passive upstream health checks */}}
+      <div class="border-t border-gray-100 dark:border-gray-800 pt-3 mt-3 space-y-3">
+        <p class="text-xs font-medium text-ink-700">Passive checks <span class="font-normal text-ink-400">(marks upstreams unhealthy based on observed errors)</span></p>
+        <div class="flex items-center gap-3">
+          <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Passive fail duration (s)</label>
+          <div class="flex items-center gap-2">
+            <input type="number" name="passive_fail_duration_sec" min="0"
+              value="{{.Host.PassiveFailDurationSec}}"
+              class="w-28 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <span class="text-sm text-gray-500 dark:text-gray-400">seconds to keep a failing upstream out of rotation. 0 = disabled.</span>
+          </div>
+        </div>
+        <div class="flex items-center gap-3">
+          <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Max consecutive fails</label>
+          <div class="flex items-center gap-2">
+            <input type="number" name="passive_max_fails" min="0"
+              value="{{.Host.PassiveMaxFails}}"
+              class="w-28 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <span class="text-sm text-gray-500 dark:text-gray-400">failures before marking unhealthy. 0 = Caddy default (1).</span>
+          </div>
+        </div>
+        <!-- v2.9.46: passive_unhealthy_latency_ms -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Passive Unhealthy Latency (ms)</label>
+          <input type="number" name="passive_unhealthy_latency_ms" value="{{.Host.PassiveUnhealthyLatencyMS}}"
+            class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+            min="0" placeholder="0 = disabled">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Mark upstream passive-unhealthy if response exceeds this latency (0 = disabled). e.g. 5000 = 5 seconds.</p>
+        </div>
+        <!-- v2.9.84: passive_unhealthy_status_codes -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Passive Unhealthy Status Codes</label>
+          <input type="text" name="passive_unhealthy_status_codes" value="{{.Host.PassiveUnhealthyStatusCodes}}"
+            class="w-64 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+            placeholder="500,502,503">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated HTTP response codes from the upstream that trigger passive health-check failures. Empty = Caddy default (5xx codes).</p>
+        </div>
+        <!-- v2.9.130: passive_unhealthy_count -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Passive Unhealthy Request Count</label>
+          <input type="number" name="passive_unhealthy_count" value="{{.Host.PassiveUnhealthyCount}}"
+            class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+            min="0" placeholder="0">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Mark upstream unhealthy when concurrent in-flight requests exceed this count. 0 = disabled.</p>
+        </div>
+      </div>
+
+      {{/* v2.9.5: Disable access log collection */}}
+      <div>
+        <label class="flex items-center gap-3 cursor-pointer group">
+          <input type="checkbox" name="disable_access_log" {{if .Host.DisableAccessLog}}checked{{end}}
+            class="w-4 h-4 text-gray-600 border-gray-300 rounded focus:ring-gray-500">
+          <span class="text-sm text-gray-700 dark:text-gray-300">Disable access log
+            <span class="text-xs text-gray-400 ml-1">(exclude from analytics collection)</span>
+          </span>
+        </label>
+      </div>
+
+      {{/* Feature A: Inject X-Request-Id header */}}
+      <div>
+        <label class="flex items-center gap-3 cursor-pointer">
+          <input type="checkbox" name="add_request_id" value="on" {{if .Host.AddRequestID}}checked{{end}}
+            class="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+          <span class="text-sm text-ink-700">Inject <code class="text-xs bg-ink-100 px-1 rounded">X-Request-Id</code> header</span>
+        </label>
+      </div>
+
+      <!-- v2.9.44: request_id_header_name -->
+      <div class="mb-4 ml-6">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Request ID Header Name</label>
+        <input type="text" name="request_id_header_name" value="{{.Host.RequestIDHeaderName}}"
+          class="w-48 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="X-Request-Id">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Custom header name for the injected request ID. Leave blank for default <code>X-Request-Id</code>.</p>
+      </div>
+
+      <!-- v2.9.147: add_request_id_to_response -->
+      <div class="ml-6">
+        <label class="flex items-center gap-3 cursor-pointer">
+          <input type="checkbox" name="add_request_id_to_response" value="on" {{if .Host.AddRequestIDToResponse}}checked{{end}}
+            class="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+          <span class="text-sm text-ink-700">Echo Request ID in Response</span>
+        </label>
+        <p class="text-xs text-ink-500 mt-1 ml-7">Copy the X-Request-Id (or custom trace header) to the response for client-side debugging. Requires 'Add Request ID' to be enabled.</p>
+      </div>
+
+      <!-- v2.9.102: inject_request_timestamp -->
+      <div>
+        <label class="flex items-center gap-3 cursor-pointer">
+          <input type="checkbox" name="inject_request_timestamp" value="on" {{if .Host.InjectRequestTimestamp}}checked{{end}}
+            class="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+          <span class="text-sm text-ink-700">Inject <code class="text-xs bg-ink-100 px-1 rounded">X-Request-Timestamp</code> header</span>
+        </label>
+        <p class="text-xs text-ink-500 mt-1 ml-7">Adds an <code>X-Request-Timestamp</code> header with the current UNIX epoch to every upstream request. Useful for logging and replay-attack detection.</p>
+      </div>
+
+      <!-- v2.9.140: add_x_request_start -->
+      <div>
+        <label class="flex items-center gap-3 cursor-pointer">
+          <input type="checkbox" name="add_x_request_start" value="on" {{if .Host.AddXRequestStart}}checked{{end}}
+            class="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+          <span class="text-sm text-ink-700">Add X-Request-Start Header</span>
+        </label>
+        <p class="text-xs text-ink-500 mt-1 ml-7">Inject X-Request-Start: t=&lt;epoch_ms&gt; request header for APM timing tools (New Relic, Datadog, etc.)</p>
+      </div>
+
+      <!-- v2.9.105: add_upstream_timing_header -->
+      <div>
+        <label class="flex items-center gap-3 cursor-pointer">
+          <input type="checkbox" name="add_upstream_timing_header" value="on" {{if .Host.AddUpstreamTimingHeader}}checked{{end}}
+            class="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+          <span class="text-sm text-ink-700">Inject <code class="text-xs bg-ink-100 px-1 rounded">X-Upstream-Time</code> response header</span>
+        </label>
+        <p class="text-xs text-ink-500 mt-1 ml-7">Adds an <code>X-Upstream-Time</code> response header containing the upstream's response latency. Useful for performance monitoring without a dedicated APM tool.</p>
+      </div>
+
+      <!-- v2.9.161: add_server_timing_header -->
+      <div>
+        <label class="flex items-center gap-3 cursor-pointer">
+          <input type="checkbox" name="add_server_timing_header" value="on" {{if .Host.AddServerTimingHeader}}checked{{end}}
+            class="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+          <span class="text-sm text-ink-700">Add Server-Timing Header</span>
+        </label>
+        <p class="text-xs text-ink-500 mt-1 ml-7">Inject standard Server-Timing response header with the upstream processing duration for performance monitoring.</p>
+      </div>
+
+      {{/* Feature C: Block user-agents */}}
+      <div>
+        <label class="block text-xs font-medium text-ink-700 mb-1">Block user-agents <span class="text-ink-400 font-normal">(comma-separated keywords, e.g. curl,sqlmap,scrapy)</span></label>
+        <input type="text" name="blocked_agents" value="{{.Host.BlockedAgents}}"
+          placeholder="sqlmap, nikto, scrapy"
+          class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+      </div>
+
+      <!-- v2.9.78: block_ua_regexp -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Block User-Agent (Regexp)</label>
+        <input type="text" name="block_ua_regexp" value="{{.Host.BlockUARegexp}}"
+          class="w-full max-w-lg rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="(?i)(curl|python-requests|Go-http-client)">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Go regular expression matched against the <code>User-Agent</code> request header. Requests that match receive a 403. Unlike the UA pattern list above, this field accepts a single full regexp with alternation (e.g. <code>(?i)badbot|scraper</code>).</p>
+      </div>
+
+      <!-- v2.9.107: block_referer_regexp -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Block Referer (Regexp)</label>
+        <input type="text" name="block_referer_regexp" value="{{.Host.BlockRefererRegexp}}"
+          class="w-full max-w-lg rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="(?i)competitor\.com|hotlinking-site\.net">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Go regular expression matched against the <code>Referer</code> request header. Requests that match receive a 403. Useful for hotlink protection and blocking traffic from specific referring sites.</p>
+      </div>
+      <!-- v2.9.121: deny_referer_empty -->
+      <div class="mb-4">
+        <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+          <input type="checkbox" name="deny_referer_empty" {{if .Host.DenyRefererEmpty}}checked{{end}} class="rounded border-gray-300 dark:border-gray-600">
+          Deny Empty Referer
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Block requests with no Referer header (prevents direct hotlinking of resources).</p>
+      </div>
+
+      {{/* API Key Authentication */}}
+      <div class="border-t border-ink-100 pt-3 mt-1">
+        <p class="text-xs font-medium text-ink-700 mb-3">API Key Auth <span class="font-normal text-ink-400">(gate all requests with a shared secret header)</span></p>
+        <div class="space-y-3">
+          <div>
+            <label class="block text-xs font-medium text-ink-700 mb-1">API Key Header Name</label>
+            <input type="text" name="api_key_header" value="{{.Host.APIKeyHeader}}"
+              placeholder="X-API-Key"
+              class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+            <p class="text-xs text-ink-500 mt-1">Header name required on all requests (leave blank to disable API key auth)</p>
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-ink-700 mb-1">API Key Value</label>
+            <input type="text" name="api_key_value" value="{{.Host.APIKeyValue}}"
+              placeholder="secret-token-here"
+              class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+            <p class="text-xs text-ink-500 mt-1">Expected value of the API key header; requests without this value receive 401</p>
+          </div>
+      <!-- v2.9.77: http_basic_auth_upstream -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream Basic Auth Credentials</label>
+        <input type="text" name="http_basic_auth_upstream" value="{{.Host.HTTPBasicAuthUpstream}}"
+          class="w-64 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="user:password">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Inject an <code>Authorization: Basic …</code> header on every upstream request. Format: <code>username:password</code>. The value is base64-encoded at config-build time. Leave empty to disable.</p>
+      </div>
+          <label class="flex items-start gap-2.5 cursor-pointer">
+            <input type="checkbox" name="block_empty_user_agent" {{if .Host.BlockEmptyUserAgent}}checked{{end}}
+              class="mt-0.5 rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
+            <span>Block Requests Without User-Agent<span class="block text-xs text-ink-500 mt-0.5 font-normal">Return 403 to requests that have no User-Agent header (blocks most scanners/bots)</span></span>
+          </label>
+        </div>
+      </div>
+
+      {{/* v2.9.27: Forward Auth */}}
+      <div class="border-t border-ink-100 pt-3 mt-1">
+        <p class="text-xs font-medium text-ink-700 mb-3">Forward Auth <span class="font-normal text-ink-400">(delegate authentication to an external service before proxying)</span></p>
+        <div class="space-y-3">
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Forward auth URL <span class="text-ink-400 font-normal">(optional)</span></label>
+        <input type="text" name="forward_auth_url" value="{{.Host.ForwardAuthURL}}" placeholder="http://authelia:9091/api/verify" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">Delegates authentication to this service before proxying. If it returns non-2xx the response is sent to the client directly. Leave blank to disable.</p>
+      </div>
+
+      <!-- v2.9.52: forward_auth_method -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Forward Auth Method</label>
+        <select name="forward_auth_method"
+          class="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm">
+          <option value="" {{if eq .Host.ForwardAuthMethod ""}}selected{{end}}>GET (default)</option>
+          <option value="POST" {{if eq .Host.ForwardAuthMethod "POST"}}selected{{end}}>POST</option>
+          <option value="HEAD" {{if eq .Host.ForwardAuthMethod "HEAD"}}selected{{end}}>HEAD</option>
+        </select>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">HTTP method for the auth subrequest (only used when Forward Auth URL is set).</p>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Copy auth headers <span class="text-ink-400 font-normal">(optional)</span></label>
+        <input type="text" name="forward_auth_copy_headers" value="{{.Host.ForwardAuthCopyHeaders}}" placeholder="Remote-User,Remote-Groups,Remote-Email" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">Comma-separated response headers from the auth service to copy into the upstream request. Requires Forward auth URL to be set.</p>
+      </div>
+
+      <!-- v2.9.54: forward_auth_headers_prefix -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Forward Auth Headers Prefix</label>
+        <input type="text" name="forward_auth_headers_prefix" value="{{.Host.ForwardAuthHeadersPrefix}}"
+          class="w-48 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. X-Auth-">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Prefix applied to all copied headers from the auth response (e.g. <code>X-Auth-</code> → <code>X-Auth-User</code>). Only used with Forward Auth URL.</p>
+      </div>
+
+      <!-- v2.9.184: forward_auth_skip_paths -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Forward Auth: Skip Paths</label>
+        <input type="text" name="forward_auth_skip_paths" value="{{.Host.ForwardAuthSkipPaths}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. /health, /metrics, /favicon.ico">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated path prefixes that bypass forward_auth (useful for health checks, metrics, public assets).</p>
+      </div>
+        </div>
+      </div>
+
+      <!-- v2.9.60: keepalive_disabled -->
+<div class="flex items-center mb-4">
+  <input type="checkbox" name="keepalive_disabled" id="keepalive_disabled" value="on" {{if .Host.KeepaliveDisabled}}checked{{end}}
+    class="rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 mr-2">
+  <label for="keepalive_disabled" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+    Disable Upstream Keepalive
+    <span class="text-xs font-normal text-gray-500 dark:text-gray-400 ml-1">— each upstream request gets a new connection (required for NTLM auth)</span>
+  </label>
+</div>
+      {{/* v2.9.4: Keepalive connection pooling */}}
+      <div class="flex items-center gap-3">
+        <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Keepalive pool</label>
+        <div class="flex items-center gap-2">
+          <input type="number" name="keepalive_conns" min="0" max="1000"
+            value="{{.Host.KeepaliveConns}}"
+            class="w-28 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <span class="text-sm text-gray-500 dark:text-gray-400">max idle connections (0 = Caddy default)</span>
+        </div>
+      </div>
+
+      <!-- v2.9.50: upstream_max_idle_conns -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Max Idle Connections (total)</label>
+        <input type="number" name="upstream_max_idle_conns" value="{{.Host.UpstreamMaxIdleConns}}"
+          class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+          min="0" placeholder="0 = default">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Max total idle upstream connections across all hosts (0 = Caddy default). Complements "Keepalive Conns" which is per-host.</p>
+      </div>
+
+      <!-- v2.9.51: upstream_keep_alive_probe_sec -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Keepalive Probe Interval (s)</label>
+        <input type="number" name="upstream_keep_alive_probe_sec" value="{{.Host.UpstreamKeepAliveProbeIntervalSec}}"
+          class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+          min="0" placeholder="0 = no probing">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">How often to probe idle upstream connections (0 = disabled). Detects stale connections before they're used.</p>
+      </div>
+
+      <!-- v2.9.115: upstream_keepalive_probes -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Keepalive Probes</label>
+        <input type="number" min="0" name="upstream_keepalive_probes" value="{{.Host.UpstreamKeepaliveProbes}}"
+          placeholder="0"
+          class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Number of TCP keepalive probes for upstream connections. 0 = OS default.</p>
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-ink-700 mb-1">Keepalive idle timeout <span class="text-ink-400 font-normal">(seconds, 0 = default 90 s)</span></label>
+        <input type="number" name="keepalive_idle_timeout_sec" min="0" value="{{.Host.KeepaliveIdleTimeoutSec}}"
+          class="w-32 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+        <p class="text-xs text-ink-500 mt-1">How long idle keepalive connections are kept open before being closed.</p>
+      </div>
+
+      <!-- v2.9.158: upstream_keepalive_max_lifetime_sec -->
+      <div>
+        <label class="block text-xs font-medium text-ink-700 mb-1">Keepalive Max Lifetime (seconds) <span class="text-ink-400 font-normal">(0 = no limit)</span></label>
+        <input type="number" name="upstream_keepalive_max_lifetime_sec" min="0" value="{{.Host.UpstreamKeepaliveMaxLifetimeSec}}"
+          class="w-32 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+        <p class="text-xs text-ink-500 mt-1">Maximum duration a keepalive connection is kept before being recycled. 0 = no limit.</p>
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-ink-700 mb-1">Max connections per upstream <span class="text-ink-400 font-normal">(0 = unlimited)</span></label>
+        <input type="number" name="max_conns_per_host" min="0" value="{{.Host.MaxConnsPerHost}}"
+          class="w-32 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-ink-700 mb-1">Upstream retries <span class="text-ink-400 font-normal">(0 = no retry)</span></label>
+        <input type="number" name="upstream_retries" min="0" max="10" value="{{.Host.UpstreamRetries}}"
+          class="w-24 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Retry status codes <span class="text-ink-400 font-normal">(optional)</span></label>
+        <input type="text" name="retry_status_codes" value="{{.Host.RetryStatusCodes}}" placeholder="502,503,504" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">Comma-separated HTTP status codes that trigger a retry to the next upstream. Requires at least 2 upstreams or upstream_retries &gt; 0.</p>
+      </div>
+
+      <label class="flex items-center gap-3 cursor-pointer">
+        <input type="checkbox" name="force_http1" value="on" {{if .Host.ForceHTTP1}}checked{{end}}
+          class="w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+        <span class="text-sm text-ink-700">Force HTTP/1.1 to upstream</span>
+      </label>
+
+      <label class="flex items-start gap-2.5 cursor-pointer">
+        <input type="checkbox" name="h2c_enabled" value="on" {{if .Host.H2CEnabled}}checked{{end}}
+          class="mt-0.5 w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+        <span>
+          <span class="text-sm font-medium text-ink-800">H2C (HTTP/2 Cleartext)</span>
+          <span class="block text-xs text-ink-500 mt-0.5">Use HTTP/2 cleartext transport to the upstream (useful for gRPC backends)</span>
+        </span>
+      </label>
+
+      <!-- v2.9.74: upstream_http_versions -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream HTTP Versions</label>
+        <input type="text" name="upstream_http_versions" value="{{.Host.UpstreamHTTPVersions}}"
+          class="w-48 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="1.1,2  (empty = Caddy default)">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated HTTP versions for upstream transport (e.g. <code>1.1</code>, <code>2</code>, <code>1.1,2</code>). Ignored when Force HTTP/1 or H2C is enabled. Empty = Caddy default (1.1 and 2).</p>
+      </div>
+
+      <!-- v2.9.92: http2_push_paths -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">HTTP/2 Push Paths</label>
+        <textarea name="http2_push_paths" rows="3"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="/style.css&#10;/app.js&#10;/fonts/inter.woff2">{{.Host.HTTP2PushPaths}}</textarea>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">One resource path per line. Caddy will push these resources to the client via HTTP/2 server push before the upstream response arrives, reducing perceived page-load time. Lines starting with <code>#</code> are ignored.</p>
+      </div>
+
+      <!-- v2.9.53: grpc_web_enabled -->
+<div class="flex items-center mb-4">
+  <input type="checkbox" name="grpc_web_enabled" id="grpc_web_enabled" value="on" {{if .Host.GRPCWebEnabled}}checked{{end}}
+    class="rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 mr-2">
+  <label for="grpc_web_enabled" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+    gRPC-Web Enabled
+    <span class="text-xs font-normal text-gray-500 dark:text-gray-400 ml-1">— transcode gRPC-Web requests for browser clients to standard gRPC for the upstream</span>
+  </label>
+</div>
+
+      <label class="flex items-start gap-2.5 cursor-pointer">
+        <input type="checkbox" name="flush_immediate" value="on" {{if .Host.FlushImmediate}}checked{{end}}
+          class="mt-0.5 w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+        <span>
+          <span class="text-sm font-medium text-ink-800">Flush Immediately (Streaming Mode)</span>
+          <span class="block text-xs text-ink-500 mt-0.5">Set flush_interval:-1 for SSE, server-sent events, or other streaming backends</span>
+        </span>
+      </label>
+
+      <label class="flex items-start gap-2.5 cursor-pointer">
+        <input type="checkbox" name="buffer_responses" value="on" {{if .Host.BufferResponses}}checked{{end}}
+          class="mt-0.5 w-4 h-4 rounded border-ink-300 text-brand-600 focus:ring-brand-500 cursor-pointer">
+        <span>
+          <span class="text-sm font-medium text-ink-800">Buffer Full Response</span>
+          <span class="block text-xs text-ink-500 mt-0.5">Buffer the complete upstream response before forwarding (frees upstream connections faster)</span>
+        </span>
+      </label>
+
+      <!-- v2.9.116: upstream_flush_interval_ms -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Flush Interval (ms)</label>
+        <input type="number" name="upstream_flush_interval_ms" value="{{.Host.UpstreamFlushIntervalMS}}" placeholder="0"
+          class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Override flush_interval in milliseconds. 0 = default. -1 = flush immediately (same as Flush Immediate). Positive = interval.</p>
+      </div>
+
+      <!-- v2.9.114: max_buffer_size_kb -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Max Buffer Size (KB)</label>
+        <input type="number" min="0" name="max_buffer_size_kb" value="{{.Host.MaxBufferSizeKB}}"
+          placeholder="0"
+          class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Maximum response buffer size in KB when Buffer Responses is enabled. 0 = unlimited.</p>
+      </div>
+
+      <!-- v2.9.49: response_buffers_kb -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Response Buffer Size (KB)</label>
+        <input type="number" name="response_buffers_kb" value="{{.Host.ResponseBuffersKB}}"
+          class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm"
+          min="0" placeholder="0 = default">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Per-connection streaming response buffer size in KB (0 = Caddy default). Distinct from "Buffer Responses" — controls chunk size, not full buffering.</p>
+      </div>
+
+      <!-- v2.9.70: upstream_read_buffer_size_kb -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream Read Buffer (KB)</label>
+        <input type="number" name="upstream_read_buffer_size_kb" min="0"
+          value="{{.Host.UpstreamReadBufferSizeKB}}"
+          placeholder="0 = Caddy default (32 KB)"
+          class="w-48 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Transport read buffer size in KB for reading upstream responses. 0 = Caddy default (32 KB). Increase for very large response headers or chunked streaming.</p>
+      </div>
+
+      <!-- v2.9.71: upstream_write_buffer_size_kb -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream Write Buffer (KB)</label>
+        <input type="number" name="upstream_write_buffer_size_kb" min="0"
+          value="{{.Host.UpstreamWriteBufferSizeKB}}"
+          placeholder="0 = Caddy default (32 KB)"
+          class="w-48 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Transport write buffer size in KB for sending requests to upstream. 0 = Caddy default (32 KB).</p>
+      </div>
+
     </div>
   </details>
 
+  {{/* v2.9.2: URL Rewrites */}}
+<details class="pt-4 border-t border-ink-100"{{if .Host.URLRewriteList}} open{{end}}>
+  <summary class="cursor-pointer select-none text-xs uppercase tracking-wider text-ink-500 hover:text-ink-700 font-medium transition">
+    URL Rewrites
+  </summary>
+  <div class="mt-3 space-y-3">
+    <p class="text-xs text-ink-400">Rewrite request paths before they reach the upstream. Rules are applied in order.</p>
+
+    <div id="rewrite-rows" class="space-y-2">
+      {{range .Host.URLRewriteList}}
+      <div class="rw-row flex items-center gap-2">
+        <select name="rewrite_type[]" class="text-sm px-2 py-1.5 rounded-lg border border-ink-200 bg-white text-ink-900 w-36 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+          <option value="strip_prefix"{{if eq .Type "strip_prefix"}} selected{{end}}>Strip prefix</option>
+          <option value="add_prefix"{{if eq .Type "add_prefix"}} selected{{end}}>Add prefix</option>
+          <option value="regex"{{if eq .Type "regex"}} selected{{end}}>Regex</option>
+        </select>
+        <input type="text" name="rewrite_from[]" placeholder="From (e.g. /api or ^/old)" value="{{.From}}"
+          class="flex-1 text-sm px-3 py-1.5 rounded-lg border border-ink-200 bg-white text-ink-900 font-mono focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+        <input type="text" name="rewrite_to[]" placeholder="To (regex only)" value="{{.To}}"
+          class="w-40 text-sm px-3 py-1.5 rounded-lg border border-ink-200 bg-white text-ink-900 font-mono focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+        <button type="button" onclick="this.closest('.rw-row').remove()" class="text-red-500 hover:text-red-700 text-xs px-2 py-1 rounded transition shrink-0">&#x2715;</button>
+      </div>
+      {{end}}
+    </div>
+
+    <button type="button" id="rw-add" class="inline-flex items-center gap-1 text-xs text-brand-600 hover:text-brand-700 font-medium mt-2 transition">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      Add rewrite rule
+    </button>
+
+    <p class="text-xs text-ink-400 mt-1">
+      <strong>strip_prefix</strong>: remove a leading path prefix (e.g. <code class="font-mono bg-ink-100 px-1 rounded">/api</code> strips <code class="font-mono bg-ink-100 px-1 rounded">/api</code> from every request path).<br>
+      <strong>add_prefix</strong>: prepend a path segment to every request.<br>
+      <strong>regex</strong>: regexp find &rarr; replace on the request path.
+    </p>
+  </div>
+</details>
+
+<script>
+(function() {
+  var rwAdd = document.getElementById('rw-add');
+  var rwContainer = document.getElementById('rewrite-rows');
+  if (!rwAdd || !rwContainer) return;
+  rwAdd.addEventListener('click', function() {
+    var div = document.createElement('div');
+    div.className = 'rw-row flex items-center gap-2';
+    div.innerHTML =
+      '<select name="rewrite_type[]" class="text-sm px-2 py-1.5 rounded-lg border border-ink-200 bg-white text-ink-900 w-36 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">'
+      + '<option value="strip_prefix">Strip prefix</option>'
+      + '<option value="add_prefix">Add prefix</option>'
+      + '<option value="regex">Regex</option>'
+      + '</select>'
+      + '<input type="text" name="rewrite_from[]" placeholder="From (e.g. /api or ^/old)" class="flex-1 text-sm px-3 py-1.5 rounded-lg border border-ink-200 bg-white text-ink-900 font-mono focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">'
+      + '<input type="text" name="rewrite_to[]" placeholder="To (regex only)" class="w-40 text-sm px-3 py-1.5 rounded-lg border border-ink-200 bg-white text-ink-900 font-mono focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">'
+      + '<button type="button" onclick="this.closest(\'.rw-row\').remove()" class="text-red-500 hover:text-red-700 text-xs px-2 py-1 rounded transition shrink-0">✕</button>';
+    rwContainer.appendChild(div);
+    div.querySelector('input[name="rewrite_from[]"]').focus();
+  });
+})();
+</script>
+
+  {{/* v2.9.1: Custom Headers */}}
+<details class="pt-4 border-t border-ink-100"{{if or .Host.CustomReqHeaderMap .Host.CustomRespHeaderMap}} open{{end}}>
+  <summary class="cursor-pointer select-none text-xs uppercase tracking-wider text-ink-500 hover:text-ink-700 font-medium transition">
+    Custom Headers <span class="font-normal normal-case">(request &amp; response)</span>
+  </summary>
+  <div class="mt-3 space-y-5">
+
+    {{/* Request headers */}}
+    <div>
+      <p class="text-xs font-medium text-ink-700 mb-2">Request headers <span class="font-normal text-ink-400">(sent upstream)</span></p>
+      <p class="text-xs text-ink-400 mb-2">Override or inject headers on the request forwarded to your upstream. Leave the value blank to <strong>delete</strong> the header. Caddy placeholders like <code class="font-mono bg-ink-100 px-1 rounded">{http.request.remote.host}</code> work here.</p>
+      <div id="req-headers-list" class="space-y-2">
+        {{range $k, $v := .Host.CustomReqHeaderMap}}
+        <div class="hdr-row flex items-center gap-2">
+          <input type="text" name="header_req_key" value="{{$k}}" placeholder="Header-Name"
+            class="flex-1 rounded-lg border border-ink-200 px-3 py-1.5 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+          <input type="text" name="header_req_val" value="{{$v}}" placeholder="value (blank = delete)"
+            class="flex-1 rounded-lg border border-ink-200 px-3 py-1.5 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+          <button type="button" onclick="this.closest('.hdr-row').remove()" class="text-red-500 hover:text-red-700 text-xs px-2 py-1 rounded transition shrink-0">&#x2715;</button>
+        </div>
+        {{end}}
+      </div>
+      <button type="button" id="req-hdr-add" class="inline-flex items-center gap-1 text-xs text-brand-600 hover:text-brand-700 font-medium mt-2 transition">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        Add request header
+      </button>
+    </div>
+
+    {{/* Response headers */}}
+    <div>
+      <p class="text-xs font-medium text-ink-700 mb-2">Response headers <span class="font-normal text-ink-400">(sent to client)</span></p>
+      <p class="text-xs text-ink-400 mb-2">Override or inject headers on the response returned to the browser. Leave the value blank to <strong>delete</strong> a header (e.g. to strip <code class="font-mono bg-ink-100 px-1 rounded">X-Powered-By</code>).</p>
+      <div id="resp-headers-list" class="space-y-2">
+        {{range $k, $v := .Host.CustomRespHeaderMap}}
+        <div class="hdr-row flex items-center gap-2">
+          <input type="text" name="header_resp_key" value="{{$k}}" placeholder="Header-Name"
+            class="flex-1 rounded-lg border border-ink-200 px-3 py-1.5 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+          <input type="text" name="header_resp_val" value="{{$v}}" placeholder="value (blank = delete)"
+            class="flex-1 rounded-lg border border-ink-200 px-3 py-1.5 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+          <button type="button" onclick="this.closest('.hdr-row').remove()" class="text-red-500 hover:text-red-700 text-xs px-2 py-1 rounded transition shrink-0">&#x2715;</button>
+        </div>
+        {{end}}
+      </div>
+      <button type="button" id="resp-hdr-add" class="inline-flex items-center gap-1 text-xs text-brand-600 hover:text-brand-700 font-medium mt-2 transition">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        Add response header
+      </button>
+    </div>
+
+    {{/* Feature B: Strip response headers */}}
+    <div class="pt-2 border-t border-ink-100 mt-2">
+      <label class="block text-xs font-medium text-ink-700 mb-1">Strip response headers <span class="text-ink-400 font-normal">(comma-separated, e.g. X-Powered-By, Server)</span></label>
+      <input type="text" name="strip_resp_headers" value="{{.Host.StripRespHeaders}}"
+        placeholder="X-Powered-By, Server, X-AspNet-Version"
+        class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+    </div>
+
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Strip request headers <span class="text-ink-400 font-normal">(comma separated)</span></label>
+        <input type="text" name="strip_req_headers" value="{{.Host.StripReqHeaders}}" placeholder="X-Internal-Header, Authorization" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">Remove these headers from the upstream request before forwarding. Companion to "Strip response headers" above.</p>
+      </div>
+
+      <!-- v2.9.127: req_header_rename -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Rename Request Headers</label>
+        <textarea name="req_header_rename" rows="3" placeholder="X-Old-Name: X-New-Name" class="mt-1 block w-full rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm text-sm font-mono">{{.Host.ReqHeaderRename}}</textarea>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">One rename rule per line in format 'OldHeader: NewHeader'. Renames request headers before forwarding to upstream.</p>
+      </div>
+
+      <!-- v2.9.72: req_header_replace -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Request Header Replace Rules</label>
+        <textarea name="req_header_replace" rows="3"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="HeaderName|regexp|replacement&#10;Authorization|^Basic (.+)$|Bearer $1">{{.Host.ReqHeaderReplace}}</textarea>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">One rule per line: <code>HeaderName|regexp|replacement</code>. Replaces matching values in the named request header using Go regexp capture groups (e.g. <code>$1</code>). Lines starting with <code>#</code> are ignored.</p>
+      </div>
+
+      <!-- v2.9.73: resp_header_replace -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Response Header Replace Rules</label>
+        <textarea name="resp_header_replace" rows="3"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="HeaderName|regexp|replacement&#10;Server|Apache.*|nginx">{{.Host.RespHeaderReplace}}</textarea>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">One rule per line: <code>HeaderName|regexp|replacement</code>. Replaces matching values in the named response header using Go regexp capture groups. Lines starting with <code>#</code> are ignored.</p>
+      </div>
+
+    <div>
+      <label class="block text-xs font-medium text-ink-700 mb-1">Override Cache-Control <span class="text-ink-400 font-normal">(leave blank to keep upstream value)</span></label>
+      <input type="text" name="response_cache_control" value="{{.Host.ResponseCacheControl}}"
+        placeholder="no-store  ·  max-age=3600, public  ·  private"
+        class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+    </div>
+    <!-- v2.9.120: add_cache_control_no_store -->
+    <div class="mb-4">
+      <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+        <input type="checkbox" name="add_cache_control_no_store" {{if .Host.AddCacheControlNoStore}}checked{{end}} class="rounded border-gray-300 dark:border-gray-600">
+        Add Cache-Control: no-store
+      </label>
+      <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Add Cache-Control: no-store response header to prevent caching of responses.</p>
+    </div>
+    <!-- v2.9.179: add_pragma_no_cache -->
+    <div class="mb-4">
+      <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+        <input type="checkbox" name="add_pragma_no_cache" {{if .Host.AddPragmaNoCache}}checked{{end}} class="rounded border-gray-300 dark:border-gray-600">
+        Add Pragma: no-cache
+      </label>
+      <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets the legacy HTTP/1.0 <code>Pragma: no-cache</code> response header to disable caching by older clients/proxies.</p>
+    </div>
+    <!-- v2.9.185: add_age_zero -->
+    <div class="mb-4">
+      <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+        <input type="checkbox" name="add_age_zero" {{if .Host.AddAgeZero}}checked{{end}} class="rounded border-gray-300 dark:border-gray-600">
+        Add Age: 0 Header
+      </label>
+      <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets <code>Age: 0</code> on responses to signal a fresh response and bypass intermediate CDN caches.</p>
+    </div>
+    <!-- v2.9.186: add_surrogate_control -->
+    <div class="mb-4">
+      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Surrogate-Control Header</label>
+      <input type="text" name="add_surrogate_control" value="{{.Host.AddSurrogateControl}}"
+        placeholder="e.g. max-age=3600, no-store"
+        class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono">
+      <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets the <code>Surrogate-Control</code> response header for CDN-only cache directives (consumed and stripped by edge caches).</p>
+    </div>
+    <!-- v2.9.187: add_warning_header -->
+    <div class="mb-4">
+      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Warning Header</label>
+      <input type="text" name="add_warning_header" value="{{.Host.AddWarningHeader}}"
+        placeholder='199 caddyui "Custom warning"'
+        class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono">
+      <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets the <code>Warning</code> response header (RFC 7234 warning codes about cache or transformation status).</p>
+    </div>
+    <!-- v2.9.139: add_cache_control_public -->
+    <div class="mb-4">
+      <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+        <input type="checkbox" name="add_cache_control_public" {{if .Host.AddCacheControlPublic}}checked{{end}} class="rounded border-gray-300 dark:border-gray-600">
+        Add Cache-Control: public
+      </label>
+      <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Add Cache-Control: public response header. Suitable for CDN-cacheable public resources.</p>
+    </div>
+    <!-- v2.9.144: response_cache_ttl_sec -->
+    <div class="mb-4">
+      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Response Cache TTL (seconds)</label>
+      <input type="number" name="response_cache_ttl_sec" value="{{.Host.ResponseCacheTTLSec}}" min="0" placeholder="0"
+        class="w-32 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono">
+      <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Set <code>Cache-Control: max-age=N</code> on all responses. 0 = disabled. Note: conflicts with Add Cache-Control: no-store.</p>
+    </div>
+
+      <!-- v2.9.80: server_header_value -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Override Server Header</label>
+        <input type="text" name="server_header_value" value="{{.Host.ServerHeaderValue}}"
+          class="w-64 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="nginx (empty = keep upstream value)">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Set a custom <code>Server</code> response header, hiding the upstream technology stack. Empty = pass through the upstream <code>Server</code> value.</p>
+      </div>
+
+      <!-- v2.9.90: vary_header -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Vary Response Header</label>
+        <input type="text" name="vary_header" value="{{.Host.VaryHeader}}"
+          class="w-64 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="Accept-Encoding, Accept-Language">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Set the <code>Vary</code> response header to instruct CDNs and caches which request headers affect the response. Empty = omit.</p>
+      </div>
+
+      <!-- v2.9.91: strip_etag -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="strip_etag" {{if .Host.StripETag}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Strip ETag Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Delete the <code>ETag</code> response header from upstream responses before forwarding to the client. Useful when response bodies are transformed and the original ETag would be stale.</p>
+      </div>
+
+      <!-- v2.9.103: add_resp_cookies -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Add Response Cookies</label>
+        <textarea name="add_resp_cookies" rows="3"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="session_hint=active; Path=/; HttpOnly; SameSite=Lax">{{.Host.AddRespCookies}}</textarea>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">One <code>Set-Cookie</code> value per line. Each line is appended as a separate <code>Set-Cookie</code> response header on every response. Lines beginning with <code>#</code> are ignored.</p>
+      </div>
+
+      <!-- v2.9.106: strip_server_header -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="strip_server_header" {{if .Host.StripServerHeader}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Strip Server Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Delete the <code>Server</code> response header from upstream replies. Prevents leaking backend server technology information (e.g. <code>Apache/2.4.41</code>) to clients.</p>
+      </div>
+
+      <!-- v2.9.131: strip_x_powered_by -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="strip_x_powered_by" {{if .Host.StripXPoweredBy}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Strip X-Powered-By</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Remove the X-Powered-By response header from upstream replies to hide the technology stack.</p>
+      </div>
+
+      <!-- v2.9.154: add_x_powered_by -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">X-Powered-By Header</label>
+        <input type="text" name="add_x_powered_by" value="{{.Host.AddXPoweredBy}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. MyApp/1.0">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Set a custom X-Powered-By response header value. Leave empty to disable. Note: 'Strip X-Powered-By' takes precedence if also enabled.</p>
+      </div>
+
+      <!-- v2.9.182: add_x_clacks_overhead -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">X-Clacks-Overhead Header</label>
+        <input type="text" name="add_x_clacks_overhead" value="{{.Host.AddXClacksOverhead}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="GNU Terry Pratchett">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets a custom X-Clacks-Overhead response header (the GNU tradition for honoring deceased).</p>
+      </div>
+
+      <!-- v2.9.183: add_x_ua_compatible -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">X-UA-Compatible Header</label>
+        <input type="text" name="add_x_ua_compatible" value="{{.Host.AddXUACompatible}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. IE=edge">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets the X-UA-Compatible response header to control rendering mode in legacy Internet Explorer.</p>
+      </div>
+
+      <!-- v2.9.126: add_via_header -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_via_header" value="on" {{if .Host.AddViaHeader}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add Via Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Add "Via: 1.1 caddy" response header identifying this proxy in the chain.</p>
+      </div>
+
+      <!-- v2.9.132: add_timing_allow_origin -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Timing-Allow-Origin</label>
+        <input type="text" name="add_timing_allow_origin" value="{{.Host.AddTimingAllowOrigin}}"
+          class="w-56 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="*">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Set Timing-Allow-Origin response header to allow Resource Timing API access. Use * to allow all origins.</p>
+      </div>
+
+      <!-- v2.9.162: add_clear_site_data -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Clear-Site-Data Header</label>
+        <input type="text" name="add_clear_site_data" value="{{.Host.AddClearSiteData}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder='e.g. "cache","cookies"'>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Set the Clear-Site-Data response header to instruct browsers to clear cached data. Use quoted comma-separated values like <code>"cache","cookies","storage"</code>.</p>
+      </div>
+
+      <!-- v2.9.163: add_x_dns_prefetch_control -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_x_dns_prefetch_control" {{if .Host.AddXDNSPrefetchControl}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add X-DNS-Prefetch-Control: off</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Add X-DNS-Prefetch-Control: off response header to prevent DNS prefetching (privacy/security).</p>
+      </div>
+
+      <!-- v2.9.164: add_accept_ranges -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="add_accept_ranges" {{if .Host.AddAcceptRanges}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Add Accept-Ranges Header</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Adds Accept-Ranges: bytes to responses, signalling byte-range support to clients.</p>
+      </div>
+
+      <!-- v2.9.165: add_content_disposition -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Content-Disposition Header</label>
+        <input type="text" name="add_content_disposition" value="{{.Host.AddContentDisposition}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder='e.g. attachment; filename="file.txt"'>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets a custom Content-Disposition response header value.</p>
+      </div>
+
+      <!-- v2.9.168: strip_response_headers -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Strip Response Headers</label>
+        <input type="text" name="strip_response_headers" value="{{.Host.StripResponseHeaders}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. X-Powered-By, Server, X-AspNet-Version">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated list of response header names to delete before sending the response to the client.</p>
+      </div>
+
+      <!-- v2.9.172: add_service_worker_allowed -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Service-Worker-Allowed Header</label>
+        <input type="text" name="add_service_worker_allowed" value="{{.Host.AddServiceWorkerAllowed}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. /">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets the Service-Worker-Allowed response header to expand the service worker's scope beyond its script URL.</p>
+      </div>
+
+      <!-- v2.9.145: add_link_preload -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Link Preload Header</label>
+        <input type="text" name="add_link_preload" value="{{.Host.AddLinkPreload}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. &lt;/app.js&gt;; rel=preload; as=script">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Value for the <code>Link</code> response header, used for HTTP/2 server push hints or resource preloading.</p>
+      </div>
+
+      <!-- v2.9.173: add_accept_ch -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Accept-CH Header</label>
+        <input type="text" name="add_accept_ch" value="{{.Host.AddAcceptCH}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. Sec-CH-UA, Sec-CH-UA-Mobile, DPR">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets the Accept-CH response header to declare which HTTP Client Hints the server accepts.</p>
+      </div>
+
+      <!-- v2.9.176: add_critical_ch -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Critical-CH Header</label>
+        <input type="text" name="add_critical_ch" value="{{.Host.AddCriticalCH}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. Sec-CH-UA, DPR">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets the Critical-CH response header listing client hints required before the page can render.</p>
+      </div>
+
+      <!-- v2.9.174: add_alt_svc -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Alt-Svc Header</label>
+        <input type="text" name="add_alt_svc" value="{{.Host.AddAltSvc}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder='e.g. h3=":443"; ma=86400'>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets the Alt-Svc response header to advertise alternative services (e.g. HTTP/3 upgrade).</p>
+      </div>
+
+      <!-- v2.9.175: add_content_language -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Content-Language Header</label>
+        <input type="text" name="add_content_language" value="{{.Host.AddContentLanguage}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. en-US, fr">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Sets the Content-Language response header to indicate the language(s) of the response content.</p>
+      </div>
+
+  </div>
+</details>
+
   {{/* Feature C: IP Allowlist */}}
-  <details class="pt-4 border-t border-ink-100"{{if .Host.AccessList}} open{{end}}>
+  <details class="pt-4 border-t border-ink-100"{{if or .Host.AccessList .Host.IPBlocklist .Host.TrustedProxies}} open{{end}}>
     <summary class="cursor-pointer select-none text-xs uppercase tracking-wider text-ink-500 hover:text-ink-700 font-medium transition">
-      IP Allowlist <span class="font-normal normal-case">(optional, comma-separated CIDRs)</span>
+      IP Allowlist / Blocklist <span class="font-normal normal-case">(optional, comma-separated CIDRs)</span>
     </summary>
-    <div class="mt-3">
-      <input name="access_list" value="{{.Host.AccessList}}" placeholder="192.168.1.0/24, 10.0.0.0/8"
-        class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
-      <p class="text-xs text-ink-500 mt-1.5">Leave blank to allow all IPs. Only listed CIDRs will be forwarded; others get 403.</p>
+    <div class="mt-3 space-y-4">
+      <div>
+        <input name="access_list" value="{{.Host.AccessList}}" placeholder="192.168.1.0/24, 10.0.0.0/8"
+          class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-500 mt-1.5">Leave blank to allow all IPs. Only listed CIDRs will be forwarded; others get 403.</p>
+      </div>
+
+      {{/* IP Blocklist */}}
+      <div class="pt-3 border-t border-ink-100">
+        <label class="flex items-center gap-1.5 text-xs font-medium text-ink-700 mb-1.5">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5 text-red-500" aria-hidden="true">
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+            <line x1="9" y1="9" x2="15" y2="15"/>
+            <line x1="15" y1="9" x2="9" y2="15"/>
+          </svg>
+          IP Blocklist
+        </label>
+        <textarea name="ip_blocklist" rows="2" placeholder="192.168.1.0/24, 10.0.0.5"
+          class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition resize-none">{{.Host.IPBlocklist}}</textarea>
+        <p class="text-xs text-ink-500 mt-1.5">Comma-separated CIDR ranges. Matching IPs receive a 403 response before any other rule.</p>
+      </div>
+
+      <!-- v2.9.88: block_private_ips -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="block_private_ips" {{if .Host.BlockPrivateIPs}}checked{{end}}
+            class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Block Private / Loopback IPs</span>
+        </label>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Reject incoming requests from RFC 1918 addresses (10.x, 172.16–31.x, 192.168.x), loopback (127.x, ::1), link-local (169.254.x), and CGNAT (100.64.x). Returns 403. Useful for public-facing hosts that should not be reachable from internal networks.</p>
+      </div>
+
+      <!-- v2.9.41: allowed_methods -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Allowed Methods (whitelist)</label>
+        <input type="text" name="allowed_methods" value="{{.Host.AllowedMethods}}"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="GET,POST,PUT,DELETE">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated methods to allow. Empty = allow all. Requests with other methods get <code>405</code>. Complement to "Blocked Methods" above.</p>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-ink-800 mb-1.5">Blocked HTTP methods <span class="text-ink-400 font-normal">(optional)</span></label>
+        <input type="text" name="blocked_methods" value="{{.Host.BlockedMethods}}" placeholder="TRACE,CONNECT" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+        <p class="text-xs text-ink-400 mt-1.5">Comma-separated HTTP methods to reject with 405 before proxying. Common hardening: <span class="font-mono">TRACE,CONNECT</span>. Case-insensitive.</p>
+      </div>
+
+      <!-- v2.9.93: deny_content_types -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Deny Request Content-Types</label>
+        <input type="text" name="deny_content_types" value="{{.Host.DenyContentTypes}}"
+          class="w-full max-w-lg rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="application/x-www-form-urlencoded,multipart/form-data">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated <code>Content-Type</code> prefixes to reject with a <strong>415 Unsupported Media Type</strong> response. Useful for APIs that should only accept JSON.</p>
+      </div>
+
+      <!-- v2.9.137: deny_request_content_type -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Deny Request Content Types</label>
+        <input type="text" name="deny_request_content_type" value="{{.Host.DenyRequestContentType}}"
+          class="w-full max-w-md rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="application/x-www-form-urlencoded, multipart/form-data">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated MIME types to block on request Content-Type (returns 415 Unsupported Media Type).</p>
+      </div>
+
+      <!-- v2.9.101: deny_extensions -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Deny File Extensions</label>
+        <input type="text" name="deny_extensions" value="{{.Host.DenyExtensions}}"
+          class="w-full max-w-md rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder=".php, .asp, .aspx">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated file extensions whose requests are rejected with <strong>403 Forbidden</strong> (case-insensitive). Example: <code>.php,.asp,.aspx</code> protects against accidental script exposure.</p>
+      </div>
+
+      <!-- v2.9.146: deny_path_regexp -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Deny Path Regexp</label>
+        <input type="text" name="deny_path_regexp" value="{{.Host.DenyPathRegexp}}"
+          class="w-full max-w-md rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. ^/admin/|\.env$">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Block requests whose path matches this regex with 403. Leave empty to disable.</p>
+      </div>
+
+      <!-- v2.9.155: block_query_params -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Block Query Parameters</label>
+        <input type="text" name="block_query_params" value="{{.Host.BlockQueryParams}}"
+          class="w-full max-w-md rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. __proto__,constructor,debug">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated list of query parameter names. Requests containing any of these parameters are rejected with 403.</p>
+      </div>
+
+      <!-- v2.9.196: block_query_param_regexp -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Block Query String (Regexp)</label>
+        <input type="text" name="block_query_param_regexp" value="{{.Host.BlockQueryParamRegexp}}"
+          class="w-full max-w-md rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. (debug|test)=true">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Blocks requests whose raw query string matches this regular expression (returns 403).</p>
+      </div>
+
+      <!-- v2.9.178: deny_user_agent_regexp -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Block User-Agent (Regexp)</label>
+        <input type="text" name="deny_user_agent_regexp" value="{{.Host.DenyUserAgentRegexp}}"
+          class="w-full max-w-md rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. (bot|crawler|spider)">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Blocks requests whose User-Agent header matches this regular expression (returns 403).</p>
+      </div>
+
+      <!-- v2.9.171: block_http_methods -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Block HTTP Methods</label>
+        <input type="text" name="block_http_methods" value="{{.Host.BlockHTTPMethods}}"
+          class="w-full max-w-md rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="e.g. TRACE, DELETE">
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated list of HTTP methods to reject with 405 Method Not Allowed.</p>
+      </div>
+
+      {{/* Trusted Proxies */}}
+      <div class="pt-3 border-t border-ink-100">
+        <label class="block text-xs font-medium text-ink-700 mb-1">Trusted Proxies <span class="text-ink-400 font-normal">(optional)</span></label>
+        <input type="text" name="trusted_proxies" value="{{.Host.TrustedProxies}}"
+          placeholder="10.0.0.0/8, 172.16.0.0/12"
+          class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+        <p class="text-xs text-ink-500 mt-1.5">Comma-separated CIDRs trusted to supply X-Forwarded-For headers (overrides global setting)</p>
+      </div>
     </div>
   </details>
 
@@ -276,6 +2705,11 @@
     </div>
     <div id="ba-section" class="{{if not .Host.BasicAuthEnabled}}hidden{{end}} space-y-2">
       <p class="text-xs text-ink-400 mb-3">Users must authenticate via HTTP Basic Auth before reaching the upstream. Passwords are bcrypt-hashed and never stored in plain text.</p>
+      <div id="basicauth-realm-row">
+        <label class="block text-xs font-medium text-ink-700 mb-1">Auth realm <span class="text-ink-400 font-normal">(shown in browser prompt)</span></label>
+        <input type="text" name="basicauth_realm" value="{{if .Host.BasicAuthRealm}}{{.Host.BasicAuthRealm}}{{else}}Restricted{{end}}"
+          class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+      </div>
       <div id="ba-users" class="space-y-2">
         {{range .Host.BasicAuthUserList}}
         <div class="ba-row flex items-center gap-2">
@@ -294,6 +2728,49 @@
       </button>
     </div>
   </div>
+
+  {{/* Error Redirect URL */}}
+  <div class="pt-4 border-t border-ink-100">
+    <label class="block text-xs font-medium text-ink-700 mb-1">Error Redirect URL</label>
+    <input type="url" name="error_redirect_url" value="{{.Host.ErrorRedirectURL}}"
+      placeholder="https://status.example.com/error"
+      class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+    <p class="text-xs text-ink-400 mt-1">When set, redirect clients here on 4xx/5xx errors instead of showing the error page (overrides Error Page HTML)</p>
+  </div>
+
+  {{/* Error page HTML */}}
+  <div class="pt-4 border-t border-ink-100">
+    <label class="block text-xs font-medium text-ink-700 mb-1">Custom error page HTML <span class="font-normal text-ink-400">(optional — shown when upstream returns 4xx/5xx)</span></label>
+    <textarea name="error_page_html" rows="5" placeholder="<!DOCTYPE html><html>...</html>"
+      class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition resize-y">{{.Host.ErrorPageHTML}}</textarea>
+    <p class="text-xs text-ink-400 mt-1">If set, this HTML is returned (with the upstream's original status code) whenever the upstream responds with a 4xx or 5xx error. Leave blank to pass upstream errors through unchanged.</p>
+  </div>
+
+<!-- v2.9.58: error_page_codes -->
+<div class="mb-4">
+  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Error Page Status Codes</label>
+  <input type="text" name="error_page_codes" value="{{.Host.ErrorPageCodes}}"
+    class="w-48 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+    placeholder="e.g. 404,500,503">
+  <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Comma-separated HTTP codes that trigger the custom error page above. Empty = all 4xx/5xx errors.</p>
+</div>
+
+  {{/* Custom robots.txt */}}
+  <div class="pt-4 border-t border-ink-100">
+    <label class="block text-xs font-medium text-ink-700 mb-1">Custom robots.txt <span class="font-normal text-ink-400">(optional — intercepts GET /robots.txt)</span></label>
+    <textarea name="robots_txt" rows="4" placeholder="User-agent: *&#10;Disallow: /"
+      class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition resize-y">{{.Host.RobotsTxt}}</textarea>
+    <p class="text-xs text-ink-400 mt-1">When set, GET /robots.txt is intercepted and this content is served instead of forwarding to the upstream. Leave blank to pass through.</p>
+  </div>
+
+      <!-- v2.9.79: security_txt_body -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">security.txt Body</label>
+        <textarea name="security_txt_body" rows="4"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-sm font-mono"
+          placeholder="Contact: mailto:security@example.com&#10;Expires: 2027-01-01T00:00:00.000Z">{{.Host.SecurityTxtBody}}</textarea>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Custom security disclosure policy served at <code>GET /.well-known/security.txt</code>. Leave empty to pass the request through to your upstream. See <a href="https://securitytxt.org" target="_blank" class="underline">securitytxt.org</a> for the standard format.</p>
+      </div>
 
   {{if .OtherServers}}
   <div class="pt-4 border-t border-ink-100">
@@ -671,6 +3148,27 @@
       row.querySelector('input[name="extra_upstream"]').focus();
     });
   }
+
+  // Custom headers \u2014 dynamic rows
+  (function() {
+    function makeAddRow(listID, keyName, valName) {
+      var btn = document.getElementById(listID.replace('-list', '-add'));
+      var list = document.getElementById(listID);
+      if (!btn || !list) return;
+      btn.addEventListener('click', function() {
+        var row = document.createElement('div');
+        row.className = 'hdr-row flex items-center gap-2';
+        row.innerHTML =
+          '<input type="text" name="' + keyName + '" placeholder="Header-Name" class="flex-1 rounded-lg border border-ink-200 px-3 py-1.5 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />'
+          + '<input type="text" name="' + valName + '" placeholder="value (blank = delete)" class="flex-1 rounded-lg border border-ink-200 px-3 py-1.5 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />'
+          + '<button type="button" onclick="this.closest(\'.hdr-row\').remove()" class="text-red-500 hover:text-red-700 text-xs px-2 py-1 rounded transition shrink-0">\u2715</button>';
+        list.appendChild(row);
+        row.querySelector('input').focus();
+      });
+    }
+    makeAddRow('req-headers-list', 'header_req_key', 'header_req_val');
+    makeAddRow('resp-headers-list', 'header_resp_key', 'header_resp_val');
+  })();
 })();
 </script>
 {{end}}


### PR DESCRIPTION
## Summary
- Replaces the in-flight `[2.9.202]` changelog entry with a single consolidated `[2.9.0 → 2.9.207]` Preview entry.
- The v2.9.x series shipped many internal-only build numbers during development; one dated entry keeps the public history readable instead of 200 micro-versions.
- Adds Fixed / Performance / UI subsections covering everything between v2.9.202 and v2.9.207:
  - **Fixed:** `/redirection-hosts` empty page (RedirectionHost.TagList), Test Upstream multipart parse, Caddyfile-import dedup against existing rows.
  - **Performance — analytics:** SQLite PRAGMAs (256MB cache + mmap, NORMAL sync, MEMORY temp_store), `access_daily` aggregator + status buckets actually wired up, `AccessTotalsSince` / `StatusBucketsSince` rollup-aware, two missing indexes on access_events.
  - **UI:** API Tokens sidebar entry + `key` icon.

The pre-existing `feat(v2.9.202)` commit is included in this branch as the parent — it has the per-host-options feature code that the original v2.9.202 changelog entry referenced. This PR is **changelog-only** in terms of the second commit.

## Test plan
- [ ] CI builds clean
- [ ] Changelog renders correctly in the GitHub UI (markdown)
- [ ] Confirm `:preview` Docker tag points at v2.9.207

🤖 Generated with [Claude Code](https://claude.com/claude-code)