### PR TITLE
Fleet observability and certificate lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.25.0] - 2026-08-14 - Fleet observability and certificate lifecycle
+
+### Added
+
+- **Certificate lifecycle visibility** projects Caddy's structured TLS logs into per-node states such as obtaining, renewing, retry scheduled, issued, revoked, and issuance error. Managed-certificate lists and live server probes now show the latest actionable message instead of an unconditional green status. Only the compact latest state is persisted; raw logs are not. ([#26](https://github.com/X4Applegate/caddyui/issues/26))
+- **Ephemeral Server Logs** gives administrators an in-app, structured runtime stream for a selected managed Caddy node with level and text filters. Full capture leaves Caddy's normal logs unchanged, stays in memory, and automatically disables after 15 minutes. ([#27](https://github.com/X4Applegate/caddyui/issues/27))
+- **Authoritative fleet attribution** stamps every analytics event with the Caddy node that handled the request. Live Traffic, Analytics, host drill-downs, and CSV exports can distinguish and filter nodes even when load-balanced servers share the same hostname. ([#28](https://github.com/X4Applegate/caddyui/issues/28))
+
+### Changed
+
+- CaddyUI installs additive named log streams for analytics, certificate events, and temporary runtime capture. Existing Caddy container, journal, and file log outputs remain unchanged.
+- Existing analytics rows migrate as legacy/unattributed data instead of guessing a source server from current route ownership.
+- SQLite and MariaDB schemas now store access-event server identity and the latest certificate lifecycle projection, with parity and migration coverage for both backends.
+
 ## [2.24.0] - 2026-08-13 - Detailed Prometheus metrics
 
 ### Added

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -72,6 +72,19 @@ The container will print a clear error message at startup if the directory isn't
 
 ## ✨ Headline features
 
+### 🔭 Fleet observability
+
+CaddyUI v2.25 makes the source and state of fleet activity visible without replacing Caddy's normal logs:
+
+- Live Traffic, Analytics, host drill-downs, and CSV exports use the node that actually handled each request
+- Shared hostnames behind load-balanced Caddy instances remain distinguishable and filterable
+- **Observe → Server Logs** streams a selected managed node at DEBUG, INFO, WARN, or ERROR
+- Full runtime capture is memory-only and automatically stops after 15 minutes
+- Managed ACME certificates show issuance, renewal, retry, success, revocation, and failure states per node
+- Only the latest compact certificate state is persisted; raw runtime logs are never stored
+
+The structured log listener should stay on a private Docker, LAN, WireGuard, or Tailscale network. CaddyUI adds named streams and does not redirect or suppress the node's existing container, journal, or file output.
+
 ### 📈 Detailed Prometheus metrics
 
 CaddyUI v2.24 manages Caddy metrics without clobbering global options loaded elsewhere:
@@ -219,7 +232,7 @@ No PEM upload, fake proxy upstream, or private-key transfer is required.
 | Tag | What it points at |
 |---|---|
 | `:vX.Y.Z` | Specific release, immutable. Recommended for production. |
-| `:latest` | Rolling — retagged at significant feature waves. Currently `v2.23.1`. |
+| `:latest` | Rolling — retagged at significant feature waves. Currently `v2.25.0`. |
 | `:stable` | Alias of `:latest`. |
 | `:preview` | Rolling dev push — every commit to main. Test with this before pinning. |
 
@@ -236,7 +249,7 @@ Multi-arch: `linux/amd64` + `linux/arm64`. Scratch base image, runs as non-root 
 | `CADDYUI_DB` | `/data/caddyui.db` | SQLite database path |
 | `CADDYUI_DB_DSN` | (none) | MariaDB DSN; required when `CADDYUI_DB_DRIVER=mariadb` |
 | `CADDYUI_LISTEN` | `:8080` | HTTP listen address |
-| `CADDYUI_INGEST_LISTEN` | `:9019` | Visitor-analytics TCP ingest from Caddy's `net` log writer (empty string disables) |
+| `CADDYUI_INGEST_LISTEN` | `:9019` | Structured Caddy log ingest for analytics, certificate lifecycle, and temporary runtime streams (empty string disables all three) |
 | `CADDYFILE_PATH` | `/etc/caddy/Caddyfile` | Optional — only read if you mount a Caddyfile into the CaddyUI container for the paste-import auto-classifier reference |
 | `CADDY_ADMIN_USER` / `CADDY_ADMIN_PASS` | (none) | Optional HTTP basic auth for Caddy's admin endpoint when proxied |
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ run CaddyUI directly in an LXC, VM, or bare-metal host.
 
 ## Features
 
+### Fleet observability in v2.25
+
+- **Actual node attribution** — Live Traffic, Analytics, per-host drill-downs, and CSV exports identify the Caddy instance that handled each request, including shared hostnames behind a load balancer.
+- **Ephemeral Server Logs** — administrators can stream structured runtime logs from one managed node at a chosen level. Full capture is memory-only, preserves normal Caddy output, and stops automatically after 15 minutes.
+- **Certificate lifecycle states** — managed ACME certificates show obtaining, renewing, retrying, issued, revoked, and failure states with the latest Caddy message instead of an unconditional healthy badge.
+
 ### What's new in v2.21
 
 - **Fleet file access logs** — independently write native JSON or console access logs to selected Caddy servers with HTTP/HTTPS scope and rotation controls while preserving CaddyUI Visitor Analytics.
@@ -156,11 +162,18 @@ Your Caddy build must include the matching `caddy-dns` provider module. The repo
 
 ### Observability
 
+- **Fleet observability** *(v2.25.0)* — attribute requests to the node that actually handled them, stream temporary in-memory runtime logs from **Observe → Server Logs**, and surface per-node ACME progress/errors from structured Caddy TLS events
 - **Prometheus metrics** *(v2.24.0)* — enable base HTTP metrics, per-host labels, and Caddy 2.11+ catch-all host observation on selected fleet servers. CaddyUI validates each target, preserves metrics it does not own, and shows the protected Admin URL's `/metrics` scrape target
 - **Visitor analytics** *(v2.7.0)* — opt-in per-host traffic counters; top hosts, 24 h sparkline, status-code mix, unique visitors. Per-server filter for multi-Caddy fleets. The Caddy log writer uses soft-start failover so Caddy can boot while CaddyUI is offline
 - **Upstream health** — live health check per proxy; polls Caddy's own admin API so Docker-internal hostnames work correctly
 - **App health** — detects whether the upstream actually responds, not just whether its TCP port is open
 - **Activity log** — every create / edit / delete / sync action is logged with actor, timestamp, and resource
+
+Certificate lifecycle monitoring and Server Logs share the structured ingest
+target configured under **Settings → Analytics**, even when visitor analytics
+is disabled. Every managed Caddy node must be able to reach that private
+host and port (default `caddyui:9019` on the repository Docker network). Do
+not publish the ingest listener to the internet.
 
 ### Operational
 
@@ -459,6 +472,7 @@ edge.
 | `CADDYUI_DB` | `/data/caddyui.db` | Path to the SQLite database |
 | `CADDYUI_DB_DSN` | *(unset)* | MariaDB DSN; required when `CADDYUI_DB_DRIVER=mariadb` |
 | `CADDYUI_LISTEN` | `:8080` | Listen address |
+| `CADDYUI_INGEST_LISTEN` | `:9019` | Structured Caddy log ingest for analytics, certificate lifecycle, and temporary runtime streams; set empty to disable all three |
 | `CADDY_ADMIN_URL` | `http://caddy:2019` | Caddy admin API base URL |
 | `CADDYFILE_PATH` | `/etc/caddy/Caddyfile` | Path to Caddyfile (optional) |
 | `CADDYUI_SYNC_ON_START` | *(unset)* | Set to `1` to push DB state to Caddy on startup |

--- a/cmd/caddyui/main.go
+++ b/cmd/caddyui/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/X4Applegate/caddyui/internal/analytics"
 	"github.com/X4Applegate/caddyui/internal/caddy"
+	"github.com/X4Applegate/caddyui/internal/caddylogs"
 	"github.com/X4Applegate/caddyui/internal/db"
 	"github.com/X4Applegate/caddyui/internal/server"
 	"github.com/X4Applegate/caddyui/web"
@@ -108,12 +109,14 @@ Fix by:
 	// a few KB of RAM and no CPU, so there's no reason to gate it.
 	var ingest *analytics.Ingest
 	if ingestListen != "" {
-		ingest = &analytics.Ingest{DB: conn, Addr: ingestListen}
+		logHub := caddylogs.New(conn)
+		ingest = &analytics.Ingest{DB: conn, Addr: ingestListen, RuntimeFn: logHub.AcceptLine}
 		if err := ingest.Start(pollerCtx); err != nil {
 			log.Printf("analytics: failed to start ingest on %s: %v (analytics disabled)", ingestListen, err)
 			ingest = nil
 		} else {
 			srv.SetAnalyticsIngest(ingest)
+			srv.SetCaddyLogHub(logHub)
 		}
 	}
 	// Refresh an enabled analytics logger on startup so upgrades can add
@@ -123,6 +126,12 @@ Fix by:
 	// server is temporarily unreachable.
 	if err := srv.ReconcileAnalyticsAccessLogs(); err != nil {
 		log.Printf("analytics: startup reconciliation: %v", err)
+	}
+	if err := srv.ResetRuntimeLogs(); err != nil {
+		log.Printf("server logs: startup cleanup: %v", err)
+	}
+	if err := srv.ReconcileCertificateLogs(); err != nil {
+		log.Printf("certificate monitoring: startup reconciliation: %v", err)
 	}
 
 	// Opt-in startup sync. Default: no initial sync — pushing an empty config
@@ -155,6 +164,9 @@ Fix by:
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = httpSrv.Shutdown(ctx)
+	if err := srv.ResetRuntimeLogs(); err != nil {
+		log.Printf("server logs: shutdown cleanup: %v", err)
+	}
 	if ingest != nil {
 		ingest.Stop()
 	}

--- a/internal/analytics/ingest.go
+++ b/internal/analytics/ingest.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"log"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -61,13 +62,18 @@ type Ingest struct {
 	// SetExcludeIPs for the common case rather than setting this directly.
 	ExcludeFn func(clientIP, host, path, userAgent string) bool
 
+	// RuntimeFn receives every structured line before access-log parsing.
+	// The Caddy runtime-log hub uses this to keep an ephemeral admin stream
+	// and project TLS lifecycle messages into compact certificate state. It
+	// must return quickly; access-log ingestion shares this connection loop.
+	RuntimeFn func([]byte)
+
 	// excludeMu guards the compiled CIDR slice below. Swapped out in whole
 	// by SetExcludeIPs so the reader path (ExcludeFn) never blocks on a
 	// lock — it takes a snapshot of the slice and evaluates against it.
 	excludeMu     sync.RWMutex
 	excludeNets   []*net.IPNet
 	excludePlains []net.IP // plain IPs (no /mask)
-
 
 	mu       sync.Mutex
 	listener net.Listener
@@ -302,6 +308,12 @@ func (i *Ingest) handleConn(ctx context.Context, conn net.Conn) {
 		if len(line) == 0 {
 			continue
 		}
+		if i.RuntimeFn != nil {
+			// Scanner reuses its backing buffer on the next Scan. The runtime
+			// callback currently consumes synchronously, but copy here keeps
+			// that contract safe if it later queues work asynchronously.
+			i.RuntimeFn(append([]byte(nil), line...))
+		}
 		ev, ok := parseLine(line)
 		if !ok {
 			i.stats.Errors.Add(1)
@@ -352,12 +364,14 @@ type caddyAccessLog struct {
 	// TS is a float seconds-since-epoch (e.g. 1702839400.1234). Caddy
 	// emits this as a number, not a string, and json.Number lets us
 	// preserve precision when converting to time.Time.
-	TS      json.Number            `json:"ts"`
-	Request caddyAccessLogRequest  `json:"request"`
-	Status  int                    `json:"status"`
-	Size    int64                  `json:"size"`
+	TS      json.Number           `json:"ts"`
+	Request caddyAccessLogRequest `json:"request"`
+	Status  int                   `json:"status"`
+	Size    int64                 `json:"size"`
 	// Duration is in seconds (float). We multiply by 1000 for ms.
-	Duration json.Number `json:"duration"`
+	Duration   json.Number     `json:"duration"`
+	ServerID   json.RawMessage `json:"caddyui_server_id"`
+	ServerName string          `json:"caddyui_server_name"`
 }
 
 type caddyAccessLogRequest struct {
@@ -448,6 +462,8 @@ func parseLine(line []byte) (models.AccessEvent, bool) {
 
 	return models.AccessEvent{
 		TS:         ts,
+		ServerID:   parseFlexibleInt64(raw.ServerID),
+		ServerName: strings.TrimSpace(raw.ServerName),
 		Host:       host,
 		Path:       path,
 		Method:     raw.Request.Method,
@@ -457,4 +473,19 @@ func parseLine(line []byte) (models.AccessEvent, bool) {
 		DurationMs: durMs,
 		BytesOut:   raw.Size,
 	}, true
+}
+
+func parseFlexibleInt64(raw json.RawMessage) int64 {
+	if len(raw) == 0 || string(raw) == "null" {
+		return 0
+	}
+	var n int64
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		n, _ = strconv.ParseInt(strings.TrimSpace(text), 10, 64)
+	}
+	return n
 }

--- a/internal/analytics/ingest_test.go
+++ b/internal/analytics/ingest_test.go
@@ -1,0 +1,31 @@
+package analytics
+
+import "testing"
+
+func TestParseLineCarriesFleetServerIdentity(t *testing.T) {
+	event, ok := parseLine([]byte(`{
+		"level":"info","ts":1700000000.25,"logger":"http.log.access.caddyui_access",
+		"msg":"handled request","caddyui_server_id":42,"caddyui_server_name":"edge-west",
+		"request":{"client_ip":"192.0.2.10","method":"GET","host":"example.test","uri":"/health?secret=no","headers":{"User-Agent":["test-agent"]}},
+		"status":200,"size":123,"duration":0.025
+	}`))
+	if !ok {
+		t.Fatal("parseLine rejected a valid access event")
+	}
+	if event.ServerID != 42 || event.ServerName != "edge-west" {
+		t.Fatalf("server identity = %d/%q, want 42/edge-west", event.ServerID, event.ServerName)
+	}
+	if event.Path != "/health" {
+		t.Fatalf("path = %q, want query string removed", event.Path)
+	}
+	if event.DurationMs != 25 {
+		t.Fatalf("duration = %dms, want 25ms", event.DurationMs)
+	}
+}
+
+func TestParseLineAcceptsStringServerID(t *testing.T) {
+	event, ok := parseLine([]byte(`{"ts":1700000000,"caddyui_server_id":"7","request":{"host":"example.test","uri":"/"},"status":204}`))
+	if !ok || event.ServerID != 7 {
+		t.Fatalf("event = %#v, ok=%t; want server_id 7", event, ok)
+	}
+}

--- a/internal/caddy/accesslog.go
+++ b/internal/caddy/accesslog.go
@@ -14,6 +14,14 @@ import (
 // toggles don't leak duplicate loggers into the Caddy config.
 const AccessLogLoggerName = "caddyui_access"
 
+// CertificateLogLoggerName is the low-volume, always-on stream CaddyUI uses
+// to observe certificate issuance and renewal. RuntimeLogLoggerName is the
+// temporary, admin-controlled stream used by the Server Logs page.
+const (
+	CertificateLogLoggerName = "caddyui_certificates"
+	RuntimeLogLoggerName     = "caddyui_runtime"
+)
+
 // AccessLogDeleteMethod is exposed so callers can tell what HTTP verb the
 // cleanup path uses, mostly for tests. Admin API DELETEs are idempotent
 // (404 is fine), which is why DisableAccessLogs doesn't treat "not found"
@@ -27,6 +35,64 @@ const AccessLogDeleteMethod = http.MethodDelete
 type AccessLogOptions struct {
 	SoftStart   bool
 	DialTimeout time.Duration
+	ServerID    int64
+	ServerName  string
+}
+
+func networkLogWriter(target string, opts AccessLogOptions) map[string]any {
+	writer := map[string]any{
+		"output":  "net",
+		"address": target,
+	}
+	if opts.SoftStart {
+		writer["soft_start"] = true
+	}
+	if opts.DialTimeout > 0 {
+		writer["dial_timeout"] = opts.DialTimeout.String()
+	}
+	return writer
+}
+
+// annotatedJSONEncoder stamps every forwarded entry with the CaddyUI fleet
+// server that produced it. The append encoder is part of Caddy core and uses
+// a JSON encoder underneath, so the ingest path receives normal structured
+// logs plus stable source metadata without changing route handlers.
+func annotatedJSONEncoder(opts AccessLogOptions) map[string]any {
+	fields := map[string]any{
+		"caddyui_server_id":   opts.ServerID,
+		"caddyui_server_name": strings.TrimSpace(opts.ServerName),
+	}
+	return map[string]any{
+		"format": "append",
+		"fields": fields,
+		"wrap":   map[string]any{"format": "json"},
+	}
+}
+
+// installNamedLog creates or replaces one entry below logging.logs while
+// preserving unrelated loggers. Fresh Caddy configs often have no logging
+// tree at all, in which case the path API cannot traverse the missing parent;
+// bootstrap the parent object and merge any loggers that do exist.
+func (c *Client) installNamedLog(name string, logger map[string]any) error {
+	if err := c.PutPath("/config/logging/logs/"+name, logger); err == nil {
+		return nil
+	} else if !isCaddyMissingPathErr(err.Error()) {
+		return err
+	}
+
+	logs := map[string]any{name: logger}
+	if cfg, _, cfgErr := c.FetchConfig(); cfgErr == nil {
+		if logging, _ := cfg["logging"].(map[string]any); logging != nil {
+			if existing, _ := logging["logs"].(map[string]any); existing != nil {
+				for key, value := range existing {
+					if key != name {
+						logs[key] = value
+					}
+				}
+			}
+		}
+	}
+	return c.PutPath("/config/logging", map[string]any{"logs": logs})
 }
 
 // EnableAccessLogs configures the live Caddy instance to stream its access
@@ -59,53 +125,13 @@ func (c *Client) EnableAccessLogs(target string, opts AccessLogOptions) error {
 
 	// Step 1: install the net-writer logger. Use PUT on the specific key so
 	// the call is create-or-replace — PATCH would 404 on first run.
-	writer := map[string]any{
-		"output":  "net",
-		"address": target,
-	}
-	if opts.SoftStart {
-		writer["soft_start"] = true
-	}
-	if opts.DialTimeout > 0 {
-		writer["dial_timeout"] = opts.DialTimeout.String()
-	}
 	logger := map[string]any{
-		"writer": writer,
-		"encoder": map[string]any{
-			"format": "json",
-		},
+		"writer":  networkLogWriter(target, opts),
+		"encoder": annotatedJSONEncoder(opts),
 		"include": []string{"http.log.access"},
 	}
-	if err := c.PutPath("/config/logging/logs/"+AccessLogLoggerName, logger); err != nil {
-		// v2.7.1: Caddy's admin API can't traverse through a null parent.
-		// On a fresh Caddy (no `logging` key at all, or `logging` present
-		// but `logging.logs` missing), the call above returns
-		//   {"error":"invalid traversal path at: config/logging/logs"}
-		// Bootstrap by PUT-ing the whole `/config/logging` object with our
-		// logger nested inside. We fetch the current config first so we
-		// preserve any other loggers the admin might have configured
-		// through the Caddyfile or a prior patch — only the null-parent
-		// case hits this fallback, but the merge costs nothing in the
-		// non-null path and makes the call idempotent either way.
-		if !isCaddyMissingPathErr(err.Error()) {
-			return fmt.Errorf("install access-log logger: %w", err)
-		}
-		logs := map[string]any{AccessLogLoggerName: logger}
-		if cfg, _, cfgErr := c.FetchConfig(); cfgErr == nil {
-			if logging, _ := cfg["logging"].(map[string]any); logging != nil {
-				if existing, _ := logging["logs"].(map[string]any); existing != nil {
-					for k, v := range existing {
-						if k == AccessLogLoggerName {
-							continue // our own key wins, skip the old one
-						}
-						logs[k] = v
-					}
-				}
-			}
-		}
-		if err2 := c.PutPath("/config/logging", map[string]any{"logs": logs}); err2 != nil {
-			return fmt.Errorf("install access-log logger (bootstrap logging tree): %w", err2)
-		}
+	if err := c.installNamedLog(AccessLogLoggerName, logger); err != nil {
+		return fmt.Errorf("install access-log logger: %w", err)
 	}
 
 	// Step 2+3: fetch the server names, then patch each one's logs block.
@@ -129,6 +155,64 @@ func (c *Client) EnableAccessLogs(target string, opts AccessLogOptions) error {
 		if err := c.PutPath("/config/apps/http/servers/"+srv+"/logs", logsCfg); err != nil {
 			return fmt.Errorf("enable logs on server %q: %w", srv, err)
 		}
+	}
+	return nil
+}
+
+// EnableCertificateLogs duplicates Caddy's TLS runtime log namespace to the
+// CaddyUI ingest socket. Caddy's default logger remains unchanged, so normal
+// container/journal logs continue to receive the same messages. The stream is
+// intentionally INFO-level and low-volume; CaddyUI persists only the latest
+// lifecycle state per server and certificate identifier.
+func (c *Client) EnableCertificateLogs(target string, opts AccessLogOptions) error {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return fmt.Errorf("EnableCertificateLogs: target is empty")
+	}
+	logger := map[string]any{
+		"writer":  networkLogWriter(target, opts),
+		"encoder": annotatedJSONEncoder(opts),
+		"include": []string{"tls"},
+		"level":   "INFO",
+	}
+	if err := c.installNamedLog(CertificateLogLoggerName, logger); err != nil {
+		return fmt.Errorf("install certificate logger: %w", err)
+	}
+	return nil
+}
+
+// EnableRuntimeLogs installs a temporary duplicate stream for operational
+// Caddy logs. Access logs are excluded because they already have a dedicated
+// analytics stream; TLS logs are excluded because the certificate monitor
+// supplies them continuously. No existing logger is replaced or redirected.
+func (c *Client) EnableRuntimeLogs(target, level string, opts AccessLogOptions) error {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return fmt.Errorf("EnableRuntimeLogs: target is empty")
+	}
+	level = strings.ToUpper(strings.TrimSpace(level))
+	switch level {
+	case "DEBUG", "INFO", "WARN", "ERROR":
+	default:
+		level = "INFO"
+	}
+	logger := map[string]any{
+		"writer":  networkLogWriter(target, opts),
+		"encoder": annotatedJSONEncoder(opts),
+		"exclude": []string{"http.log.access", "tls"},
+		"level":   level,
+	}
+	if err := c.installNamedLog(RuntimeLogLoggerName, logger); err != nil {
+		return fmt.Errorf("install runtime logger: %w", err)
+	}
+	return nil
+}
+
+// DisableRuntimeLogs stops the temporary operational stream. It does not
+// touch Caddy's default logger, access analytics, or certificate monitoring.
+func (c *Client) DisableRuntimeLogs() error {
+	if err := c.deletePathIgnoreMissing("/config/logging/logs/" + RuntimeLogLoggerName); err != nil {
+		return fmt.Errorf("remove runtime logger: %w", err)
 	}
 	return nil
 }

--- a/internal/caddy/accesslog_test.go
+++ b/internal/caddy/accesslog_test.go
@@ -32,6 +32,8 @@ func TestEnableAccessLogsConfiguresSoftStartAndDialTimeout(t *testing.T) {
 	if err := client.EnableAccessLogs("caddyui:9019", AccessLogOptions{
 		SoftStart:   true,
 		DialTimeout: 5 * time.Second,
+		ServerID:    9,
+		ServerName:  "edge-west",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -48,5 +50,59 @@ func TestEnableAccessLogsConfiguresSoftStartAndDialTimeout(t *testing.T) {
 	}
 	if writer["dial_timeout"] != "5s" {
 		t.Fatalf("dial_timeout = %#v, want 5s", writer["dial_timeout"])
+	}
+	encoder, ok := logger["encoder"].(map[string]any)
+	if !ok || encoder["format"] != "append" {
+		t.Fatalf("encoder = %#v, want append", logger["encoder"])
+	}
+	fields, _ := encoder["fields"].(map[string]any)
+	if fields["caddyui_server_id"] != float64(9) || fields["caddyui_server_name"] != "edge-west" {
+		t.Fatalf("source fields = %#v", fields)
+	}
+}
+
+func TestRuntimeAndCertificateLoggersAreAdditiveAndScoped(t *testing.T) {
+	loggers := map[string]map[string]any{}
+	admin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := ""
+		switch r.URL.Path {
+		case "/config/logging/logs/" + RuntimeLogLoggerName:
+			name = RuntimeLogLoggerName
+		case "/config/logging/logs/" + CertificateLogLoggerName:
+			name = CertificateLogLoggerName
+		}
+		if r.Method != http.MethodPost || name == "" {
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
+		}
+		var logger map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&logger); err != nil {
+			t.Fatal(err)
+		}
+		loggers[name] = logger
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer admin.Close()
+
+	client := New(admin.URL, "", "")
+	opts := AccessLogOptions{SoftStart: true, DialTimeout: time.Second, ServerID: 3, ServerName: "edge"}
+	if err := client.EnableCertificateLogs("caddyui:9019", opts); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.EnableRuntimeLogs("caddyui:9019", "debug", opts); err != nil {
+		t.Fatal(err)
+	}
+	certificate := loggers[CertificateLogLoggerName]
+	include, _ := certificate["include"].([]any)
+	if len(include) != 1 || include[0] != "tls" {
+		t.Fatalf("certificate include = %#v", certificate["include"])
+	}
+	runtime := loggers[RuntimeLogLoggerName]
+	if runtime["level"] != "DEBUG" {
+		t.Fatalf("runtime level = %#v, want DEBUG", runtime["level"])
+	}
+	exclude, _ := runtime["exclude"].([]any)
+	if len(exclude) != 2 || exclude[0] != "http.log.access" || exclude[1] != "tls" {
+		t.Fatalf("runtime excludes = %#v", runtime["exclude"])
 	}
 }

--- a/internal/caddylogs/hub.go
+++ b/internal/caddylogs/hub.go
@@ -1,0 +1,320 @@
+// Package caddylogs consumes Caddy's structured runtime logs. It keeps a
+// bounded in-memory ring for the admin Server Logs page and persists only the
+// latest certificate lifecycle projection; raw runtime logs never touch disk.
+package caddylogs
+
+import (
+	"database/sql"
+	"encoding/json"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+const maxEntries = 1000
+
+type Entry struct {
+	ID         uint64         `json:"id"`
+	TS         time.Time      `json:"ts"`
+	ServerID   int64          `json:"server_id"`
+	ServerName string         `json:"server_name"`
+	Level      string         `json:"level"`
+	Logger     string         `json:"logger"`
+	Message    string         `json:"message"`
+	Fields     map[string]any `json:"fields,omitempty"`
+}
+
+type CaptureState struct {
+	ServerID   int64     `json:"server_id"`
+	ServerName string    `json:"server_name"`
+	Level      string    `json:"level"`
+	ExpiresAt  time.Time `json:"expires_at"`
+}
+
+type Hub struct {
+	DB *sql.DB
+
+	mu      sync.RWMutex
+	nextID  uint64
+	entries []Entry
+	active  map[int64]CaptureState
+
+	persistMu sync.Mutex
+}
+
+func New(db *sql.DB) *Hub {
+	return &Hub{DB: db, active: map[int64]CaptureState{}}
+}
+
+// AcceptLine consumes one NDJSON record. Access events are deliberately
+// ignored here because the analytics ingest has its own persistence and UI.
+func (h *Hub) AcceptLine(line []byte) {
+	var raw map[string]any
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return
+	}
+	logger := strings.TrimSpace(stringField(raw["logger"]))
+	if strings.HasPrefix(logger, "http.log.access") {
+		return
+	}
+	message := strings.TrimSpace(stringField(raw["msg"]))
+	if logger == "" && message == "" {
+		return
+	}
+	entry := Entry{
+		TS:         logTime(raw["ts"]),
+		ServerID:   int64Field(raw["caddyui_server_id"]),
+		ServerName: strings.TrimSpace(stringField(raw["caddyui_server_name"])),
+		Level:      strings.ToUpper(strings.TrimSpace(stringField(raw["level"]))),
+		Logger:     logger,
+		Message:    message,
+		Fields:     remainingFields(raw),
+	}
+	if entry.TS.IsZero() {
+		entry.TS = time.Now().UTC()
+	}
+	if entry.Level == "" {
+		entry.Level = "INFO"
+	}
+
+	h.mu.Lock()
+	h.nextID++
+	entry.ID = h.nextID
+	h.entries = append(h.entries, entry)
+	if len(h.entries) > maxEntries {
+		copy(h.entries, h.entries[len(h.entries)-maxEntries:])
+		h.entries = h.entries[:maxEntries]
+	}
+	h.mu.Unlock()
+
+	states := certificateStates(entry, raw)
+	if len(states) == 0 || h.DB == nil {
+		return
+	}
+	h.persistMu.Lock()
+	defer h.persistMu.Unlock()
+	for _, state := range states {
+		if err := models.UpsertCertificateLifecycle(h.DB, state); err != nil {
+			log.Printf("certificate lifecycle: store %s on server %d: %v", state.Identifier, state.ServerID, err)
+		}
+	}
+}
+
+func (h *Hub) Since(cursor uint64, serverID int64, limit int) []Entry {
+	if limit <= 0 || limit > 500 {
+		limit = 200
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	out := make([]Entry, 0, limit)
+	for _, entry := range h.entries {
+		if entry.ID <= cursor || (serverID > 0 && entry.ServerID != serverID) {
+			continue
+		}
+		entry.Fields = cloneFields(entry.Fields)
+		out = append(out, entry)
+	}
+	if len(out) > limit {
+		out = out[len(out)-limit:]
+	}
+	return out
+}
+
+func (h *Hub) SetCapture(state CaptureState) {
+	h.mu.Lock()
+	h.active[state.ServerID] = state
+	h.mu.Unlock()
+}
+
+func (h *Hub) ClearCapture(serverID int64) {
+	h.mu.Lock()
+	delete(h.active, serverID)
+	h.mu.Unlock()
+}
+
+func (h *Hub) Captures() []CaptureState {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	out := make([]CaptureState, 0, len(h.active))
+	for _, state := range h.active {
+		out = append(out, state)
+	}
+	return out
+}
+
+func (h *Hub) Capture(serverID int64) (CaptureState, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	state, ok := h.active[serverID]
+	return state, ok
+}
+
+func remainingFields(raw map[string]any) map[string]any {
+	fields := make(map[string]any, len(raw))
+	for key, value := range raw {
+		switch key {
+		case "ts", "level", "logger", "msg", "caddyui_server_id", "caddyui_server_name":
+			continue
+		}
+		fields[key] = value
+	}
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}
+
+func cloneFields(fields map[string]any) map[string]any {
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(fields))
+	for key, value := range fields {
+		out[key] = value
+	}
+	return out
+}
+
+func logTime(value any) time.Time {
+	switch v := value.(type) {
+	case float64:
+		seconds := int64(v)
+		nanos := int64((v - float64(seconds)) * float64(time.Second))
+		return time.Unix(seconds, nanos).UTC()
+	case json.Number:
+		if number, err := v.Float64(); err == nil {
+			return logTime(number)
+		}
+	case string:
+		if parsed, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func int64Field(value any) int64 {
+	switch v := value.(type) {
+	case float64:
+		return int64(v)
+	case json.Number:
+		n, _ := v.Int64()
+		return n
+	case string:
+		n, _ := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		return n
+	default:
+		return 0
+	}
+}
+
+func stringField(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case json.Number:
+		return v.String()
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		return ""
+	}
+}
+
+func certificateStates(entry Entry, raw map[string]any) []models.CertificateLifecycleStatus {
+	if entry.ServerID <= 0 || !strings.HasPrefix(entry.Logger, "tls") {
+		return nil
+	}
+	message := strings.ToLower(entry.Message)
+	phase := ""
+	switch {
+	case strings.Contains(message, "revoked"):
+		phase = "revoked"
+	case strings.Contains(message, "certificate obtained") ||
+		strings.Contains(message, "certificate renewed") ||
+		strings.Contains(message, "renewed certificate") ||
+		strings.Contains(message, "cached managed certificate") ||
+		strings.Contains(message, "loaded certificate"):
+		phase = "active"
+	case strings.Contains(message, "will retry"):
+		phase = "retrying"
+	case entry.Level == "ERROR" || strings.Contains(message, "could not get certificate") ||
+		strings.Contains(message, "failed") || strings.Contains(message, "giving up"):
+		phase = "error"
+	case strings.Contains(entry.Logger, "renew") || strings.Contains(message, "renewing certificate"):
+		phase = "renewing"
+	case strings.Contains(entry.Logger, "issuance") || strings.Contains(entry.Logger, "obtain") ||
+		strings.Contains(message, "obtaining certificate") || strings.Contains(message, "trying to solve challenge"):
+		phase = "obtaining"
+	default:
+		return nil
+	}
+
+	identifiers := certificateIdentifiers(raw)
+	errText := truncate(stringField(raw["error"]), 2000)
+	if len(identifiers) == 0 && errText != "" {
+		if identifier := bracketIdentifier(errText); identifier != "" {
+			identifiers = append(identifiers, identifier)
+		}
+	}
+	if len(identifiers) == 0 {
+		return nil
+	}
+	states := make([]models.CertificateLifecycleStatus, 0, len(identifiers))
+	for _, identifier := range identifiers {
+		identifier = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(identifier)), ".")
+		if identifier == "" {
+			continue
+		}
+		states = append(states, models.CertificateLifecycleStatus{
+			ServerID: entry.ServerID, ServerName: entry.ServerName,
+			Identifier: identifier, Phase: phase, Level: entry.Level,
+			Message: truncate(entry.Message, 500), Error: errText, UpdatedAt: entry.TS,
+		})
+	}
+	return states
+}
+
+func certificateIdentifiers(raw map[string]any) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value != "" && !seen[value] {
+			seen[value] = true
+			out = append(out, value)
+		}
+	}
+	add(stringField(raw["identifier"]))
+	for _, key := range []string{"identifiers", "subjects", "sans"} {
+		if values, ok := raw[key].([]any); ok {
+			for _, value := range values {
+				add(stringField(value))
+			}
+		}
+	}
+	return out
+}
+
+func bracketIdentifier(value string) string {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "[") {
+		return ""
+	}
+	end := strings.IndexByte(value, ']')
+	if end <= 1 {
+		return ""
+	}
+	return value[1:end]
+}
+
+func truncate(value string, max int) string {
+	if len(value) <= max {
+		return value
+	}
+	return value[:max]
+}

--- a/internal/caddylogs/hub_test.go
+++ b/internal/caddylogs/hub_test.go
@@ -1,0 +1,77 @@
+package caddylogs
+
+import (
+	"path/filepath"
+	"testing"
+
+	appdb "github.com/X4Applegate/caddyui/internal/db"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+func TestHubPersistsCertificateLifecycleAndKeepsRuntimeLogsInMemory(t *testing.T) {
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	hub := New(conn)
+	hub.AcceptLine([]byte(`{"level":"info","ts":1700000000,"logger":"tls.obtain","msg":"obtaining certificate","identifier":"example.test","caddyui_server_id":2,"caddyui_server_name":"edge"}`))
+	states, err := models.ListCertificateLifecycle(conn, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].Phase != "obtaining" || states[0].Identifier != "example.test" {
+		t.Fatalf("states = %#v, want obtaining example.test", states)
+	}
+
+	// CertMagic's retry line often omits identifier and embeds it at the
+	// beginning of the error. The projection must retain that failure.
+	hub.AcceptLine([]byte(`{"level":"error","ts":1700000001,"logger":"tls.obtain","msg":"will retry","error":"[example.test] Obtain: DNS challenge failed","attempt":1,"retrying_in":60,"caddyui_server_id":2,"caddyui_server_name":"edge"}`))
+	states, err = models.ListCertificateLifecycle(conn, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].Phase != "retrying" || states[0].Error == "" {
+		t.Fatalf("retry state = %#v", states)
+	}
+
+	// A delayed line from another connection must not overwrite a newer
+	// lifecycle projection that has already reached the UI.
+	hub.AcceptLine([]byte(`{"level":"info","ts":1699999999,"logger":"tls.obtain","msg":"obtaining certificate","identifier":"example.test","caddyui_server_id":2,"caddyui_server_name":"edge"}`))
+	states, err = models.ListCertificateLifecycle(conn, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].Phase != "retrying" {
+		t.Fatalf("stale event replaced newer lifecycle state: %#v", states)
+	}
+	hub.AcceptLine([]byte(`{"level":"info","ts":1700000002,"logger":"tls.obtain","msg":"certificate obtained successfully","identifier":"example.test","caddyui_server_id":2,"caddyui_server_name":"edge"}`))
+	states, err = models.ListCertificateLifecycle(conn, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].Phase != "active" || states[0].Error != "" {
+		t.Fatalf("success state = %#v, want active without an error", states)
+	}
+
+	entries := hub.Since(0, 2, 20)
+	if len(entries) != 4 {
+		t.Fatalf("runtime entries = %d, want 4", len(entries))
+	}
+	var count int
+	if err := conn.QueryRow(`SELECT COUNT(*) FROM certificate_lifecycle`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("persisted lifecycle rows = %d, want compact single row", count)
+	}
+}
+
+func TestHubDropsAccessLogsFromRuntimeRing(t *testing.T) {
+	hub := New(nil)
+	hub.AcceptLine([]byte(`{"level":"info","logger":"http.log.access.caddyui_access","msg":"handled request","request":{"host":"example.test"}}`))
+	if entries := hub.Since(0, 0, 20); len(entries) != 0 {
+		t.Fatalf("access events leaked into runtime ring: %#v", entries)
+	}
+}

--- a/internal/db/data_migration.go
+++ b/internal/db/data_migration.go
@@ -36,6 +36,7 @@ var migrationTableOrder = []string{
 	"api_tokens",
 	"config_snapshots",
 	"activity_log",
+	"certificate_lifecycle",
 	"access_daily",
 	"proxy_health",
 	"access_events",

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -142,6 +142,8 @@ CREATE TABLE IF NOT EXISTS fleet_deployments (
 CREATE TABLE IF NOT EXISTS access_events (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     ts INTEGER NOT NULL,
+    server_id INTEGER NOT NULL DEFAULT 0,
+    server_name TEXT NOT NULL DEFAULT '',
     host TEXT NOT NULL DEFAULT '',
     path TEXT NOT NULL DEFAULT '',
     method TEXT NOT NULL DEFAULT '',
@@ -153,6 +155,7 @@ CREATE TABLE IF NOT EXISTS access_events (
 );
 CREATE INDEX IF NOT EXISTS idx_access_events_ts      ON access_events(ts);
 CREATE INDEX IF NOT EXISTS idx_access_events_host_ts ON access_events(host, ts);
+CREATE INDEX IF NOT EXISTS idx_access_events_server_ts ON access_events(server_id, ts);
 -- v2.9.206: indexes for status-code breakdown card and unique-visitor count.
 -- (path, ts) intentionally omitted — path values are high-cardinality and the
 -- index would be larger than the table itself; top-paths queries already use
@@ -183,6 +186,21 @@ CREATE TABLE IF NOT EXISTS access_daily (
     s5xx INTEGER NOT NULL DEFAULT 0,
     s_other INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (day, host)
+);
+
+-- Latest observed ACME lifecycle state for each certificate identifier on
+-- each Caddy server. Runtime logs remain ephemeral; only this compact status
+-- projection is persisted so issuance failures survive a UI refresh/restart.
+CREATE TABLE IF NOT EXISTS certificate_lifecycle (
+    server_id INTEGER NOT NULL,
+    server_name TEXT NOT NULL DEFAULT '',
+    identifier VARCHAR(255) NOT NULL,
+    phase VARCHAR(32) NOT NULL DEFAULT '',
+    level VARCHAR(16) NOT NULL DEFAULT '',
+    message TEXT NOT NULL DEFAULT '',
+    error TEXT NOT NULL DEFAULT '',
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (server_id, identifier)
 );
 
 -- v2.7.4: groups let admin bundle user-role accounts into a team. Every user
@@ -2143,6 +2161,21 @@ func migrate(db *sql.DB) error {
 	if !columnExists2(db, "certificates", "dns_profile_id") {
 		_, _ = db.Exec(`ALTER TABLE certificates ADD COLUMN dns_profile_id TEXT NOT NULL DEFAULT ''`)
 	}
+
+	// Fleet observability: retain the actual Caddy node stamped into each
+	// forwarded access event. Existing rows remain server_id=0 and render as
+	// legacy/unattributed rather than being guessed from hostname ownership.
+	if !columnExists2(db, "access_events", "server_id") {
+		if _, err := db.Exec(`ALTER TABLE access_events ADD COLUMN server_id BIGINT NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add server_id to access_events: %w", err)
+		}
+	}
+	if !columnExists2(db, "access_events", "server_name") {
+		if _, err := db.Exec(`ALTER TABLE access_events ADD COLUMN server_name VARCHAR(255) NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add server_name to access_events: %w", err)
+		}
+	}
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_access_events_server_ts ON access_events(server_id, ts)`)
 
 	return nil
 }

--- a/internal/db/mariadb_integration_test.go
+++ b/internal/db/mariadb_integration_test.go
@@ -147,7 +147,7 @@ func assertMariaDBSchemaMatchesSQLite(t *testing.T, maria *sql.DB) {
 	tables := []string{
 		"users", "sessions", "proxy_hosts", "redirection_hosts", "raw_routes",
 		"settings", "config_snapshots", "activity_log", "certificates",
-		"caddy_servers", "fleet_deployments", "access_events", "access_daily", "groups",
+		"caddy_servers", "fleet_deployments", "access_events", "access_daily", "certificate_lifecycle", "groups",
 		"user_groups", "api_tokens", "proxy_health",
 	}
 	for _, table := range tables {
@@ -216,10 +216,19 @@ func TestSQLiteToMariaDBMigration(t *testing.T) {
 	}
 	host := "migration.example.test"
 	if err := models.InsertAccessEvent(source, models.AccessEvent{
-		TS:     time.Now().UTC(),
-		Host:   host,
-		Method: "GET",
-		Status: 204,
+		TS:         time.Now().UTC(),
+		ServerID:   17,
+		ServerName: "Migration Edge",
+		Host:       host,
+		Method:     "GET",
+		Status:     204,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := models.UpsertCertificateLifecycle(source, models.CertificateLifecycleStatus{
+		ServerID: 17, ServerName: "Migration Edge", Identifier: host,
+		Phase: "retrying", Level: "ERROR", Message: "will retry",
+		Error: "synthetic migration failure", UpdatedAt: time.Now().UTC(),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -258,6 +267,13 @@ func TestSQLiteToMariaDBMigration(t *testing.T) {
 	if counts[host] != 1 {
 		t.Fatalf("migrated analytics count = %d, want 1", counts[host])
 	}
+	lifecycle, err := models.ListCertificateLifecycle(target, 17)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lifecycle) != 1 || lifecycle[0].Identifier != host || lifecycle[0].Phase != "retrying" {
+		t.Fatalf("unexpected migrated certificate lifecycle: %#v", lifecycle)
+	}
 }
 
 func cleanMariaDBTestTables(t *testing.T, conn interface {
@@ -268,7 +284,7 @@ func cleanMariaDBTestTables(t *testing.T, conn interface {
 		t.Fatal(err)
 	}
 	tables := []string{
-		"access_events", "proxy_health", "access_daily", "activity_log",
+		"access_events", "proxy_health", "access_daily", "certificate_lifecycle", "activity_log",
 		"config_snapshots", "api_tokens", "sessions", "user_groups",
 		"fleet_deployments", "raw_routes", "redirection_hosts", "proxy_hosts", "certificates",
 		"settings", "caddy_servers", "groups", "users",

--- a/internal/db/mariadb_schema.go
+++ b/internal/db/mariadb_schema.go
@@ -128,6 +128,8 @@ CREATE TABLE IF NOT EXISTS fleet_deployments (
 CREATE TABLE IF NOT EXISTS access_events (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
     ts BIGINT NOT NULL,
+    server_id BIGINT NOT NULL DEFAULT 0,
+    server_name VARCHAR(255) NOT NULL DEFAULT '',
     host VARCHAR(255) NOT NULL DEFAULT '',
     path TEXT NOT NULL DEFAULT '',
     method VARCHAR(16) NOT NULL DEFAULT '',
@@ -138,8 +140,21 @@ CREATE TABLE IF NOT EXISTS access_events (
     bytes_out BIGINT NOT NULL DEFAULT 0,
     INDEX idx_access_events_ts (ts),
     INDEX idx_access_events_host_ts (host, ts),
+    INDEX idx_access_events_server_ts (server_id, ts),
     INDEX idx_access_events_status_ts (status, ts),
     INDEX idx_access_events_client_ip_ts (client_ip, ts)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS certificate_lifecycle (
+    server_id BIGINT NOT NULL,
+    server_name VARCHAR(255) NOT NULL DEFAULT '',
+    identifier VARCHAR(255) NOT NULL,
+    phase VARCHAR(32) NOT NULL DEFAULT '',
+    level VARCHAR(16) NOT NULL DEFAULT '',
+    message TEXT NOT NULL DEFAULT '',
+    error TEXT NOT NULL DEFAULT '',
+    updated_at BIGINT NOT NULL,
+    PRIMARY KEY (server_id, identifier)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS access_daily (

--- a/internal/models/access.go
+++ b/internal/models/access.go
@@ -16,6 +16,8 @@ import (
 type AccessEvent struct {
 	ID         int64
 	TS         time.Time
+	ServerID   int64
+	ServerName string
 	Host       string
 	Path       string
 	Method     string
@@ -33,9 +35,9 @@ type AccessEvent struct {
 // well under SQLite's 1000+ inserts/sec capacity.
 func InsertAccessEvent(db *sql.DB, e AccessEvent) error {
 	_, err := db.Exec(`
-        INSERT INTO access_events (ts, host, path, method, status, client_ip, user_agent, duration_ms, bytes_out)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		e.TS.Unix(), e.Host, e.Path, e.Method, e.Status, e.ClientIP, e.UserAgent, e.DurationMs, e.BytesOut)
+        INSERT INTO access_events (ts, server_id, server_name, host, path, method, status, client_ip, user_agent, duration_ms, bytes_out)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		e.TS.Unix(), e.ServerID, e.ServerName, e.Host, e.Path, e.Method, e.Status, e.ClientIP, e.UserAgent, e.DurationMs, e.BytesOut)
 	return err
 }
 
@@ -89,7 +91,28 @@ func hostMatchClause(host string) (string, []any) {
 	return " AND host = ?", []any{host}
 }
 
-func AccessTotalsSince(db *sql.DB, since time.Time, host string) (AccessTotals, error) {
+func requestedServerID(serverIDs []int64) int64 {
+	if len(serverIDs) > 0 && serverIDs[0] > 0 {
+		return serverIDs[0]
+	}
+	return 0
+}
+
+func serverMatchClause(serverID int64) (string, []any) {
+	if serverID <= 0 {
+		return "", nil
+	}
+	return " AND server_id = ?", []any{serverID}
+}
+
+func AccessTotalsSince(db *sql.DB, since time.Time, host string, serverIDs ...int64) (AccessTotals, error) {
+	serverID := requestedServerID(serverIDs)
+	// The long-term rollup intentionally remains fleet-wide. Server-scoped
+	// views cover the UI's retained raw-event window and read access_events
+	// directly so a host served by multiple nodes is attributed accurately.
+	if serverID > 0 {
+		return accessTotalsFromEvents(db, since, time.Time{}, host, serverID)
+	}
 	todayStart := time.Now().UTC().Truncate(24 * time.Hour)
 	if !since.UTC().Before(todayStart) {
 		// Window starts today or in the future — events table is fast enough
@@ -113,7 +136,7 @@ func AccessTotalsSince(db *sql.DB, since time.Time, host string) (AccessTotals, 
 
 // accessTotalsFromEvents scans access_events directly. When `to` is the zero
 // value the upper bound is unbounded ("ts >= since" only).
-func accessTotalsFromEvents(db *sql.DB, from, to time.Time, host string) (AccessTotals, error) {
+func accessTotalsFromEvents(db *sql.DB, from, to time.Time, host string, serverIDs ...int64) (AccessTotals, error) {
 	var t AccessTotals
 	q := `SELECT COUNT(*), COUNT(DISTINCT client_ip) FROM access_events WHERE ts >= ?`
 	args := []any{from.Unix()}
@@ -124,6 +147,10 @@ func accessTotalsFromEvents(db *sql.DB, from, to time.Time, host string) (Access
 	if hostClause, hostArgs := hostMatchClause(host); hostClause != "" {
 		q += hostClause
 		args = append(args, hostArgs...)
+	}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
 	}
 	err := db.QueryRow(q, args...).Scan(&t.Views, &t.Visitors)
 	if err == sql.ErrNoRows {
@@ -277,13 +304,17 @@ func AggregateAccessDaily(db *sql.DB) (int, error) {
 // AccessTotalsBetween is a variant of AccessTotalsSince with an explicit
 // end time, for finite windows like "yesterday's visitors" where "now" is
 // the wrong upper bound.
-func AccessTotalsBetween(db *sql.DB, from, to time.Time, host string) (AccessTotals, error) {
+func AccessTotalsBetween(db *sql.DB, from, to time.Time, host string, serverIDs ...int64) (AccessTotals, error) {
 	var t AccessTotals
 	q := `SELECT COUNT(*), COUNT(DISTINCT client_ip) FROM access_events WHERE ts >= ? AND ts < ?`
 	args := []any{from.Unix(), to.Unix()}
-	if host != "" {
-		q += ` AND host = ?`
-		args = append(args, host)
+	if hostClause, hostArgs := hostMatchClause(host); hostClause != "" {
+		q += hostClause
+		args = append(args, hostArgs...)
+	}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
 	}
 	err := db.QueryRow(q, args...).Scan(&t.Views, &t.Visitors)
 	if err == sql.ErrNoRows {
@@ -294,10 +325,15 @@ func AccessTotalsBetween(db *sql.DB, from, to time.Time, host string) (AccessTot
 
 // AccessLiveVisitors returns the distinct-IP count over the last `window`
 // (typically 5 minutes). This powers the "Live now" card on /analytics.
-func AccessLiveVisitors(db *sql.DB, window time.Duration) (int, error) {
+func AccessLiveVisitors(db *sql.DB, window time.Duration, serverIDs ...int64) (int, error) {
 	var n int
-	err := db.QueryRow(`SELECT COUNT(DISTINCT client_ip) FROM access_events WHERE ts >= ?`,
-		time.Now().Add(-window).Unix()).Scan(&n)
+	q := `SELECT COUNT(DISTINCT client_ip) FROM access_events WHERE ts >= ?`
+	args := []any{time.Now().Add(-window).Unix()}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
+	}
+	err := db.QueryRow(q, args...).Scan(&n)
 	if err == sql.ErrNoRows {
 		return 0, nil
 	}
@@ -319,17 +355,23 @@ type HostStats struct {
 // ordered by view count. Limit caps the returned set. TopPath is filled via
 // a second pass (one query per host) to avoid a correlated subquery that
 // produces empty results in modernc.org/sqlite when no host filter is present.
-func TopHostsSince(db *sql.DB, since time.Time, limit int) ([]HostStats, error) {
+func TopHostsSince(db *sql.DB, since time.Time, limit int, serverIDs ...int64) ([]HostStats, error) {
 	sinceUnix := since.Unix()
+	serverID := requestedServerID(serverIDs)
 	// Step 1: aggregate by host — no correlated subquery, no alias in GROUP BY.
-	rows, err := db.Query(
-		`SELECT host, COUNT(*) AS views, COUNT(DISTINCT client_ip) AS visitors, MAX(ts) AS last_ts
+	q := `SELECT host, COUNT(*) AS views, COUNT(DISTINCT client_ip) AS visitors, MAX(ts) AS last_ts
 		   FROM access_events
-		  WHERE ts >= ?
+		  WHERE ts >= ?`
+	args := []any{sinceUnix}
+	if serverClause, serverArgs := serverMatchClause(serverID); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
+	}
+	q += `
 		  GROUP BY host
 		  ORDER BY views DESC
-		  LIMIT `+strconv.Itoa(limit),
-		sinceUnix)
+		  LIMIT ` + strconv.Itoa(limit)
+	rows, err := db.Query(q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -352,13 +394,19 @@ func TopHostsSince(db *sql.DB, since time.Time, limit int) ([]HostStats, error) 
 	// Runs up to `limit` small indexed lookups — fast on the (host, ts) index.
 	for i := range out {
 		var p string
-		_ = db.QueryRow(
-			`SELECT path FROM access_events
+		pathQuery := `SELECT path FROM access_events
 			  WHERE host = ? AND ts >= ?
+			`
+		pathArgs := []any{out[i].Host, sinceUnix}
+		if serverClause, serverArgs := serverMatchClause(serverID); serverClause != "" {
+			pathQuery += serverClause
+			pathArgs = append(pathArgs, serverArgs...)
+		}
+		pathQuery += `
 			  GROUP BY path
 			  ORDER BY COUNT(*) DESC
-			  LIMIT 1`,
-			out[i].Host, sinceUnix).Scan(&p)
+			  LIMIT 1`
+		_ = db.QueryRow(pathQuery, pathArgs...).Scan(&p)
 		out[i].TopPath = p
 	}
 	return out, nil
@@ -368,7 +416,7 @@ func TopHostsSince(db *sql.DB, since time.Time, limit int) ([]HostStats, error) 
 // the allowed host set (the caller computes it from the user's owned
 // proxy/raw-route rows) and only those hosts are returned. Empty set returns
 // nil (not an error) — a non-admin with no owned sites sees an empty table.
-func HostStatsForHosts(db *sql.DB, since time.Time, hosts []string) ([]HostStats, error) {
+func HostStatsForHosts(db *sql.DB, since time.Time, hosts []string, serverIDs ...int64) ([]HostStats, error) {
 	if len(hosts) == 0 {
 		return nil, nil
 	}
@@ -379,8 +427,20 @@ func HostStatsForHosts(db *sql.DB, since time.Time, hosts []string) ([]HostStats
 		hosts = hosts[:500]
 	}
 	placeholders := make([]byte, 0, len(hosts)*2)
-	args := make([]any, 0, len(hosts)+2)
-	args = append(args, since.Unix(), since.Unix())
+	serverID := requestedServerID(serverIDs)
+	args := make([]any, 0, len(hosts)+4)
+	args = append(args, since.Unix())
+	innerServer := ""
+	outerServer := ""
+	if serverID > 0 {
+		innerServer = ` AND server_id = ?`
+		outerServer = ` AND server_id = ?`
+		args = append(args, serverID)
+	}
+	args = append(args, since.Unix())
+	if serverID > 0 {
+		args = append(args, serverID)
+	}
 	for i, h := range hosts {
 		if i > 0 {
 			placeholders = append(placeholders, ',')
@@ -394,12 +454,12 @@ func HostStatsForHosts(db *sql.DB, since time.Time, hosts []string) ([]HostStats
                COUNT(DISTINCT client_ip) AS visitors,
                COALESCE((
                    SELECT path FROM access_events
-                   WHERE host = outer_e.host AND ts >= ?
+                   WHERE host = outer_e.host AND ts >= ?` + innerServer + `
                    GROUP BY path ORDER BY COUNT(*) DESC LIMIT 1
                ), '') AS top_path,
                MAX(ts) AS last_ts
           FROM access_events outer_e
-         WHERE ts >= ? AND host IN (` + string(placeholders) + `)
+         WHERE ts >= ?` + outerServer + ` AND host IN (` + string(placeholders) + `)
          GROUP BY host
          ORDER BY views DESC`
 	rows, err := db.Query(q, args...)
@@ -435,7 +495,7 @@ type HourlyBucket struct {
 // NOT returned — the caller reconstructs the full series by walking the
 // expected range and filling gaps with zeros. Keeps the query cheap when
 // a long/sparse window would otherwise scan millions of near-empty buckets.
-func AccessBuckets(db *sql.DB, from, to time.Time, bucketSeconds int64, host string) ([]HourlyBucket, error) {
+func AccessBuckets(db *sql.DB, from, to time.Time, bucketSeconds int64, host string, serverIDs ...int64) ([]HourlyBucket, error) {
 	if bucketSeconds <= 0 {
 		bucketSeconds = 3600
 	}
@@ -446,9 +506,13 @@ func AccessBuckets(db *sql.DB, from, to time.Time, bucketSeconds int64, host str
           FROM access_events
          WHERE ts >= ? AND ts < ?`
 	args := []any{bucketSeconds, bucketSeconds, from.Unix(), to.Unix()}
-	if host != "" {
-		q += ` AND host = ?`
-		args = append(args, host)
+	if hostClause, hostArgs := hostMatchClause(host); hostClause != "" {
+		q += hostClause
+		args = append(args, hostArgs...)
+	}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
 	}
 	q += ` GROUP BY 1 ORDER BY 1 ASC`
 	rows, err := db.Query(q, args...)
@@ -478,17 +542,21 @@ type PathStats struct {
 	Views  int
 }
 
-func TopPaths(db *sql.DB, since time.Time, host string, limit int) ([]PathStats, error) {
+func TopPaths(db *sql.DB, since time.Time, host string, limit int, serverIDs ...int64) ([]PathStats, error) {
 	if host == "" {
 		return nil, nil
 	}
-	rows, err := db.Query(`
+	q := `
         SELECT path, method, COUNT(*) AS views
           FROM access_events
-         WHERE ts >= ? AND host = ?
-         GROUP BY path, method
-         ORDER BY views DESC
-         LIMIT `+strconv.Itoa(limit), since.Unix(), host)
+		 WHERE ts >= ? AND host = ?`
+	args := []any{since.Unix(), host}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
+	}
+	q += ` GROUP BY path, method ORDER BY views DESC LIMIT ` + strconv.Itoa(limit)
+	rows, err := db.Query(q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -519,7 +587,11 @@ type StatusBuckets struct {
 // the past) read past-day buckets from the access_daily rollup and only scan
 // access_events for today, dropping the cost from O(window-rows) to
 // O(today-rows + days-in-window).
-func StatusBucketsSince(db *sql.DB, since time.Time, host string) (StatusBuckets, error) {
+func StatusBucketsSince(db *sql.DB, since time.Time, host string, serverIDs ...int64) (StatusBuckets, error) {
+	serverID := requestedServerID(serverIDs)
+	if serverID > 0 {
+		return statusBucketsFromEvents(db, since, time.Time{}, host, serverID)
+	}
 	todayStart := time.Now().UTC().Truncate(24 * time.Hour)
 	if !since.UTC().Before(todayStart) {
 		return statusBucketsFromEvents(db, since, time.Time{}, host)
@@ -541,7 +613,7 @@ func StatusBucketsSince(db *sql.DB, since time.Time, host string) (StatusBuckets
 	}, nil
 }
 
-func statusBucketsFromEvents(db *sql.DB, from, to time.Time, host string) (StatusBuckets, error) {
+func statusBucketsFromEvents(db *sql.DB, from, to time.Time, host string, serverIDs ...int64) (StatusBuckets, error) {
 	var b StatusBuckets
 	q := `SELECT
 		COALESCE(SUM(CASE WHEN status >= 200 AND status < 300 THEN 1 ELSE 0 END), 0),
@@ -555,9 +627,13 @@ func statusBucketsFromEvents(db *sql.DB, from, to time.Time, host string) (Statu
 		q += ` AND ts < ?`
 		args = append(args, to.Unix())
 	}
-	if host != "" {
-		q += ` AND host = ?`
-		args = append(args, host)
+	if hostClause, hostArgs := hostMatchClause(host); hostClause != "" {
+		q += hostClause
+		args = append(args, hostArgs...)
+	}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
 	}
 	err := db.QueryRow(q, args...).Scan(&b.S2xx, &b.S3xx, &b.S4xx, &b.S5xx, &b.SOther)
 	if err == sql.ErrNoRows {
@@ -592,7 +668,7 @@ type ClientIPStats struct {
 	Views    int
 }
 
-func TopClientIPs(db *sql.DB, since time.Time, host string, limit int) ([]ClientIPStats, error) {
+func TopClientIPs(db *sql.DB, since time.Time, host string, limit int, serverIDs ...int64) ([]ClientIPStats, error) {
 	q := `
         SELECT client_ip, COUNT(*) AS views
           FROM access_events
@@ -601,6 +677,10 @@ func TopClientIPs(db *sql.DB, since time.Time, host string, limit int) ([]Client
 	if host != "" {
 		q += ` AND host = ?`
 		args = append(args, host)
+	}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
 	}
 	q += ` GROUP BY client_ip ORDER BY views DESC LIMIT ` + strconv.Itoa(limit)
 	rows, err := db.Query(q, args...)
@@ -630,30 +710,31 @@ type ResponseTimeStats struct {
 // ResponseTimeSince returns avg/min/max/p95 response times for events in the
 // window. P95 is approximated with a second OFFSET query — close enough for a
 // dashboard panel without a full window-function pass.
-func ResponseTimeSince(db *sql.DB, since time.Time, host string) (ResponseTimeStats, error) {
+func ResponseTimeSince(db *sql.DB, since time.Time, host string, serverIDs ...int64) (ResponseTimeStats, error) {
 	var s ResponseTimeStats
 	args := []any{since.Unix()}
-	hostFilter := ""
+	filter := ""
 	if host != "" {
-		hostFilter = " AND host = ?"
+		filter += " AND host = ?"
 		args = append(args, host)
+	}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		filter += serverClause
+		args = append(args, serverArgs...)
 	}
 	err := db.QueryRow(
 		`SELECT COALESCE(AVG(duration_ms),0), COALESCE(MIN(duration_ms),0), COALESCE(MAX(duration_ms),0)
-		   FROM access_events WHERE ts >= ?`+hostFilter, args...).Scan(&s.AvgMs, &s.MinMs, &s.MaxMs)
+		   FROM access_events WHERE ts >= ?`+filter, args...).Scan(&s.AvgMs, &s.MinMs, &s.MaxMs)
 	if err != nil && err != sql.ErrNoRows {
 		return s, err
 	}
 	// P95 approximation: the value at the 95th-percentile index.
 	var count int64
-	_ = db.QueryRow(`SELECT COUNT(*) FROM access_events WHERE ts >= ?`+hostFilter, args...).Scan(&count)
+	_ = db.QueryRow(`SELECT COUNT(*) FROM access_events WHERE ts >= ?`+filter, args...).Scan(&count)
 	if count > 0 {
 		offset := count * 95 / 100
-		p95args := make([]any, len(args)*2)
-		copy(p95args, args)
-		copy(p95args[len(args):], args)
 		_ = db.QueryRow(
-			`SELECT COALESCE(duration_ms,0) FROM access_events WHERE ts >= ?`+hostFilter+
+			`SELECT COALESCE(duration_ms,0) FROM access_events WHERE ts >= ?`+filter+
 				` ORDER BY duration_ms LIMIT 1 OFFSET `+strconv.FormatInt(offset, 10), args...).Scan(&s.P95Ms)
 	}
 	return s, nil
@@ -661,13 +742,17 @@ func ResponseTimeSince(db *sql.DB, since time.Time, host string) (ResponseTimeSt
 
 // BandwidthSince returns the total bytes_out for events newer than since,
 // optionally scoped to a single host.
-func BandwidthSince(db *sql.DB, since time.Time, host string) (int64, error) {
+func BandwidthSince(db *sql.DB, since time.Time, host string, serverIDs ...int64) (int64, error) {
 	var total int64
 	q := `SELECT COALESCE(SUM(bytes_out),0) FROM access_events WHERE ts >= ?`
 	args := []any{since.Unix()}
 	if hostClause, hostArgs := hostMatchClause(host); hostClause != "" {
 		q += hostClause
 		args = append(args, hostArgs...)
+	}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
 	}
 	err := db.QueryRow(q, args...).Scan(&total)
 	if err == sql.ErrNoRows {
@@ -685,7 +770,7 @@ type BandwidthBucket struct {
 // BandwidthBuckets returns equally-sized time buckets of bytes_out between
 // `from` and `to`, each covering `bucketSeconds`. Buckets with zero bytes are
 // NOT returned — caller fills gaps. Same contract as AccessBuckets.
-func BandwidthBuckets(db *sql.DB, from, to time.Time, bucketSeconds int64, host string) ([]BandwidthBucket, error) {
+func BandwidthBuckets(db *sql.DB, from, to time.Time, bucketSeconds int64, host string, serverIDs ...int64) ([]BandwidthBucket, error) {
 	if bucketSeconds <= 0 {
 		bucketSeconds = 3600
 	}
@@ -695,9 +780,13 @@ func BandwidthBuckets(db *sql.DB, from, to time.Time, bucketSeconds int64, host 
           FROM access_events
          WHERE ts >= ? AND ts < ?`
 	args := []any{bucketSeconds, bucketSeconds, from.Unix(), to.Unix()}
-	if host != "" {
-		q += ` AND host = ?`
-		args = append(args, host)
+	if hostClause, hostArgs := hostMatchClause(host); hostClause != "" {
+		q += hostClause
+		args = append(args, hostArgs...)
+	}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
 	}
 	q += ` GROUP BY 1 ORDER BY 1 ASC`
 	rows, err := db.Query(q, args...)
@@ -720,13 +809,19 @@ func BandwidthBuckets(db *sql.DB, from, to time.Time, bucketSeconds int64, host 
 
 // RecentAccessEvents returns the most recent `limit` access events, ordered
 // newest-first. Used by the live traffic feed page and its SSE stream.
-func RecentAccessEvents(db *sql.DB, since int64, limit int) ([]AccessEvent, error) {
-	q := `SELECT id, ts, host, path, method, status, client_ip, user_agent, duration_ms, bytes_out
+func RecentAccessEvents(db *sql.DB, since int64, limit int, serverIDs ...int64) ([]AccessEvent, error) {
+	q := `SELECT id, ts, server_id, server_name, host, path, method, status, client_ip, user_agent, duration_ms, bytes_out
 	        FROM access_events
-	       WHERE id > ?
+	       WHERE id > ?`
+	args := []any{since}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
+	}
+	q += `
 	       ORDER BY id DESC
 	       LIMIT ` + strconv.Itoa(limit)
-	rows, err := db.Query(q, since)
+	rows, err := db.Query(q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -735,7 +830,7 @@ func RecentAccessEvents(db *sql.DB, since int64, limit int) ([]AccessEvent, erro
 	for rows.Next() {
 		var e AccessEvent
 		var ts int64
-		if err := rows.Scan(&e.ID, &ts, &e.Host, &e.Path, &e.Method, &e.Status, &e.ClientIP, &e.UserAgent, &e.DurationMs, &e.BytesOut); err != nil {
+		if err := rows.Scan(&e.ID, &ts, &e.ServerID, &e.ServerName, &e.Host, &e.Path, &e.Method, &e.Status, &e.ClientIP, &e.UserAgent, &e.DurationMs, &e.BytesOut); err != nil {
 			return nil, err
 		}
 		e.TS = time.Unix(ts, 0)
@@ -747,14 +842,18 @@ func RecentAccessEvents(db *sql.DB, since int64, limit int) ([]AccessEvent, erro
 // ExportAccessEvents returns up to `limit` access events newer than `since`,
 // optionally scoped to one host. Used by the CSV export endpoint. Ordered
 // oldest-first so the CSV reads chronologically.
-func ExportAccessEvents(db *sql.DB, since time.Time, host string, limit int) ([]AccessEvent, error) {
-	q := `SELECT id, ts, host, path, method, status, client_ip, user_agent, duration_ms, bytes_out
+func ExportAccessEvents(db *sql.DB, since time.Time, host string, limit int, serverIDs ...int64) ([]AccessEvent, error) {
+	q := `SELECT id, ts, server_id, server_name, host, path, method, status, client_ip, user_agent, duration_ms, bytes_out
 	        FROM access_events
 	       WHERE ts >= ?`
 	args := []any{since.Unix()}
-	if host != "" {
-		q += ` AND host = ?`
-		args = append(args, host)
+	if hostClause, hostArgs := hostMatchClause(host); hostClause != "" {
+		q += hostClause
+		args = append(args, hostArgs...)
+	}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
 	}
 	q += ` ORDER BY ts ASC LIMIT ` + strconv.Itoa(limit)
 	rows, err := db.Query(q, args...)
@@ -766,7 +865,7 @@ func ExportAccessEvents(db *sql.DB, since time.Time, host string, limit int) ([]
 	for rows.Next() {
 		var e AccessEvent
 		var ts int64
-		if err := rows.Scan(&e.ID, &ts, &e.Host, &e.Path, &e.Method, &e.Status,
+		if err := rows.Scan(&e.ID, &ts, &e.ServerID, &e.ServerName, &e.Host, &e.Path, &e.Method, &e.Status,
 			&e.ClientIP, &e.UserAgent, &e.DurationMs, &e.BytesOut); err != nil {
 			return nil, err
 		}
@@ -785,7 +884,7 @@ type ErrorPathStats struct {
 
 // TopErrorPaths returns the paths+methods with the most 4xx/5xx responses
 // in the window, ordered by error count descending.
-func TopErrorPaths(db *sql.DB, since time.Time, host string, limit int) ([]ErrorPathStats, error) {
+func TopErrorPaths(db *sql.DB, since time.Time, host string, limit int, serverIDs ...int64) ([]ErrorPathStats, error) {
 	q := `SELECT path, method, COUNT(*) AS cnt
 		    FROM access_events
 		   WHERE ts >= ? AND status >= 400`
@@ -793,6 +892,10 @@ func TopErrorPaths(db *sql.DB, since time.Time, host string, limit int) ([]Error
 	if host != "" {
 		q += ` AND host = ?`
 		args = append(args, host)
+	}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
 	}
 	q += ` GROUP BY path, method ORDER BY cnt DESC LIMIT ` + strconv.Itoa(limit)
 	rows, err := db.Query(q, args...)
@@ -930,16 +1033,20 @@ func DomainRequestsTodayForDomains(db *sql.DB, domains []string) (map[string]int
 // by a bucketed key so we don't pull millions of strings into Go.
 // Since SQLite doesn't have a Go-callable UDF from SQL, we fetch the top
 // user_agent strings with their counts and classify them in Go.
-func TopBrowsers(db *sql.DB, since time.Time, host string, limit int) ([]UABucket, error) {
+func TopBrowsers(db *sql.DB, since time.Time, host string, limit int, serverIDs ...int64) ([]UABucket, error) {
 	// Fetch top N distinct user_agent values by count — 200 is enough to cover
 	// all meaningful browsers while keeping the result set small.
-	rows, err := db.Query(`
+	q := `
         SELECT user_agent, COUNT(*) AS cnt
         FROM access_events
-        WHERE ts >= ? AND host = ?
-        GROUP BY user_agent
-        ORDER BY cnt DESC
-        LIMIT 200`, since.Unix(), host)
+		WHERE ts >= ? AND host = ?`
+	args := []any{since.Unix(), host}
+	if serverClause, serverArgs := serverMatchClause(requestedServerID(serverIDs)); serverClause != "" {
+		q += serverClause
+		args = append(args, serverArgs...)
+	}
+	q += ` GROUP BY user_agent ORDER BY cnt DESC LIMIT 200`
+	rows, err := db.Query(q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/models/access_server_test.go
+++ b/internal/models/access_server_test.go
@@ -1,0 +1,83 @@
+package models_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	appdb "github.com/X4Applegate/caddyui/internal/db"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+func TestAccessQueriesFilterByActualFleetServer(t *testing.T) {
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	now := time.Now().UTC()
+	events := []models.AccessEvent{
+		{TS: now, ServerID: 1, ServerName: "edge-a", Host: "shared.test", Path: "/a", Method: "GET", Status: 200, ClientIP: "192.0.2.1", UserAgent: "Firefox", DurationMs: 11, BytesOut: 10},
+		{TS: now.Add(time.Second), ServerID: 2, ServerName: "edge-b", Host: "shared.test", Path: "/b", Method: "POST", Status: 503, ClientIP: "192.0.2.2", UserAgent: "Chrome", DurationMs: 22, BytesOut: 20},
+		{TS: now.Add(2 * time.Second), ServerID: 2, ServerName: "edge-b", Host: "other.test", Path: "/c", Method: "GET", Status: 200, ClientIP: "192.0.2.3", UserAgent: "curl", DurationMs: 33, BytesOut: 30},
+	}
+	for _, event := range events {
+		if err := models.InsertAccessEvent(conn, event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	totals, err := models.AccessTotalsSince(conn, now.Add(-time.Minute), "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if totals.Views != 2 || totals.Visitors != 2 {
+		t.Fatalf("server 2 totals = %#v, want 2/2", totals)
+	}
+	shared, err := models.AccessTotalsSince(conn, now.Add(-time.Minute), "shared.test", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shared.Views != 1 {
+		t.Fatalf("server 2 shared.test views = %d, want 1", shared.Views)
+	}
+	status, err := models.StatusBucketsSince(conn, now.Add(-time.Minute), "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.S2xx != 1 || status.S5xx != 1 {
+		t.Fatalf("server 2 status = %#v, want one 2xx and one 5xx", status)
+	}
+	recent, err := models.RecentAccessEvents(conn, 0, 20, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recent) != 1 || recent[0].ServerName != "edge-a" || recent[0].Path != "/a" {
+		t.Fatalf("server 1 recent = %#v", recent)
+	}
+	paths, err := models.TopPaths(conn, now.Add(-time.Minute), "shared.test", 20, 1)
+	if err != nil || len(paths) != 1 || paths[0].Path != "/a" {
+		t.Fatalf("server 1 paths = %#v, err=%v", paths, err)
+	}
+	clients, err := models.TopClientIPs(conn, now.Add(-time.Minute), "shared.test", 20, 1)
+	if err != nil || len(clients) != 1 || clients[0].ClientIP != "192.0.2.1" {
+		t.Fatalf("server 1 clients = %#v, err=%v", clients, err)
+	}
+	responseTime, err := models.ResponseTimeSince(conn, now.Add(-time.Minute), "shared.test", 1)
+	if err != nil || responseTime.AvgMs != 11 || responseTime.MaxMs != 11 {
+		t.Fatalf("server 1 response time = %#v, err=%v", responseTime, err)
+	}
+	errors, err := models.TopErrorPaths(conn, now.Add(-time.Minute), "shared.test", 20, 1)
+	if err != nil || len(errors) != 0 {
+		t.Fatalf("server 1 errors = %#v, err=%v", errors, err)
+	}
+	browsers, err := models.TopBrowsers(conn, now.Add(-time.Minute), "shared.test", 20, 1)
+	if err != nil || len(browsers) != 1 || browsers[0].Browser != "Firefox" {
+		t.Fatalf("server 1 browsers = %#v, err=%v", browsers, err)
+	}
+	bandwidth, err := models.BandwidthSince(conn, now.Add(-time.Minute), "shared.test", 1)
+	if err != nil || bandwidth != 10 {
+		t.Fatalf("server 1 bandwidth = %d, err=%v", bandwidth, err)
+	}
+}

--- a/internal/models/certificate_lifecycle.go
+++ b/internal/models/certificate_lifecycle.go
@@ -1,0 +1,108 @@
+package models
+
+import (
+	"database/sql"
+	"strings"
+	"time"
+)
+
+// CertificateLifecycleStatus is the latest ACME state observed in Caddy's
+// structured TLS logs for one identifier on one fleet server.
+type CertificateLifecycleStatus struct {
+	ServerID   int64     `json:"server_id"`
+	ServerName string    `json:"server_name"`
+	Identifier string    `json:"identifier"`
+	Phase      string    `json:"phase"`
+	Level      string    `json:"level"`
+	Message    string    `json:"message"`
+	Error      string    `json:"error,omitempty"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+func normalizeCertificateIdentifier(identifier string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(identifier)), ".")
+}
+
+// UpsertCertificateLifecycle stores only the latest state. UPDATE-then-INSERT
+// is portable across SQLite and MariaDB, unlike their different UPSERT
+// syntaxes. Timestamp guards prevent delayed log lines from replacing newer
+// state, and the final UPDATE handles an unlikely duplicate insert race.
+func UpsertCertificateLifecycle(db *sql.DB, state CertificateLifecycleStatus) error {
+	state.Identifier = normalizeCertificateIdentifier(state.Identifier)
+	if state.ServerID <= 0 || state.Identifier == "" {
+		return nil
+	}
+	if state.UpdatedAt.IsZero() {
+		state.UpdatedAt = time.Now().UTC()
+	}
+	args := []any{
+		state.ServerName, state.Phase, state.Level, state.Message, state.Error,
+		state.UpdatedAt.Unix(), state.ServerID, state.Identifier, state.UpdatedAt.Unix(),
+	}
+	result, err := db.Exec(`UPDATE certificate_lifecycle
+		SET server_name=?, phase=?, level=?, message=?, error=?, updated_at=?
+		WHERE server_id=? AND identifier=? AND updated_at <= ?`, args...)
+	if err != nil {
+		return err
+	}
+	if n, _ := result.RowsAffected(); n > 0 {
+		return nil
+	}
+	var currentUpdated int64
+	if err := db.QueryRow(`SELECT updated_at FROM certificate_lifecycle
+		WHERE server_id=? AND identifier=?`, state.ServerID, state.Identifier).Scan(&currentUpdated); err == nil {
+		return nil
+	} else if err != sql.ErrNoRows {
+		return err
+	}
+	_, insertErr := db.Exec(`INSERT INTO certificate_lifecycle
+		(server_id, server_name, identifier, phase, level, message, error, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		state.ServerID, state.ServerName, state.Identifier, state.Phase,
+		state.Level, state.Message, state.Error, state.UpdatedAt.Unix())
+	if insertErr == nil {
+		return nil
+	}
+	result, retryErr := db.Exec(`UPDATE certificate_lifecycle
+		SET server_name=?, phase=?, level=?, message=?, error=?, updated_at=?
+		WHERE server_id=? AND identifier=? AND updated_at <= ?`, args...)
+	if retryErr != nil {
+		return retryErr
+	}
+	if n, _ := result.RowsAffected(); n > 0 {
+		return nil
+	}
+	if err := db.QueryRow(`SELECT updated_at FROM certificate_lifecycle
+		WHERE server_id=? AND identifier=?`, state.ServerID, state.Identifier).Scan(&currentUpdated); err == nil {
+		return nil
+	}
+	return insertErr
+}
+
+func ListCertificateLifecycle(db *sql.DB, serverID int64) ([]CertificateLifecycleStatus, error) {
+	q := `SELECT server_id, server_name, identifier, phase, level, message, error, updated_at
+		FROM certificate_lifecycle`
+	var args []any
+	if serverID > 0 {
+		q += ` WHERE server_id=?`
+		args = append(args, serverID)
+	}
+	q += ` ORDER BY updated_at DESC, identifier ASC`
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []CertificateLifecycleStatus
+	for rows.Next() {
+		var state CertificateLifecycleStatus
+		var updated int64
+		if err := rows.Scan(&state.ServerID, &state.ServerName, &state.Identifier,
+			&state.Phase, &state.Level, &state.Message, &state.Error, &updated); err != nil {
+			return nil, err
+		}
+		state.UpdatedAt = time.Unix(updated, 0).UTC()
+		out = append(out, state)
+	}
+	return out, rows.Err()
+}

--- a/internal/server/analytics.go
+++ b/internal/server/analytics.go
@@ -182,6 +182,7 @@ func (s *Server) applyAnalyticsToggle(cfg analyticsConfig) error {
 		if cfg.Enabled {
 			if err := cli.EnableAccessLogs(cfg.Target, caddy.AccessLogOptions{
 				SoftStart: cfg.SoftStart, DialTimeout: cfg.DialTimeout,
+				ServerID: sr.ID, ServerName: sr.Name,
 			}); err != nil {
 				errMsgs = append(errMsgs, fmt.Sprintf("server %q (%s): enable: %v", sr.Name, sr.AdminURL, err))
 				continue
@@ -240,8 +241,7 @@ func (s *Server) userAllowedHosts(u *models.User) ([]string, error) {
 //	  - non-admin → union of owned hosts across every server.
 //
 //	serverID > 0 → scoped to that one server.
-//	  - admin    → every host routed by that server (a *concrete* list so
-//	              the existing per-host-list query paths apply).
+//	  - admin    → nil host filter; access_events.server_id is authoritative.
 //	  - non-admin → intersection of "owned" with "routed by this server"
 //	              (i.e. the same ListProxyHosts/ListRawRoutes call with
 //	              viewerID + isAdmin=false).
@@ -253,9 +253,10 @@ func (s *Server) scopedHostsForAnalytics(u *models.User, serverID int64) ([]stri
 		return []string{}, nil
 	}
 	isAdmin := u.Role == models.RoleAdmin
-	// Cross-fleet + admin → no filter. Single-query hot path through
-	// AccessTotalsSince("") / TopHostsSince(...).
-	if isAdmin && serverID == 0 {
+	// Admin views never infer node ownership from current route hostnames.
+	// The stamped access_events.server_id is authoritative, including for
+	// shared hostnames and routes that were changed after an event arrived.
+	if isAdmin {
 		return nil, nil
 	}
 
@@ -279,21 +280,11 @@ func (s *Server) scopedHostsForAnalytics(u *models.User, serverID int64) ([]stri
 		}
 	}
 
-	// viewerID is only consulted when isAdmin=false. For admin + specific
-	// server we pass ID=0 + isAdmin=true so the ListProxyHosts path returns
-	// every row; non-admin passes the user's ID + isAdmin=false so only
-	// owned rows come back.
-	viewerID := int64(0)
-	queryAsAdmin := true
-	var peers []int64
-	if !isAdmin {
-		viewerID = u.ID
-		queryAsAdmin = false
-		// v2.7.4: analytics visibility follows list visibility — if a user can
-		// see a teammate's proxy host on the hosts page, they should also see
-		// its traffic in the analytics picker.
-		peers, _ = models.GroupPeerIDs(s.DB, u.ID)
-	}
+	viewerID := u.ID
+	queryAsAdmin := false
+	// Analytics visibility follows list visibility — if a user can see a
+	// teammate's proxy host, they should also see its traffic.
+	peers, _ := models.GroupPeerIDs(s.DB, u.ID)
 
 	var hosts []string
 	seen := make(map[string]bool)
@@ -347,14 +338,28 @@ func (s *Server) scopedHostsForAnalytics(u *models.User, serverID int64) ([]stri
 	return hosts, nil
 }
 
+// analyticsServerScope resolves the inline server filter. Bare analytics
+// pages follow the globally selected server; an explicit "all" requests the
+// cross-fleet view.
+func (s *Server) analyticsServerScope(r *http.Request) int64 {
+	if !r.URL.Query().Has("server") {
+		return s.currentServerID(r)
+	}
+	raw := strings.TrimSpace(r.URL.Query().Get("server"))
+	if raw == "" || raw == "0" || raw == "all" {
+		return 0
+	}
+	serverID, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || serverID <= 0 {
+		return 0
+	}
+	return serverID
+}
+
 // getAnalytics renders the /analytics overview page. Shows totals (today +
 // last 7d), the "live now" visitor count, a per-host table, a 24-hour
 // hourly sparkline, and a status-code breakdown. Scope is admin-see-all
 // vs non-admin-see-only-my-hosts, driven by scopedHostsForAnalytics above.
-//
-// v2.7.1 added the `?server=<id>` query-param for the inline server filter
-// — an admin with 5+ Caddy servers can now narrow the dashboard to one
-// server without changing their global CurrentServer selection.
 func (s *Server) getAnalytics(w http.ResponseWriter, r *http.Request) {
 	u := s.currentUser(r)
 
@@ -364,21 +369,7 @@ func (s *Server) getAnalytics(w http.ResponseWriter, r *http.Request) {
 	// "show me what's happening on the server I picked." Explicit
 	// ?server=all (or ?server=0 for back-compat with old bookmarks)
 	// still gets you the cross-fleet view.
-	var serverScopeID int64
-	q := r.URL.Query()
-	if q.Has("server") {
-		raw := strings.TrimSpace(q.Get("server"))
-		switch raw {
-		case "", "0", "all":
-			serverScopeID = 0
-		default:
-			if n, err := strconv.ParseInt(raw, 10, 64); err == nil && n > 0 {
-				serverScopeID = n
-			}
-		}
-	} else {
-		serverScopeID = s.currentServerID(r)
-	}
+	serverScopeID := s.analyticsServerScope(r)
 
 	allowedHosts, err := s.scopedHostsForAnalytics(u, serverScopeID)
 	if err != nil {
@@ -420,44 +411,44 @@ func (s *Server) getAnalytics(w http.ResponseWriter, r *http.Request) {
 	)
 	if !scoped {
 		var err2 error
-		todayTotals, err2 = models.AccessTotalsSince(s.DB, todayStart, "")
+		todayTotals, err2 = models.AccessTotalsSince(s.DB, todayStart, "", serverScopeID)
 		if err2 != nil {
 			log.Printf("analytics: AccessTotalsSince(today): %v", err2)
 		}
-		sevenTotals, err2 = models.AccessTotalsSince(s.DB, sevenDaysAgo, "")
+		sevenTotals, err2 = models.AccessTotalsSince(s.DB, sevenDaysAgo, "", serverScopeID)
 		if err2 != nil {
 			log.Printf("analytics: AccessTotalsSince(7d): %v", err2)
 		}
-		liveVisitors, err2 = models.AccessLiveVisitors(s.DB, 5*time.Minute)
+		liveVisitors, err2 = models.AccessLiveVisitors(s.DB, 5*time.Minute, serverScopeID)
 		if err2 != nil {
 			log.Printf("analytics: AccessLiveVisitors: %v", err2)
 		}
 	} else {
 		for _, h := range allowedHosts {
-			t1, _ := models.AccessTotalsSince(s.DB, todayStart, h)
+			t1, _ := models.AccessTotalsSince(s.DB, todayStart, h, serverScopeID)
 			todayTotals.Views += t1.Views
 			todayTotals.Visitors += t1.Visitors
-			t7, _ := models.AccessTotalsSince(s.DB, sevenDaysAgo, h)
+			t7, _ := models.AccessTotalsSince(s.DB, sevenDaysAgo, h, serverScopeID)
 			sevenTotals.Views += t7.Views
 			sevenTotals.Visitors += t7.Visitors
 		}
 		// Live: distinct IPs across owned hosts. Per-host counts aren't
 		// additive (an IP visiting two hosts would double-count), so we
 		// union in code rather than sum.
-		liveVisitors = s.liveVisitorsAcrossHosts(allowedHosts, 5*time.Minute)
+		liveVisitors = s.liveVisitorsAcrossHosts(allowedHosts, 5*time.Minute, serverScopeID)
 	}
 
 	// Per-host table: top 50 by views in last 7 days.
 	var hostRows []models.HostStats
 	if !scoped {
 		var err2 error
-		hostRows, err2 = models.TopHostsSince(s.DB, sevenDaysAgo, 50)
+		hostRows, err2 = models.TopHostsSince(s.DB, sevenDaysAgo, 50, serverScopeID)
 		if err2 != nil {
 			log.Printf("analytics: TopHostsSince: %v", err2)
 		}
 	} else {
 		var err2 error
-		hostRows, err2 = models.HostStatsForHosts(s.DB, sevenDaysAgo, allowedHosts)
+		hostRows, err2 = models.HostStatsForHosts(s.DB, sevenDaysAgo, allowedHosts, serverScopeID)
 		if err2 != nil {
 			log.Printf("analytics: HostStatsForHosts: %v", err2)
 		}
@@ -468,7 +459,7 @@ func (s *Server) getAnalytics(w http.ResponseWriter, r *http.Request) {
 	var rawBuckets []models.HourlyBucket
 	if !scoped {
 		var err2 error
-		rawBuckets, err2 = models.AccessBuckets(s.DB, twentyFourHoursAgo, now, bucketSec, "")
+		rawBuckets, err2 = models.AccessBuckets(s.DB, twentyFourHoursAgo, now, bucketSec, "", serverScopeID)
 		if err2 != nil {
 			log.Printf("analytics: AccessBuckets(unscoped): %v", err2)
 		}
@@ -477,7 +468,7 @@ func (s *Server) getAnalytics(w http.ResponseWriter, r *http.Request) {
 		// single host string, so loop and merge by hour.
 		merged := make(map[int64]models.HourlyBucket)
 		for _, h := range allowedHosts {
-			bs, _ := models.AccessBuckets(s.DB, twentyFourHoursAgo, now, bucketSec, h)
+			bs, _ := models.AccessBuckets(s.DB, twentyFourHoursAgo, now, bucketSec, h, serverScopeID)
 			for _, b := range bs {
 				key := b.Hour.Unix()
 				m := merged[key]
@@ -496,11 +487,11 @@ func (s *Server) getAnalytics(w http.ResponseWriter, r *http.Request) {
 	// Bandwidth (bytes_out) sparkline — same window and bucket as request sparkline.
 	var bwBuckets []models.BandwidthBucket
 	if !scoped {
-		bwBuckets, _ = models.BandwidthBuckets(s.DB, twentyFourHoursAgo, now, bucketSec, "")
+		bwBuckets, _ = models.BandwidthBuckets(s.DB, twentyFourHoursAgo, now, bucketSec, "", serverScopeID)
 	} else {
 		bwMap := make(map[int64]models.BandwidthBucket)
 		for _, h := range allowedHosts {
-			bs, _ := models.BandwidthBuckets(s.DB, twentyFourHoursAgo, now, bucketSec, h)
+			bs, _ := models.BandwidthBuckets(s.DB, twentyFourHoursAgo, now, bucketSec, h, serverScopeID)
 			for _, b := range bs {
 				key := b.Hour.Unix()
 				m := bwMap[key]
@@ -531,13 +522,13 @@ func (s *Server) getAnalytics(w http.ResponseWriter, r *http.Request) {
 	var statusBuckets models.StatusBuckets
 	if !scoped {
 		var err2 error
-		statusBuckets, err2 = models.StatusBucketsSince(s.DB, sevenDaysAgo, "")
+		statusBuckets, err2 = models.StatusBucketsSince(s.DB, sevenDaysAgo, "", serverScopeID)
 		if err2 != nil {
 			log.Printf("analytics: StatusBucketsSince(unscoped): %v", err2)
 		}
 	} else {
 		for _, h := range allowedHosts {
-			b, err2 := models.StatusBucketsSince(s.DB, sevenDaysAgo, h)
+			b, err2 := models.StatusBucketsSince(s.DB, sevenDaysAgo, h, serverScopeID)
 			if err2 != nil {
 				log.Printf("analytics: StatusBucketsSince(%s): %v", h, err2)
 				continue
@@ -602,8 +593,9 @@ func (s *Server) getAnalyticsHost(w http.ResponseWriter, r *http.Request) {
 	}
 	u := s.currentUser(r)
 	isAdmin := u != nil && u.Role == models.RoleAdmin
+	serverScopeID := s.analyticsServerScope(r)
 	if !isAdmin {
-		allowed, err := s.userAllowedHosts(u)
+		allowed, err := s.scopedHostsForAnalytics(u, serverScopeID)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -640,8 +632,8 @@ func (s *Server) getAnalyticsHost(w http.ResponseWriter, r *http.Request) {
 	prevSince := since.Add(-window) // start of previous period
 	prevTo := since                 // = start of current period
 
-	totals, _ := models.AccessTotalsBetween(s.DB, since, now, host)
-	prevTotals, _ := models.AccessTotalsBetween(s.DB, prevSince, prevTo, host)
+	totals, _ := models.AccessTotalsBetween(s.DB, since, now, host, serverScopeID)
+	prevTotals, _ := models.AccessTotalsBetween(s.DB, prevSince, prevTo, host, serverScopeID)
 
 	var viewsChange, visitorsChange int
 	var viewsUp, visitorsUp bool
@@ -667,34 +659,43 @@ func (s *Server) getAnalyticsHost(w http.ResponseWriter, r *http.Request) {
 	if visitorsChangeAbs < 0 {
 		visitorsChangeAbs = -visitorsChangeAbs
 	}
-	paths, _ := models.TopPaths(s.DB, since, host, 20)
-	clients, _ := models.TopClientIPs(s.DB, since, host, 20)
-	status, _ := models.StatusBucketsSince(s.DB, since, host)
-	rtStats, err2 := models.ResponseTimeSince(s.DB, since, host)
+	paths, _ := models.TopPaths(s.DB, since, host, 20, serverScopeID)
+	clients, _ := models.TopClientIPs(s.DB, since, host, 20, serverScopeID)
+	status, _ := models.StatusBucketsSince(s.DB, since, host, serverScopeID)
+	rtStats, err2 := models.ResponseTimeSince(s.DB, since, host, serverScopeID)
 	if err2 != nil {
 		log.Printf("analytics: ResponseTimeSince(%s): %v", host, err2)
 	}
-	bandwidth, err3 := models.BandwidthSince(s.DB, since, host)
+	bandwidth, err3 := models.BandwidthSince(s.DB, since, host, serverScopeID)
 	if err3 != nil {
 		log.Printf("analytics: BandwidthSince(%s): %v", host, err3)
 	}
-	errorPaths, err4 := models.TopErrorPaths(s.DB, since, host, 15)
+	errorPaths, err4 := models.TopErrorPaths(s.DB, since, host, 15, serverScopeID)
 	if err4 != nil {
 		log.Printf("analytics: TopErrorPaths(%s): %v", host, err4)
 	}
-	browsers, _ := models.TopBrowsers(s.DB, since, host, 8)
+	browsers, _ := models.TopBrowsers(s.DB, since, host, 8, serverScopeID)
 
 	bucketSec := int64(3600) // 1h buckets regardless of window — keeps the
 	if window >= 30*24*time.Hour {
 		bucketSec = 86400 // ...except 30d+ views where hourly would be 720 bars.
 	}
-	rawBuckets, _ := models.AccessBuckets(s.DB, since, now, bucketSec, host)
+	rawBuckets, _ := models.AccessBuckets(s.DB, since, now, bucketSec, host, serverScopeID)
 	buckets := fillBuckets(rawBuckets, since, now, bucketSec)
+	serverScopeName := "All servers"
+	if serverScopeID > 0 {
+		serverScopeName = fmt.Sprintf("Server %d", serverScopeID)
+		if server, _ := models.GetCaddyServer(s.DB, serverScopeID); server != nil {
+			serverScopeName = server.Name
+		}
+	}
 
 	s.render(w, r, "analytics_host.html", map[string]any{
 		"User":              u,
 		"IsAdmin":           isAdmin,
 		"Host":              host,
+		"SelectedServerID":  serverScopeID,
+		"ServerScopeName":   serverScopeName,
 		"Window":            window,
 		"WindowLabel":       formatWindow(window),
 		"Totals":            totals,
@@ -721,7 +722,7 @@ func (s *Server) getAnalyticsHost(w http.ResponseWriter, r *http.Request) {
 // liveVisitorsAcrossHosts counts distinct client IPs on the given host
 // list over the last `window`. Used by the non-admin path of getAnalytics
 // so an IP visiting two owned hosts is counted once, not twice.
-func (s *Server) liveVisitorsAcrossHosts(hosts []string, window time.Duration) int {
+func (s *Server) liveVisitorsAcrossHosts(hosts []string, window time.Duration, serverIDs ...int64) int {
 	if len(hosts) == 0 {
 		return 0
 	}
@@ -736,6 +737,10 @@ func (s *Server) liveVisitorsAcrossHosts(hosts []string, window time.Duration) i
 		args = append(args, h)
 	}
 	q := `SELECT COUNT(DISTINCT client_ip) FROM access_events WHERE ts >= ? AND host IN (` + string(placeholders) + `)`
+	if len(serverIDs) > 0 && serverIDs[0] > 0 {
+		q += ` AND server_id = ?`
+		args = append(args, serverIDs[0])
+	}
 	var n int
 	if err := s.DB.QueryRow(q, args...).Scan(&n); err != nil {
 		return 0
@@ -1005,6 +1010,10 @@ func (s *Server) exportAnalyticsCSV(w http.ResponseWriter, r *http.Request) {
 			days = n
 		}
 	}
+	var serverID int64
+	if raw := strings.TrimSpace(r.URL.Query().Get("server")); raw != "" && raw != "all" && raw != "0" {
+		serverID, _ = strconv.ParseInt(raw, 10, 64)
+	}
 
 	// Non-admins: verify they own the requested host.
 	if !isAdmin && host != "" {
@@ -1031,7 +1040,7 @@ func (s *Server) exportAnalyticsCSV(w http.ResponseWriter, r *http.Request) {
 	}
 
 	since := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
-	rows, err := models.ExportAccessEvents(s.DB, since, host, 50000)
+	rows, err := models.ExportAccessEvents(s.DB, since, host, 50000, serverID)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
 		return
@@ -1045,10 +1054,11 @@ func (s *Server) exportAnalyticsCSV(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s_%dd.csv"`, fname, days))
 
 	cw := csv.NewWriter(w)
-	_ = cw.Write([]string{"timestamp", "host", "path", "method", "status", "client_ip", "user_agent", "duration_ms", "bytes_out"})
+	_ = cw.Write([]string{"timestamp", "server_id", "server_name", "host", "path", "method", "status", "client_ip", "user_agent", "duration_ms", "bytes_out"})
 	for _, e := range rows {
 		_ = cw.Write([]string{
 			e.TS.UTC().Format(time.RFC3339),
+			strconv.FormatInt(e.ServerID, 10), e.ServerName,
 			e.Host, e.Path, e.Method,
 			strconv.Itoa(e.Status),
 			e.ClientIP, e.UserAgent,

--- a/internal/server/caddy_logs.go
+++ b/internal/server/caddy_logs.go
@@ -1,0 +1,306 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/X4Applegate/caddyui/internal/caddy"
+	"github.com/X4Applegate/caddyui/internal/caddylogs"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+const (
+	runtimeLogCaptureTTL   = 15 * time.Minute
+	runtimeLogCleanupRetry = 30 * time.Second
+)
+
+func caddyLogOptions(server models.CaddyServer, cfg analyticsConfig) caddy.AccessLogOptions {
+	return caddy.AccessLogOptions{
+		SoftStart: cfg.SoftStart, DialTimeout: cfg.DialTimeout,
+		ServerID: server.ID, ServerName: server.Name,
+	}
+}
+
+// ReconcileCertificateLogs installs the low-volume TLS lifecycle stream on
+// every managed Caddy. It is safe to call at startup, after Settings changes,
+// and after a server is registered; unrelated/default loggers are preserved.
+func (s *Server) ReconcileCertificateLogs() error {
+	if s.caddyLogHub == nil {
+		return nil
+	}
+	servers, err := models.ListCaddyServers(s.DB)
+	if err != nil {
+		return err
+	}
+	cfg := loadAnalyticsConfig(s.DB)
+	var failures []string
+	for _, server := range servers {
+		if server.Type != models.CaddyServerTypeManaged {
+			continue
+		}
+		client := newCaddyClient(server.AdminURL, server.AdminUsername, server.AdminPassword)
+		if err := client.EnableCertificateLogs(cfg.Target, caddyLogOptions(server, cfg)); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", server.Name, err))
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("certificate log monitoring: %s", strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+// ResetRuntimeLogs removes streams left in Caddy's persisted config by a
+// prior process/browser session. Full runtime capture is deliberately
+// ephemeral; certificate monitoring remains enabled independently.
+func (s *Server) ResetRuntimeLogs() error {
+	servers, err := models.ListCaddyServers(s.DB)
+	if err != nil {
+		return err
+	}
+	var failures []string
+	for _, server := range servers {
+		if server.Type != models.CaddyServerTypeManaged {
+			continue
+		}
+		if err := s.disableRuntimeLogCapture(server); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", server.Name, err))
+			s.runtimeLogMu.Lock()
+			if s.runtimeLogTimers[server.ID] == nil {
+				s.scheduleRuntimeLogDisableLocked(server.ID, runtimeLogCleanupRetry)
+			}
+			s.runtimeLogMu.Unlock()
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("reset runtime log capture: %s", strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+func (s *Server) getServerLogs(w http.ResponseWriter, r *http.Request) {
+	servers, err := models.ListCaddyServers(s.DB)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	managed := servers[:0]
+	for _, server := range servers {
+		if server.Type == models.CaddyServerTypeManaged {
+			managed = append(managed, server)
+		}
+	}
+	selected := s.currentServerID(r)
+	if len(managed) > 0 {
+		found := false
+		for _, server := range managed {
+			if server.ID == selected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			selected = managed[0].ID
+		}
+	}
+	s.render(w, r, "server_logs.html", map[string]any{
+		"User": s.currentUser(r), "Servers": managed,
+		"SelectedServerID": selected, "HubAvailable": s.caddyLogHub != nil,
+		"CaptureTTLMinutes": int(runtimeLogCaptureTTL / time.Minute),
+		"Section":           "server_logs",
+	})
+}
+
+func (s *Server) serverLogStatus(w http.ResponseWriter, _ *http.Request) {
+	if s.caddyLogHub == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"available": false, "captures": []caddylogs.CaptureState{},
+		})
+		return
+	}
+	captures := s.caddyLogHub.Captures()
+	sort.Slice(captures, func(i, j int) bool { return captures[i].ServerID < captures[j].ServerID })
+	writeJSON(w, http.StatusOK, map[string]any{"available": true, "captures": captures})
+}
+
+func (s *Server) enableServerLogs(w http.ResponseWriter, r *http.Request) {
+	if s.caddyLogHub == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "Caddy log ingest is unavailable")
+		return
+	}
+	server, ok := s.runtimeLogServerFromRequest(w, r)
+	if !ok {
+		return
+	}
+	level := strings.ToUpper(strings.TrimSpace(r.FormValue("level")))
+	switch level {
+	case "DEBUG", "INFO", "WARN", "ERROR":
+	default:
+		level = "INFO"
+	}
+	cfg := loadAnalyticsConfig(s.DB)
+	expires := time.Now().UTC().Add(runtimeLogCaptureTTL)
+	if err := s.enableRuntimeLogCapture(*server, cfg, level, expires); err != nil {
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"enabled": true, "expires_at": expires})
+}
+
+func (s *Server) disableServerLogs(w http.ResponseWriter, r *http.Request) {
+	server, ok := s.runtimeLogServerFromRequest(w, r)
+	if !ok {
+		return
+	}
+	if err := s.disableRuntimeLogCapture(*server); err != nil {
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"enabled": false})
+}
+
+func (s *Server) runtimeLogServerFromRequest(w http.ResponseWriter, r *http.Request) (*models.CaddyServer, bool) {
+	if err := r.ParseForm(); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid form")
+		return nil, false
+	}
+	id, err := strconv.ParseInt(strings.TrimSpace(r.FormValue("server_id")), 10, 64)
+	if err != nil || id <= 0 {
+		writeJSONError(w, http.StatusBadRequest, "select a Caddy server")
+		return nil, false
+	}
+	server, err := models.GetCaddyServer(s.DB, id)
+	if err != nil || server == nil {
+		writeJSONError(w, http.StatusNotFound, "Caddy server not found")
+		return nil, false
+	}
+	if server.Type != models.CaddyServerTypeManaged {
+		writeJSONError(w, http.StatusBadRequest, "external servers cannot be reconfigured")
+		return nil, false
+	}
+	return server, true
+}
+
+// enableRuntimeLogCapture serializes Caddy config updates with timer expiry so
+// an older capture's timer can never disable a newer capture on the same node.
+func (s *Server) enableRuntimeLogCapture(server models.CaddyServer, cfg analyticsConfig, level string, expires time.Time) error {
+	s.runtimeLogMu.Lock()
+	defer s.runtimeLogMu.Unlock()
+
+	client := newCaddyClient(server.AdminURL, server.AdminUsername, server.AdminPassword)
+	if err := client.EnableRuntimeLogs(cfg.Target, level, caddyLogOptions(server, cfg)); err != nil {
+		return err
+	}
+
+	serverID := server.ID
+	if timer := s.runtimeLogTimers[serverID]; timer != nil {
+		timer.Stop()
+	}
+	if s.caddyLogHub != nil {
+		s.caddyLogHub.SetCapture(caddylogs.CaptureState{
+			ServerID: serverID, ServerName: server.Name, Level: level, ExpiresAt: expires,
+		})
+	}
+	s.scheduleRuntimeLogDisableLocked(serverID, time.Until(expires))
+	return nil
+}
+
+// scheduleRuntimeLogDisableLocked installs one cleanup attempt for a node.
+// The caller holds runtimeLogMu. A failed remote DELETE is retried rather than
+// dropping local state and leaving Caddy's temporary network logger behind.
+func (s *Server) scheduleRuntimeLogDisableLocked(serverID int64, delay time.Duration) {
+	if s.runtimeLogTimers == nil {
+		s.runtimeLogTimers = map[int64]*time.Timer{}
+	}
+	if timer := s.runtimeLogTimers[serverID]; timer != nil {
+		timer.Stop()
+	}
+	var timer *time.Timer
+	timer = time.AfterFunc(delay, func() {
+		s.runtimeLogMu.Lock()
+		defer s.runtimeLogMu.Unlock()
+		if s.runtimeLogTimers[serverID] != timer {
+			return
+		}
+		server, err := models.GetCaddyServer(s.DB, serverID)
+		if err == nil && server != nil {
+			if err := s.disableRuntimeLogCaptureLocked(*server); err != nil {
+				log.Printf("server logs: automatic disable for %s failed: %v", server.Name, err)
+				s.scheduleRuntimeLogDisableLocked(serverID, runtimeLogCleanupRetry)
+			}
+		} else {
+			s.clearRuntimeLogCaptureLocked(serverID)
+		}
+	})
+	s.runtimeLogTimers[serverID] = timer
+}
+
+func (s *Server) disableRuntimeLogCapture(server models.CaddyServer) error {
+	s.runtimeLogMu.Lock()
+	defer s.runtimeLogMu.Unlock()
+	return s.disableRuntimeLogCaptureLocked(server)
+}
+
+func (s *Server) disableRuntimeLogCaptureLocked(server models.CaddyServer) error {
+	client := newCaddyClient(server.AdminURL, server.AdminUsername, server.AdminPassword)
+	if err := client.DisableRuntimeLogs(); err != nil {
+		return err
+	}
+	s.clearRuntimeLogCaptureLocked(server.ID)
+	return nil
+}
+
+func (s *Server) clearRuntimeLogCaptureLocked(serverID int64) {
+	if timer := s.runtimeLogTimers[serverID]; timer != nil {
+		timer.Stop()
+	}
+	delete(s.runtimeLogTimers, serverID)
+	if s.caddyLogHub != nil {
+		s.caddyLogHub.ClearCapture(serverID)
+	}
+}
+
+func (s *Server) serverLogStream(w http.ResponseWriter, r *http.Request) {
+	if s.caddyLogHub == nil {
+		http.Error(w, "Caddy log ingest is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.Header().Set("Connection", "keep-alive")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "SSE not supported", http.StatusInternalServerError)
+		return
+	}
+	cursor, _ := strconv.ParseUint(strings.TrimSpace(r.URL.Query().Get("since")), 10, 64)
+	serverID, _ := strconv.ParseInt(strings.TrimSpace(r.URL.Query().Get("server")), 10, 64)
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			entries := s.caddyLogHub.Since(cursor, serverID, 200)
+			for _, entry := range entries {
+				if entry.ID > cursor {
+					cursor = entry.ID
+				}
+			}
+			if len(entries) == 0 {
+				_, _ = fmt.Fprint(w, ": ping\n\n")
+			} else {
+				data, _ := json.Marshal(entries)
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/internal/server/caddy_logs_test.go
+++ b/internal/server/caddy_logs_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/X4Applegate/caddyui/internal/caddylogs"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+func TestDisableRuntimeLogCaptureRetainsStateAfterRemoteFailure(t *testing.T) {
+	admin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+	}))
+	defer admin.Close()
+
+	hub := caddylogs.New(nil)
+	hub.SetCapture(caddylogs.CaptureState{
+		ServerID: 4, ServerName: "edge", Level: "INFO", ExpiresAt: time.Now().Add(time.Minute),
+	})
+	timer := time.NewTimer(time.Hour)
+	t.Cleanup(func() { timer.Stop() })
+	s := &Server{
+		caddyLogHub:      hub,
+		runtimeLogTimers: map[int64]*time.Timer{4: timer},
+	}
+	server := models.CaddyServer{ID: 4, Name: "edge", AdminURL: admin.URL}
+	if err := s.disableRuntimeLogCapture(server); err == nil {
+		t.Fatal("disable returned nil after the Caddy admin API rejected cleanup")
+	}
+	if _, active := hub.Capture(server.ID); !active {
+		t.Fatal("capture state was cleared even though the remote logger is still installed")
+	}
+	if s.runtimeLogTimers[server.ID] != timer {
+		t.Fatal("cleanup timer was discarded after a failed remote disable")
+	}
+}
+
+func TestDisableRuntimeLogCaptureClearsStateAfterSuccess(t *testing.T) {
+	admin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer admin.Close()
+
+	hub := caddylogs.New(nil)
+	hub.SetCapture(caddylogs.CaptureState{ServerID: 8, ServerName: "edge"})
+	timer := time.NewTimer(time.Hour)
+	s := &Server{
+		caddyLogHub:      hub,
+		runtimeLogTimers: map[int64]*time.Timer{8: timer},
+	}
+	server := models.CaddyServer{ID: 8, Name: "edge", AdminURL: admin.URL}
+	if err := s.disableRuntimeLogCapture(server); err != nil {
+		t.Fatal(err)
+	}
+	if _, active := hub.Capture(server.ID); active {
+		t.Fatal("capture state remains after successful remote cleanup")
+	}
+	if _, found := s.runtimeLogTimers[server.ID]; found {
+		t.Fatal("cleanup timer remains after successful remote cleanup")
+	}
+}

--- a/internal/server/caddy_servers.go
+++ b/internal/server/caddy_servers.go
@@ -147,6 +147,14 @@ func (s *Server) createServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r), "server_create", fmt.Sprintf("server:%d", id), c.Name, true)
+	go func() {
+		if err := s.ReconcileAnalyticsAccessLogs(); err != nil {
+			log.Printf("server create: analytics log monitoring: %v", err)
+		}
+		if err := s.ReconcileCertificateLogs(); err != nil {
+			log.Printf("server create: certificate log monitoring: %v", err)
+		}
+	}()
 	http.Redirect(w, r, "/servers", http.StatusSeeOther)
 }
 
@@ -171,6 +179,7 @@ func (s *Server) updateServer(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
+	previous := *existing
 	_ = r.ParseForm()
 	existing.Name = strings.TrimSpace(r.FormValue("name"))
 	existing.AdminURL = strings.TrimSpace(r.FormValue("admin_url"))
@@ -202,11 +211,27 @@ func (s *Server) updateServer(w http.ResponseWriter, r *http.Request) {
 		renderErr("Admin URL must start with http://, https://, or unix:///")
 		return
 	}
+	if s.caddyLogHub != nil {
+		if _, active := s.caddyLogHub.Capture(id); active {
+			if err := s.disableRuntimeLogCapture(previous); err != nil {
+				renderErr("Stop full server-log capture before changing this server: " + err.Error())
+				return
+			}
+		}
+	}
 	if err := models.UpdateCaddyServer(s.DB, existing); err != nil {
 		renderErr(err.Error())
 		return
 	}
 	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r), "server_update", fmt.Sprintf("server:%d", id), existing.Name, true)
+	go func() {
+		if err := s.ReconcileAnalyticsAccessLogs(); err != nil {
+			log.Printf("server update: analytics log monitoring: %v", err)
+		}
+		if err := s.ReconcileCertificateLogs(); err != nil {
+			log.Printf("server update: certificate log monitoring: %v", err)
+		}
+	}()
 	http.Redirect(w, r, "/servers", http.StatusSeeOther)
 }
 
@@ -221,6 +246,14 @@ func (s *Server) deleteServer(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
+	}
+	if s.caddyLogHub != nil {
+		if _, active := s.caddyLogHub.Capture(id); active {
+			if err := s.disableRuntimeLogCapture(*c); err != nil {
+				http.Error(w, "stop full server-log capture before deleting this server: "+err.Error(), http.StatusBadGateway)
+				return
+			}
+		}
 	}
 	if err := models.DeleteCaddyServer(s.DB, id); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/X4Applegate/caddyui/internal/analytics"
 	"github.com/X4Applegate/caddyui/internal/auth"
 	"github.com/X4Applegate/caddyui/internal/caddy"
+	"github.com/X4Applegate/caddyui/internal/caddylogs"
 	appdb "github.com/X4Applegate/caddyui/internal/db"
 	"github.com/X4Applegate/caddyui/internal/dns"
 	"github.com/X4Applegate/caddyui/internal/models"
@@ -91,6 +92,13 @@ type Server struct {
 	// DB ref that has to exist before we hand it over.
 	analyticsIngest *analytics.Ingest
 
+	// Runtime Caddy logs share the analytics NDJSON socket but stay in a
+	// bounded in-memory hub. Only the latest certificate lifecycle projection
+	// is persisted. Temporary full-log captures are guarded by expiry timers.
+	caddyLogHub      *caddylogs.Hub
+	runtimeLogMu     sync.Mutex
+	runtimeLogTimers map[int64]*time.Timer
+
 	// v2.9.2: HTTP client used by the background per-proxy-host health checker.
 	healthClient *http.Client
 }
@@ -106,6 +114,10 @@ func (s *Server) SetAnalyticsIngest(ing *analytics.Ingest) {
 	s.analyticsIngest = ing
 }
 
+func (s *Server) SetCaddyLogHub(hub *caddylogs.Hub) {
+	s.caddyLogHub = hub
+}
+
 func New(db *sql.DB, caddyClient *caddy.Client, templates fs.FS, static fs.FS, caddyfilePath string, version string, dbPath string) (*Server, error) {
 	tpl, err := parseTemplates(templates)
 	if err != nil {
@@ -117,15 +129,16 @@ func New(db *sql.DB, caddyClient *caddy.Client, templates fs.FS, static fs.FS, c
 	loc := loadActiveLocation(db)
 	log.Printf("timezone: rendering timestamps in %s", loc)
 	s := &Server{
-		DB:             db,
-		Caddy:          caddyClient,
-		Templates:      tpl,
-		Static:         static,
-		CaddyfilePath:  caddyfilePath,
-		Version:        version,
-		DBPath:         dbPath,
-		healthFailures: map[int64]int{},
-		appHealth:      map[int64]appHealthEntry{},
+		DB:               db,
+		Caddy:            caddyClient,
+		Templates:        tpl,
+		Static:           static,
+		CaddyfilePath:    caddyfilePath,
+		Version:          version,
+		DBPath:           dbPath,
+		healthFailures:   map[int64]int{},
+		appHealth:        map[int64]appHealthEntry{},
+		runtimeLogTimers: map[int64]*time.Timer{},
 	}
 	// Initialize health check HTTP client (short timeouts, no redirect following).
 	s.healthClient = &http.Client{
@@ -782,6 +795,11 @@ func (s *Server) Routes() http.Handler {
 			r.Post("/servers/{id}", s.updateServer)
 			r.Post("/servers/{id}/sync-from-current", s.syncServerFromCurrent)
 			r.Post("/servers/{id}/delete", s.deleteServer)
+			r.Get("/server-logs", s.getServerLogs)
+			r.Get("/api/server-logs/status", s.serverLogStatus)
+			r.Get("/api/server-logs/stream", s.serverLogStream)
+			r.Post("/api/server-logs/enable", s.enableServerLogs)
+			r.Post("/api/server-logs/disable", s.disableServerLogs)
 			r.Post("/dashboard/recommendations/unused-certificates/dismiss", s.dismissUnusedCertificateRecommendation)
 
 			// v2.7.2: create/edit moved up to the requireWrite group so
@@ -3867,12 +3885,39 @@ type certView struct {
 	DaysLeft  int  // positive = days until expiry; negative = already expired
 	CanEdit   bool // per-row ownership (see above)
 	IsUnused  bool // custom PEM/path certificate with no resource reference
+	Lifecycle *models.CertificateLifecycleStatus
 }
 
 type autoDomainView struct {
 	Domain          string
 	CertificateName string
 	UsesWildcard    bool
+	Lifecycle       *models.CertificateLifecycleStatus
+}
+
+func certificateLifecycleForDomains(states []models.CertificateLifecycleStatus, domains []string) *models.CertificateLifecycleStatus {
+	priority := map[string]int{"active": 1, "obtaining": 2, "renewing": 3, "retrying": 4, "error": 5, "revoked": 6}
+	var best *models.CertificateLifecycleStatus
+	for i := range states {
+		identifier := models.NormalizeHostname(states[i].Identifier)
+		matched := false
+		for _, domain := range domains {
+			domain = models.NormalizeHostname(domain)
+			if identifier == domain || managedCertificateCovers(identifier, domain) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		if best == nil || priority[states[i].Phase] > priority[best.Phase] ||
+			(priority[states[i].Phase] == priority[best.Phase] && states[i].UpdatedAt.After(best.UpdatedAt)) {
+			candidate := states[i]
+			best = &candidate
+		}
+	}
+	return best
 }
 
 // dnsProviderViewData builds the template data describing which DNS
@@ -6826,6 +6871,7 @@ func (s *Server) listCertificates(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	lifecycleStates, _ := models.ListCertificateLifecycle(s.DB, sid)
 	// Usage must be calculated against the complete environment, not only
 	// resources visible to the current user. Otherwise a global certificate
 	// used by another tenant could be incorrectly labeled as unused.
@@ -6849,6 +6895,9 @@ func (s *Server) listCertificates(w http.ResponseWriter, r *http.Request) {
 			Certificate: c,
 			CanEdit:     canEdit,
 			IsUnused:    isUnusedCustomCertificate(c, referencedCerts),
+		}
+		if c.Source == models.CertSourceManaged {
+			view.Lifecycle = certificateLifecycleForDomains(lifecycleStates, c.DomainList())
 		}
 		if view.IsUnused {
 			unusedCount++
@@ -6886,10 +6935,13 @@ func (s *Server) listCertificates(w http.ResponseWriter, r *http.Request) {
 			Domain:          domain,
 			CertificateName: "Direct certificate",
 		}
+		statusDomains := []string{domain}
 		if cert := managedWildcardForHost(certs, domain); cert != nil {
 			view.CertificateName = cert.Name
 			view.UsesWildcard = true
+			statusDomains = cert.DomainList()
 		}
+		view.Lifecycle = certificateLifecycleForDomains(lifecycleStates, statusDomains)
 		autoDomains = append(autoDomains, view)
 	}
 	for _, h := range allHosts {
@@ -7043,15 +7095,18 @@ func (s *Server) getCertificateInspect(w http.ResponseWriter, r *http.Request) {
 }
 
 type managedCertificateServerStatus struct {
-	ServerID   int64      `json:"server_id"`
-	ServerName string     `json:"server_name"`
-	Deployed   bool       `json:"deployed"`
-	Status     string     `json:"status"`
-	ProbeName  string     `json:"probe_name,omitempty"`
-	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
-	DaysLeft   int        `json:"days_left,omitempty"`
-	Issuer     string     `json:"issuer,omitempty"`
-	Error      string     `json:"error,omitempty"`
+	ServerID         int64      `json:"server_id"`
+	ServerName       string     `json:"server_name"`
+	Deployed         bool       `json:"deployed"`
+	Status           string     `json:"status"`
+	ProbeName        string     `json:"probe_name,omitempty"`
+	ExpiresAt        *time.Time `json:"expires_at,omitempty"`
+	DaysLeft         int        `json:"days_left,omitempty"`
+	Issuer           string     `json:"issuer,omitempty"`
+	Error            string     `json:"error,omitempty"`
+	LifecyclePhase   string     `json:"lifecycle_phase,omitempty"`
+	LifecycleMessage string     `json:"lifecycle_message,omitempty"`
+	LifecycleAt      *time.Time `json:"lifecycle_at,omitempty"`
 }
 
 func managedCertificateProbeName(cert models.Certificate) string {
@@ -7186,6 +7241,30 @@ func (s *Server) getManagedCertificateStatus(w http.ResponseWriter, r *http.Requ
 		}(i, server)
 	}
 	wg.Wait()
+	states, _ := models.ListCertificateLifecycle(s.DB, 0)
+	for i := range results {
+		serverStates := make([]models.CertificateLifecycleStatus, 0)
+		for _, state := range states {
+			if state.ServerID == results[i].ServerID {
+				serverStates = append(serverStates, state)
+			}
+		}
+		state := certificateLifecycleForDomains(serverStates, cert.DomainList())
+		if state == nil {
+			continue
+		}
+		results[i].LifecyclePhase = state.Phase
+		results[i].LifecycleMessage = state.Message
+		updated := state.UpdatedAt
+		results[i].LifecycleAt = &updated
+		switch state.Phase {
+		case "obtaining", "renewing", "retrying", "error", "revoked":
+			results[i].Status = state.Phase
+			if state.Error != "" {
+				results[i].Error = state.Error
+			}
+		}
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"servers": results})
 }
 
@@ -14468,6 +14547,12 @@ func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 	if err := s.applyAnalyticsToggle(loadAnalyticsConfig(s.DB)); err != nil {
 		log.Printf("settings: analytics toggle: %v", err)
 	}
+	// The certificate monitor shares the analytics ingest target even when
+	// visitor analytics itself is disabled. Refresh it after target/timeout
+	// changes so lifecycle events keep flowing to the right listener.
+	if err := s.ReconcileCertificateLogs(); err != nil {
+		log.Printf("settings: certificate log monitoring: %v", err)
+	}
 
 	// v2.4.0: per-server public IP update. The settings form submits one
 	// server_ip_<id> field per Caddy server. For each one that changed,
@@ -14719,15 +14804,24 @@ func (s *Server) revokeAPIToken(w http.ResponseWriter, r *http.Request) {
 // getLiveTraffic renders the live traffic feed page.
 func (s *Server) getLiveTraffic(w http.ResponseWriter, r *http.Request) {
 	u := s.currentUser(r)
+	serverID := s.currentServerID(r)
+	if r.URL.Query().Has("server") {
+		raw := strings.TrimSpace(r.URL.Query().Get("server"))
+		if raw == "" || raw == "0" || raw == "all" {
+			serverID = 0
+		} else if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed > 0 {
+			serverID = parsed
+		}
+	}
 	// Seed with last 50 events for initial load.
-	events, err := models.RecentAccessEvents(s.DB, 0, 50)
+	events, err := models.RecentAccessEvents(s.DB, 0, 50, serverID)
 	if err != nil {
 		log.Printf("live-traffic: query: %v", err)
 	}
 	s.render(w, r, "live_traffic.html", map[string]any{
-		"User":    u,
-		"Events":  events,
-		"Section": "live_traffic",
+		"User": u, "Events": events,
+		"AllServers":       func() []models.CaddyServer { servers, _ := models.ListCaddyServers(s.DB); return servers }(),
+		"SelectedServerID": serverID, "Section": "live_traffic",
 	})
 }
 
@@ -14752,6 +14846,10 @@ func (s *Server) liveTrafficStream(w http.ResponseWriter, r *http.Request) {
 			cursor = n
 		}
 	}
+	var serverID int64
+	if raw := strings.TrimSpace(r.URL.Query().Get("server")); raw != "" && raw != "0" && raw != "all" {
+		serverID, _ = strconv.ParseInt(raw, 10, 64)
+	}
 
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
@@ -14761,7 +14859,7 @@ func (s *Server) liveTrafficStream(w http.ResponseWriter, r *http.Request) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			events, err := models.RecentAccessEvents(s.DB, cursor, 100)
+			events, err := models.RecentAccessEvents(s.DB, cursor, 100, serverID)
 			if err != nil {
 				log.Printf("live-traffic SSE: %v", err)
 				continue
@@ -14785,6 +14883,8 @@ func (s *Server) liveTrafficStream(w http.ResponseWriter, r *http.Request) {
 			type wireEvent struct {
 				ID         int64  `json:"id"`
 				TS         string `json:"ts"`
+				ServerID   int64  `json:"server_id"`
+				ServerName string `json:"server_name"`
 				Host       string `json:"host"`
 				Path       string `json:"path"`
 				Method     string `json:"method"`
@@ -14798,6 +14898,8 @@ func (s *Server) liveTrafficStream(w http.ResponseWriter, r *http.Request) {
 				wire[i] = wireEvent{
 					ID:         e.ID,
 					TS:         e.TS.Format(time.RFC3339),
+					ServerID:   e.ServerID,
+					ServerName: e.ServerName,
 					Host:       e.Host,
 					Path:       e.Path,
 					Method:     e.Method,

--- a/web/templates/analytics.html
+++ b/web/templates/analytics.html
@@ -5,7 +5,7 @@
     <h1 class="text-2xl font-semibold tracking-tight text-ink-900">Analytics</h1>
     <p class="text-sm text-ink-500 mt-1 max-w-2xl">
       Privacy-light visitor stats built from Caddy's access logs.
-      {{if .IsAdmin}}{{if eq .SelectedServerID 0}}You're seeing every host this fleet routes.{{else}}You're seeing hosts routed by the selected server.{{end}}
+      {{if .IsAdmin}}{{if eq .SelectedServerID 0}}You're seeing events handled across the fleet.{{else}}You're seeing requests actually handled by the selected node.{{end}}
       {{else}}You're seeing the hosts you own.{{end}}
     </p>
   </div>
@@ -29,7 +29,7 @@
       {{end}}
     </select>
     {{end}}
-    <a href="/analytics/export.csv?days=7" download
+    <a href="/analytics/export.csv?days=7&amp;server={{if eq .SelectedServerID 0}}all{{else}}{{.SelectedServerID}}{{end}}" download
        class="inline-flex items-center gap-1.5 text-sm text-ink-600 hover:text-ink-800 border border-ink-200 hover:border-ink-300 px-3 py-1.5 rounded-lg transition">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
@@ -155,7 +155,7 @@
     </thead>
     <tbody>
       {{range .Hosts}}
-      <tr class="border-t border-ink-100 hover:bg-ink-50/60 transition cursor-pointer" onclick="window.location='/analytics/{{.Host}}'">
+      <tr class="border-t border-ink-100 hover:bg-ink-50/60 transition cursor-pointer" data-href="/analytics/{{urlquery .Host}}?server={{if eq $.SelectedServerID 0}}all{{else}}{{$.SelectedServerID}}{{end}}" onclick="window.location=this.dataset.href">
         <td class="px-5 py-3 text-ink-800 font-medium">{{if .Host}}{{.Host}}{{else}}<span class="text-ink-400 italic">—</span>{{end}}</td>
         <td class="px-5 py-3 text-ink-700 font-mono">{{.Visitors}}</td>
         <td class="px-5 py-3 text-ink-700 font-mono">{{.Views}}</td>

--- a/web/templates/analytics_host.html
+++ b/web/templates/analytics_host.html
@@ -1,7 +1,7 @@
 {{define "title"}}{{.Host}} · Analytics · CaddyUI{{end}}
 {{define "content"}}
 <div class="flex items-center gap-2 text-xs text-ink-500 mb-2">
-  <a href="/analytics" class="hover:text-ink-700 inline-flex items-center gap-1">
+  <a href="/analytics?server={{if eq .SelectedServerID 0}}all{{else}}{{.SelectedServerID}}{{end}}" class="hover:text-ink-700 inline-flex items-center gap-1">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5"><polyline points="15 18 9 12 15 6"/></svg>
     All hosts
   </a>
@@ -11,7 +11,7 @@
   <div class="min-w-0">
     <h1 class="text-2xl font-semibold tracking-tight text-ink-900 truncate">{{.Host}}</h1>
     <p class="text-sm text-ink-500 mt-1">
-      {{.WindowLabel}} · {{.Totals.Visitors}} visitors · {{.Totals.Views}} views
+      {{.WindowLabel}} · {{.Totals.Visitors}} visitors · {{.Totals.Views}} views · handled by {{.ServerScopeName}}
     </p>
   </div>
   {{/* Window selector — keeps the query-string approach honest; server only
@@ -19,11 +19,11 @@
   <div class="flex items-center gap-2 flex-wrap">
     <div class="inline-flex rounded-lg border border-ink-200 bg-white p-0.5 text-xs shadow-card">
       {{$cur := .WindowLabel}}
-      <a href="/analytics/{{.Host}}?window=1d" class="px-3 py-1.5 rounded-md transition {{if eq $cur "last 24 hours"}}bg-brand-50 text-brand-700 font-medium{{else}}text-ink-600 hover:bg-ink-50{{end}}">24 hours</a>
-      <a href="/analytics/{{.Host}}?window=7d" class="px-3 py-1.5 rounded-md transition {{if eq $cur "last 7 days"}}bg-brand-50 text-brand-700 font-medium{{else}}text-ink-600 hover:bg-ink-50{{end}}">7 days</a>
-      <a href="/analytics/{{.Host}}?window=30d" class="px-3 py-1.5 rounded-md transition {{if eq $cur "last 30 days"}}bg-brand-50 text-brand-700 font-medium{{else}}text-ink-600 hover:bg-ink-50{{end}}">30 days</a>
+      <a href="/analytics/{{urlquery .Host}}?window=1d&amp;server={{if eq .SelectedServerID 0}}all{{else}}{{.SelectedServerID}}{{end}}" class="px-3 py-1.5 rounded-md transition {{if eq $cur "last 24 hours"}}bg-brand-50 text-brand-700 font-medium{{else}}text-ink-600 hover:bg-ink-50{{end}}">24 hours</a>
+      <a href="/analytics/{{urlquery .Host}}?window=7d&amp;server={{if eq .SelectedServerID 0}}all{{else}}{{.SelectedServerID}}{{end}}" class="px-3 py-1.5 rounded-md transition {{if eq $cur "last 7 days"}}bg-brand-50 text-brand-700 font-medium{{else}}text-ink-600 hover:bg-ink-50{{end}}">7 days</a>
+      <a href="/analytics/{{urlquery .Host}}?window=30d&amp;server={{if eq .SelectedServerID 0}}all{{else}}{{.SelectedServerID}}{{end}}" class="px-3 py-1.5 rounded-md transition {{if eq $cur "last 30 days"}}bg-brand-50 text-brand-700 font-medium{{else}}text-ink-600 hover:bg-ink-50{{end}}">30 days</a>
     </div>
-    <a href="/analytics/export.csv?host={{.Host}}&days=7" download
+    <a href="/analytics/export.csv?host={{urlquery .Host}}&amp;days=7&amp;server={{if eq .SelectedServerID 0}}all{{else}}{{.SelectedServerID}}{{end}}" download
        class="inline-flex items-center gap-1.5 text-sm text-ink-600 hover:text-ink-800 border border-ink-200 hover:border-ink-300 px-3 py-1.5 rounded-lg transition">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>

--- a/web/templates/certificate_form.html
+++ b/web/templates/certificate_form.html
@@ -161,6 +161,11 @@ function setCertSource(source) {
   var loading = document.getElementById('managed-status-loading');
   var refresh = document.getElementById('managed-status-refresh');
   function labelFor(row) {
+    if (row.status === 'obtaining') return 'Obtaining…';
+    if (row.status === 'renewing') return 'Renewing…';
+    if (row.status === 'retrying') return 'Retry scheduled';
+    if (row.status === 'error') return 'Issuance error';
+    if (row.status === 'revoked') return 'Revoked';
     if (row.status === 'healthy') return row.days_left + ' days left';
     if (row.status === 'expiring') return 'Expires in ' + row.days_left + ' days';
     if (row.status === 'expired') return 'Expired';
@@ -172,7 +177,9 @@ function setCertSource(source) {
   function colorFor(status) {
     if (status === 'healthy') return 'bg-green-50 text-green-700';
     if (status === 'expiring') return 'bg-amber-50 text-amber-700';
-    if (status === 'expired' || status === 'mismatch') return 'bg-red-50 text-red-700';
+    if (status === 'obtaining' || status === 'renewing') return 'bg-sky-50 text-sky-700';
+    if (status === 'retrying') return 'bg-amber-50 text-amber-700';
+    if (status === 'expired' || status === 'mismatch' || status === 'error' || status === 'revoked') return 'bg-red-50 text-red-700';
     return 'bg-ink-100 text-ink-600';
   }
   function render(rows) {
@@ -187,10 +194,12 @@ function setCertSource(source) {
       left.appendChild(name);
       var detail = document.createElement('div');
       detail.className = 'text-xs text-ink-400 mt-0.5';
-      if (row.expires_at) {
-        detail.textContent = 'Expires ' + new Date(row.expires_at).toLocaleString() + (row.issuer ? ' · ' + row.issuer : '');
-      } else if (row.error) {
+      if (row.error) {
         detail.textContent = row.error;
+      } else if (row.lifecycle_message) {
+        detail.textContent = row.lifecycle_message + (row.lifecycle_at ? ' · ' + new Date(row.lifecycle_at).toLocaleString() : '');
+      } else if (row.expires_at) {
+        detail.textContent = 'Expires ' + new Date(row.expires_at).toLocaleString() + (row.issuer ? ' · ' + row.issuer : '');
       } else if (row.probe_name) {
         detail.textContent = 'Probe SNI: ' + row.probe_name;
       }

--- a/web/templates/certificates.html
+++ b/web/templates/certificates.html
@@ -76,7 +76,13 @@
           <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700 shrink-0">{{.DaysLeft}}d</span>
         {{end}}
       {{else if eq .Source "managed"}}
-        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700 shrink-0">Auto-renewed</span>
+        {{if .Lifecycle}}
+          {{if eq .Lifecycle.Phase "active"}}<span class="ui-status ui-status--success shrink-0" title="{{.Lifecycle.Message}}">Issued</span>
+          {{else if eq .Lifecycle.Phase "obtaining"}}<span class="ui-status ui-status--info shrink-0" title="{{.Lifecycle.Message}}">Obtaining…</span>
+          {{else if eq .Lifecycle.Phase "renewing"}}<span class="ui-status ui-status--info shrink-0" title="{{.Lifecycle.Message}}">Renewing…</span>
+          {{else if eq .Lifecycle.Phase "retrying"}}<span class="ui-status ui-status--warning shrink-0" title="{{if .Lifecycle.Error}}{{.Lifecycle.Error}}{{else}}{{.Lifecycle.Message}}{{end}}">Retry scheduled</span>
+          {{else}}<span class="ui-status ui-status--danger shrink-0" title="{{if .Lifecycle.Error}}{{.Lifecycle.Error}}{{else}}{{.Lifecycle.Message}}{{end}}">{{if eq .Lifecycle.Phase "revoked"}}Revoked{{else}}Issuance error{{end}}</span>{{end}}
+        {{else}}<span class="ui-status ui-status--neutral shrink-0" title="No certificate lifecycle event has been received from this server yet">Awaiting event</span>{{end}}
       {{end}}
     </div>
     {{/* v2.15.0: expiry progress bar — JS sets width via data-expiry-bar */}}
@@ -224,7 +230,14 @@
               <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700" title="{{fmtIn .ExpiresAt "Jan 2, 2006"}}">{{.DaysLeft}}d left</span>
             {{end}}
           {{else if eq .Source "managed"}}
-            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700" title="Caddy renews this certificate automatically">Auto-renewed</span>
+            {{if .Lifecycle}}
+              {{if eq .Lifecycle.Phase "active"}}<span class="ui-status ui-status--success" title="{{.Lifecycle.Message}}">Issued</span>
+              {{else if eq .Lifecycle.Phase "obtaining"}}<span class="ui-status ui-status--info" title="{{.Lifecycle.Message}}">Obtaining…</span>
+              {{else if eq .Lifecycle.Phase "renewing"}}<span class="ui-status ui-status--info" title="{{.Lifecycle.Message}}">Renewing…</span>
+              {{else if eq .Lifecycle.Phase "retrying"}}<span class="ui-status ui-status--warning" title="{{if .Lifecycle.Error}}{{.Lifecycle.Error}}{{else}}{{.Lifecycle.Message}}{{end}}">Retry scheduled</span>
+              {{else}}<span class="ui-status ui-status--danger" title="{{if .Lifecycle.Error}}{{.Lifecycle.Error}}{{else}}{{.Lifecycle.Message}}{{end}}">{{if eq .Lifecycle.Phase "revoked"}}Revoked{{else}}Issuance error{{end}}</span>{{end}}
+              <div class="text-[10px] text-ink-400 mt-1">{{fmtRel .Lifecycle.UpdatedAt}}</div>
+            {{else}}<span class="ui-status ui-status--neutral" title="No certificate lifecycle event has been received from this server yet">Awaiting event</span>{{end}}
           {{else}}
             <span class="text-ink-400 text-xs italic">—</span>
           {{end}}
@@ -310,9 +323,14 @@
             {{end}}
           </td>
           <td class="px-5 py-3">
-            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700">
-              <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>Caddy / ACME
-            </span>
+            {{if .Lifecycle}}
+              {{if eq .Lifecycle.Phase "active"}}<span class="ui-status ui-status--success" title="{{.Lifecycle.Message}}">Issued</span>
+              {{else if eq .Lifecycle.Phase "obtaining"}}<span class="ui-status ui-status--info" title="{{.Lifecycle.Message}}">Obtaining…</span>
+              {{else if eq .Lifecycle.Phase "renewing"}}<span class="ui-status ui-status--info" title="{{.Lifecycle.Message}}">Renewing…</span>
+              {{else if eq .Lifecycle.Phase "retrying"}}<span class="ui-status ui-status--warning" title="{{if .Lifecycle.Error}}{{.Lifecycle.Error}}{{else}}{{.Lifecycle.Message}}{{end}}">Retry scheduled</span>
+              {{else}}<span class="ui-status ui-status--danger" title="{{if .Lifecycle.Error}}{{.Lifecycle.Error}}{{else}}{{.Lifecycle.Message}}{{end}}">{{if eq .Lifecycle.Phase "revoked"}}Revoked{{else}}Issuance error{{end}}</span>{{end}}
+              <div class="text-[10px] text-ink-400 mt-1">{{fmtRel .Lifecycle.UpdatedAt}}</div>
+            {{else}}<span class="ui-status ui-status--neutral">Awaiting event</span>{{end}}
           </td>
         </tr>
         {{end}}
@@ -327,9 +345,13 @@
             {{if .UsesWildcard}}Wildcard: {{.CertificateName}}{{else}}Direct certificate{{end}}
           </div>
         </div>
-        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700 shrink-0">
-          <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>ACME
-        </span>
+        {{if .Lifecycle}}
+          {{if eq .Lifecycle.Phase "active"}}<span class="ui-status ui-status--success shrink-0">Issued</span>
+          {{else if eq .Lifecycle.Phase "obtaining"}}<span class="ui-status ui-status--info shrink-0">Obtaining…</span>
+          {{else if eq .Lifecycle.Phase "renewing"}}<span class="ui-status ui-status--info shrink-0">Renewing…</span>
+          {{else if eq .Lifecycle.Phase "retrying"}}<span class="ui-status ui-status--warning shrink-0">Retry scheduled</span>
+          {{else}}<span class="ui-status ui-status--danger shrink-0">{{if eq .Lifecycle.Phase "revoked"}}Revoked{{else}}Error{{end}}</span>{{end}}
+        {{else}}<span class="ui-status ui-status--neutral shrink-0">Awaiting event</span>{{end}}
       </div>
       {{end}}
     </div>

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -469,6 +469,7 @@ if ('serviceWorker' in navigator) {
           <span class="app-nav__label">Observe</span>
           {{template "navItem" (dict "Section" $sec "Active" "analytics" "Href" "/analytics" "Label" "Analytics" "Icon" "chart")}}
           {{template "navItem" (dict "Section" $sec "Active" "live_traffic" "Href" "/live-traffic" "Label" "Live Traffic" "Icon" "lightning")}}
+          {{if eq .User.Role "admin"}}{{template "navItem" (dict "Section" $sec "Active" "server_logs" "Href" "/server-logs" "Label" "Server Logs" "Icon" "pulse")}}{{end}}
           {{template "navItem" (dict "Section" $sec "Active" "activity" "Href" "/activity" "Label" "Activity Log" "Icon" "pulse")}}
         </div>
 

--- a/web/templates/live_traffic.html
+++ b/web/templates/live_traffic.html
@@ -23,6 +23,10 @@
 
   <!-- Filter bar -->
   <div class="flex items-center gap-3">
+    <select id="filter-server" class="text-sm px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+      <option value="all" {{if eq .SelectedServerID 0}}selected{{end}}>All servers</option>
+      {{range .AllServers}}<option value="{{.ID}}" {{if eq $.SelectedServerID .ID}}selected{{end}}>{{.Name}}</option>{{end}}
+    </select>
     <input id="filter-host" type="text" placeholder="Filter by host…"
       class="text-sm px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white w-48 focus:outline-none focus:ring-2 focus:ring-blue-500">
     <select id="filter-status" class="text-sm px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
@@ -37,10 +41,11 @@
 
   <!-- Table -->
   <div class="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm">
-    <table class="w-full text-sm">
+    <table class="w-full text-sm min-w-[1080px]">
       <thead class="border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
         <tr class="text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
           <th class="px-4 py-3 font-medium">Time</th>
+          <th class="px-4 py-3 font-medium">Server</th>
           <th class="px-4 py-3 font-medium">Method</th>
           <th class="px-4 py-3 font-medium">Host</th>
           <th class="px-4 py-3 font-medium">Path</th>
@@ -53,8 +58,9 @@
       <tbody id="traffic-tbody" class="divide-y divide-gray-100 dark:divide-gray-800 font-mono text-xs">
         {{range .Events}}
         <tr class="hover:bg-gray-50 dark:hover:bg-gray-800/40 transition-colors event-row"
-            data-host="{{.Host}}" data-status="{{.Status}}">
+            data-id="{{.ID}}" data-host="{{.Host}}" data-status="{{.Status}}" data-server-id="{{.ServerID}}">
           <td class="px-4 py-2.5 text-gray-500 dark:text-gray-400 whitespace-nowrap">{{.TS.Format "15:04:05"}}</td>
+          <td class="px-4 py-2.5 text-gray-600 dark:text-gray-300 whitespace-nowrap">{{if .ServerName}}{{.ServerName}}{{else if .ServerID}}Server {{.ServerID}}{{else}}Legacy / unknown{{end}}</td>
           <td class="px-4 py-2.5">
             <span class="px-1.5 py-0.5 rounded font-medium text-[11px] {{if eq .Method "GET"}}bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400{{else if eq .Method "POST"}}bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400{{else if eq .Method "DELETE"}}bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400{{else}}bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300{{end}}">
               {{.Method}}
@@ -72,14 +78,12 @@
         {{end}}
       </tbody>
     </table>
-    {{if not .Events}}
-    <div id="empty-state" class="py-16 text-center text-gray-400 dark:text-gray-500">
+    <div id="empty-state" class="py-16 text-center text-gray-400 dark:text-gray-500"{{if .Events}} style="display:none"{{end}}>
       <svg class="w-10 h-10 mx-auto mb-3 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
       </svg>
       <p class="text-sm">No traffic yet — waiting for requests…</p>
     </div>
-    {{end}}
   </div>
   <p class="text-xs text-gray-400 dark:text-gray-600 text-right">Showing up to 500 most recent rows · older rows pruned automatically</p>
 </div>
@@ -93,6 +97,7 @@
   const clearBtn = document.getElementById('clear-btn');
   const filterHost = document.getElementById('filter-host');
   const filterStatus = document.getElementById('filter-status');
+  const filterServer = document.getElementById('filter-server');
   const emptyState = document.getElementById('empty-state');
 
   let paused = false;
@@ -139,19 +144,27 @@
     return n+' B';
   }
 
+  function esc(value) {
+    return String(value == null ? '' : value).replace(/[&<>"']/g, function(ch) {
+      return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch];
+    });
+  }
+
   function buildRow(e) {
     const tr = document.createElement('tr');
     tr.className = 'hover:bg-gray-50 dark:hover:bg-gray-800/40 transition-colors event-row new-row';
     tr.dataset.host = e.host;
     tr.dataset.status = String(e.status);
     tr.dataset.id = String(e.id);
+    tr.dataset.serverId = String(e.server_id || 0);
     tr.innerHTML = `
       <td class="px-4 py-2.5 text-gray-500 dark:text-gray-400 whitespace-nowrap">${fmtTime(e.ts)}</td>
-      <td class="px-4 py-2.5"><span class="px-1.5 py-0.5 rounded font-medium text-[11px] ${methodClass(e.method)}">${e.method}</span></td>
-      <td class="px-4 py-2.5 text-gray-800 dark:text-gray-200 max-w-[180px] truncate">${e.host}</td>
-      <td class="px-4 py-2.5 text-gray-600 dark:text-gray-300 max-w-[260px] truncate">${e.path}</td>
+      <td class="px-4 py-2.5 text-gray-600 dark:text-gray-300 whitespace-nowrap">${esc(e.server_name || (e.server_id ? 'Server ' + e.server_id : 'Legacy / unknown'))}</td>
+      <td class="px-4 py-2.5"><span class="px-1.5 py-0.5 rounded font-medium text-[11px] ${methodClass(e.method)}">${esc(e.method)}</span></td>
+      <td class="px-4 py-2.5 text-gray-800 dark:text-gray-200 max-w-[180px] truncate">${esc(e.host)}</td>
+      <td class="px-4 py-2.5 text-gray-600 dark:text-gray-300 max-w-[260px] truncate">${esc(e.path)}</td>
       <td class="px-4 py-2.5"><span class="font-bold ${statusClass(e.status)}">${e.status}</span></td>
-      <td class="px-4 py-2.5 text-gray-500 dark:text-gray-400">${e.client_ip}</td>
+      <td class="px-4 py-2.5 text-gray-500 dark:text-gray-400">${esc(e.client_ip)}</td>
       <td class="px-4 py-2.5 text-gray-500 dark:text-gray-400">${e.duration_ms}ms</td>
       <td class="px-4 py-2.5 text-gray-500 dark:text-gray-400">${fmtBytes(e.bytes_out)}</td>
     `;
@@ -179,7 +192,7 @@
 
   function connect() {
     if (es) es.close();
-    es = new EventSource('/api/live-traffic/stream?since=' + cursor);
+    es = new EventSource('/api/live-traffic/stream?since=' + cursor + '&server=' + encodeURIComponent(filterServer.value));
     const dot = document.querySelector('#status-dot span.rounded-full');
     const label = document.getElementById('status-dot');
 
@@ -215,6 +228,16 @@
   }
 
   connect();
+
+  filterServer.addEventListener('change', () => {
+    tbody.querySelectorAll('tr.event-row').forEach(tr => tr.remove());
+    cursor = 0;
+    const url = new URL(window.location.href);
+    url.searchParams.set('server', filterServer.value);
+    window.history.replaceState({}, '', url);
+    connect();
+    updateCount();
+  });
 
   pauseBtn.addEventListener('click', () => {
     paused = !paused;

--- a/web/templates/server_logs.html
+++ b/web/templates/server_logs.html
@@ -1,0 +1,220 @@
+{{define "title"}}Server Logs · CaddyUI{{end}}
+{{define "content"}}
+<div class="flex flex-col xl:flex-row xl:items-start xl:justify-between gap-4 mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold tracking-tight text-ink-900">Caddy server logs</h1>
+    <p class="text-sm text-ink-500 mt-1 max-w-3xl">
+      Stream structured runtime logs from a managed Caddy node. Full capture is temporary, stays in memory, and stops automatically after {{.CaptureTTLMinutes}} minutes. Caddy's normal container or journal output continues unchanged.
+    </p>
+  </div>
+  <div class="flex items-center gap-2 flex-wrap">
+    <span id="capture-status" class="ui-status ui-status--neutral">Checking…</span>
+    <button id="clear-logs" type="button" class="ui-button ui-button--quiet">Clear screen</button>
+  </div>
+</div>
+
+{{if not .HubAvailable}}
+<div class="rounded-xl border border-red-200 bg-red-50 px-5 py-4 mb-6 text-sm text-red-900">
+  Caddy's log ingest listener is unavailable. Check <code class="font-mono">CADDYUI_INGEST_LISTEN</code> and restart CaddyUI before enabling capture.
+</div>
+{{end}}
+{{if not .Servers}}
+<div class="rounded-xl border border-amber-200 bg-amber-50 px-5 py-4 mb-6 text-sm text-amber-900">
+  Add a managed Caddy server before starting runtime log capture.
+</div>
+{{end}}
+
+<div class="ui-panel p-4 mb-4">
+  <div class="flex flex-wrap items-end gap-3">
+    <label class="block min-w-56 flex-1 max-w-md">
+      <span class="block text-xs font-medium text-ink-600 mb-1">Caddy server</span>
+      <select id="log-server" class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none">
+        {{range .Servers}}
+        <option value="{{.ID}}" {{if eq $.SelectedServerID .ID}}selected{{end}}>{{.Name}} · {{.AdminURL}}</option>
+        {{end}}
+      </select>
+    </label>
+    <label class="block">
+      <span class="block text-xs font-medium text-ink-600 mb-1">Minimum level</span>
+      <select id="log-level" class="rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none">
+        <option value="INFO">Info</option>
+        <option value="DEBUG">Debug</option>
+        <option value="WARN">Warning</option>
+        <option value="ERROR">Error</option>
+      </select>
+    </label>
+    <button id="enable-capture" type="button" class="ui-button ui-button--primary" {{if or (not .HubAvailable) (not .Servers)}}disabled{{end}}>Start full capture</button>
+    <button id="disable-capture" type="button" class="ui-button ui-button--secondary" {{if or (not .HubAvailable) (not .Servers)}}disabled{{end}}>Stop full capture</button>
+  </div>
+  <p id="capture-detail" class="text-xs text-ink-500 mt-3">Certificate issuance and renewal events remain monitored even when full capture is off.</p>
+</div>
+
+<div class="flex flex-wrap items-center gap-3 mb-3">
+  <input id="log-filter" type="search" placeholder="Filter logger, message, or fields…" autocomplete="off"
+    class="min-w-64 flex-1 max-w-xl rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none">
+  <select id="visible-level" class="rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white">
+    <option value="">All levels</option>
+    <option value="DEBUG">Debug</option>
+    <option value="INFO">Info</option>
+    <option value="WARN">Warning</option>
+    <option value="ERROR">Error</option>
+  </select>
+  <span id="log-count" class="text-xs text-ink-500 ml-auto">0 entries</span>
+</div>
+
+<div class="bg-white border border-ink-200 rounded-xl shadow-card overflow-x-auto">
+  <table class="w-full text-sm min-w-[980px]">
+    <thead class="bg-ink-50/50 text-left">
+      <tr class="text-xs uppercase tracking-wider text-ink-500">
+        <th class="px-4 py-3 font-medium">Time</th>
+        <th class="px-4 py-3 font-medium">Server</th>
+        <th class="px-4 py-3 font-medium">Level</th>
+        <th class="px-4 py-3 font-medium">Logger</th>
+        <th class="px-4 py-3 font-medium">Message</th>
+        <th class="px-4 py-3 font-medium">Fields</th>
+      </tr>
+    </thead>
+    <tbody id="server-log-body" class="divide-y divide-ink-100 font-mono text-xs"></tbody>
+  </table>
+  <div id="server-log-empty" class="py-16 text-center text-sm text-ink-400">Waiting for structured log entries…</div>
+</div>
+
+<script>
+(function() {
+  var server = document.getElementById('log-server');
+  var captureLevel = document.getElementById('log-level');
+  var visibleLevel = document.getElementById('visible-level');
+  var filter = document.getElementById('log-filter');
+  var body = document.getElementById('server-log-body');
+  var empty = document.getElementById('server-log-empty');
+  var count = document.getElementById('log-count');
+  var badge = document.getElementById('capture-status');
+  var detail = document.getElementById('capture-detail');
+  var enable = document.getElementById('enable-capture');
+  var disable = document.getElementById('disable-capture');
+  var source = null;
+  var cursor = 0;
+  var captures = [];
+  var maxRows = 500;
+
+  function selectedID() { return parseInt(server && server.value || '0', 10); }
+
+  function setStatus(message, kind) {
+    badge.textContent = message;
+    badge.className = 'ui-status ' + (kind === 'active' ? 'ui-status--success' : kind === 'error' ? 'ui-status--danger' : 'ui-status--neutral');
+  }
+
+  function refreshStatus() {
+    fetch('/api/server-logs/status', {headers: {'Accept': 'application/json'}})
+      .then(function(response) { return response.json().then(function(data) { return {ok: response.ok, data: data}; }); })
+      .then(function(result) {
+        if (!result.ok || !result.data.available) throw new Error(result.data.error || 'Log ingest unavailable');
+        captures = result.data.captures || [];
+        var active = captures.find(function(item) { return item.server_id === selectedID(); });
+        if (active) {
+          setStatus('Full capture active', 'active');
+          detail.textContent = active.level + ' and above · automatically stops ' + new Date(active.expires_at).toLocaleString();
+        } else {
+          setStatus('Certificate events only', 'neutral');
+          detail.textContent = 'Certificate issuance and renewal events remain monitored even when full capture is off.';
+        }
+      })
+      .catch(function(error) { setStatus(error.message, 'error'); });
+  }
+
+  function post(url) {
+    var form = new URLSearchParams();
+    form.set('server_id', String(selectedID()));
+    form.set('level', captureLevel.value);
+    enable.disabled = true;
+    disable.disabled = true;
+    return fetch(url, {method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'Accept': 'application/json'}, body: form.toString()})
+      .then(function(response) { return response.json().then(function(data) { if (!response.ok) throw new Error(data.error || 'Request failed'); return data; }); })
+      .then(function(data) { refreshStatus(); return data; })
+      .catch(function(error) { setStatus(error.message, 'error'); throw error; })
+      .finally(function() { enable.disabled = false; disable.disabled = false; });
+  }
+
+  function levelClass(level) {
+    if (level === 'ERROR') return 'bg-red-50 text-red-700';
+    if (level === 'WARN') return 'bg-amber-50 text-amber-700';
+    if (level === 'DEBUG') return 'bg-sky-50 text-sky-700';
+    return 'bg-emerald-50 text-emerald-700';
+  }
+
+  function addCell(row, text, className) {
+    var cell = document.createElement('td');
+    cell.className = className || 'px-4 py-2.5 align-top text-ink-600';
+    cell.textContent = text || '—';
+    row.appendChild(cell);
+    return cell;
+  }
+
+  function applyFilter(row) {
+    var query = filter.value.trim().toLowerCase();
+    var level = visibleLevel.value;
+    var show = (!query || (row.dataset.search || '').includes(query)) && (!level || row.dataset.level === level);
+    row.style.display = show ? '' : 'none';
+  }
+
+  function addEntry(entry) {
+    if (body.querySelector('[data-entry-id="' + entry.id + '"]')) return;
+    var row = document.createElement('tr');
+    row.dataset.entryId = String(entry.id);
+    row.dataset.level = entry.level || 'INFO';
+    var fieldText = entry.fields && Object.keys(entry.fields).length ? JSON.stringify(entry.fields) : '';
+    row.dataset.search = ((entry.logger || '') + ' ' + (entry.message || '') + ' ' + fieldText).toLowerCase();
+    row.className = 'hover:bg-ink-50/60 transition';
+    addCell(row, new Date(entry.ts).toLocaleTimeString(), 'px-4 py-2.5 align-top whitespace-nowrap text-ink-500');
+    addCell(row, entry.server_name || ('Server ' + entry.server_id), 'px-4 py-2.5 align-top whitespace-nowrap text-ink-700');
+    var levelCell = addCell(row, '', 'px-4 py-2.5 align-top');
+    var levelBadge = document.createElement('span');
+    levelBadge.className = 'inline-flex px-2 py-0.5 rounded-full text-[11px] font-medium ' + levelClass(entry.level);
+    levelBadge.textContent = entry.level || 'INFO';
+    levelCell.appendChild(levelBadge);
+    addCell(row, entry.logger, 'px-4 py-2.5 align-top text-ink-500 whitespace-nowrap');
+    addCell(row, entry.message, 'px-4 py-2.5 align-top text-ink-800 min-w-72');
+    addCell(row, fieldText, 'px-4 py-2.5 align-top text-ink-500 break-all max-w-md');
+    applyFilter(row);
+    body.appendChild(row);
+    while (body.children.length > maxRows) body.removeChild(body.firstChild);
+  }
+
+  function updateCount() {
+    var total = body.children.length;
+    count.textContent = total + (total === 1 ? ' entry' : ' entries');
+    empty.style.display = total ? 'none' : '';
+  }
+
+  function connect() {
+    if (!server || !server.value) return;
+    if (source) source.close();
+    source = new EventSource('/api/server-logs/stream?server=' + encodeURIComponent(server.value) + '&since=' + cursor);
+    source.onmessage = function(event) {
+      var entries;
+      try { entries = JSON.parse(event.data); } catch (_) { return; }
+      if (!Array.isArray(entries)) return;
+      entries.forEach(function(entry) { if (entry.id > cursor) cursor = entry.id; addEntry(entry); });
+      updateCount();
+    };
+    source.onerror = function() { if (!captures.length) setStatus('Stream reconnecting…', 'error'); };
+  }
+
+  if (server) server.addEventListener('change', function() {
+    body.replaceChildren();
+    cursor = 0;
+    updateCount();
+    refreshStatus();
+    connect();
+  });
+  filter.addEventListener('input', function() { body.querySelectorAll('tr').forEach(applyFilter); });
+  visibleLevel.addEventListener('change', function() { body.querySelectorAll('tr').forEach(applyFilter); });
+  document.getElementById('clear-logs').addEventListener('click', function() { body.replaceChildren(); updateCount(); });
+  enable.addEventListener('click', function() { post('/api/server-logs/enable'); });
+  disable.addEventListener('click', function() { post('/api/server-logs/disable'); });
+  refreshStatus();
+  connect();
+  window.setInterval(refreshStatus, 10000);
+})();
+</script>
+{{end}}


### PR DESCRIPTION
## Summary

- surface Caddy ACME issuance, renewal, retry, success, revocation, and error lifecycle per managed node
- add an admin-only, memory-bounded Server Logs stream with 15-minute automatic cleanup
- stamp analytics events with the Caddy node that actually handled each request and add filters/CSV attribution
- preserve existing Caddy log outputs with additive named loggers
- keep SQLite and MariaDB schemas and migration paths in parity

## Verification

- `go test ./...`
- `go vet ./...`
- race tests for analytics/Caddy/log hub/models/server
- MariaDB 11.4 schema and SQLite migration integration tests
- Caddy 2.11.4 config validation and real access-log attribution probe
- isolated production-image HTTP/Caddy smoke test

Closes #26
Closes #27
Closes #28