### PR TITLE
fix: make v2.25.0 SQLite upgrade migration-safe

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -155,7 +155,6 @@ CREATE TABLE IF NOT EXISTS access_events (
 );
 CREATE INDEX IF NOT EXISTS idx_access_events_ts      ON access_events(ts);
 CREATE INDEX IF NOT EXISTS idx_access_events_host_ts ON access_events(host, ts);
-CREATE INDEX IF NOT EXISTS idx_access_events_server_ts ON access_events(server_id, ts);
 -- v2.9.206: indexes for status-code breakdown card and unique-visitor count.
 -- (path, ts) intentionally omitted — path values are high-cardinality and the
 -- index would be larger than the table itself; top-paths queries already use
@@ -2175,7 +2174,9 @@ func migrate(db *sql.DB) error {
 			return fmt.Errorf("add server_name to access_events: %w", err)
 		}
 	}
-	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_access_events_server_ts ON access_events(server_id, ts)`)
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_access_events_server_ts ON access_events(server_id, ts)`); err != nil {
+		return fmt.Errorf("create access_events server index: %w", err)
+	}
 
 	return nil
 }

--- a/internal/db/db_upgrade_test.go
+++ b/internal/db/db_upgrade_test.go
@@ -1,0 +1,56 @@
+package db
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenUpgradesLegacyAccessEventsSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	legacy, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open legacy database: %v", err)
+	}
+	if _, err := legacy.Exec(`
+		CREATE TABLE access_events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			ts INTEGER NOT NULL,
+			host TEXT NOT NULL DEFAULT '',
+			path TEXT NOT NULL DEFAULT '',
+			method TEXT NOT NULL DEFAULT '',
+			status INTEGER NOT NULL DEFAULT 0,
+			client_ip TEXT NOT NULL DEFAULT '',
+			user_agent TEXT NOT NULL DEFAULT '',
+			duration_ms INTEGER NOT NULL DEFAULT 0,
+			bytes_out INTEGER NOT NULL DEFAULT 0
+		);
+		INSERT INTO access_events (ts, host) VALUES (1700000000, 'legacy.example');
+	`); err != nil {
+		legacy.Close()
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatalf("close legacy database: %v", err)
+	}
+
+	upgraded, err := Open(path)
+	if err != nil {
+		t.Fatalf("upgrade legacy database: %v", err)
+	}
+	defer upgraded.Close()
+
+	var serverID int64
+	var serverName, host string
+	if err := upgraded.QueryRow(`SELECT server_id, server_name, host FROM access_events WHERE id=1`).Scan(&serverID, &serverName, &host); err != nil {
+		t.Fatalf("read upgraded event: %v", err)
+	}
+	if serverID != 0 || serverName != "" || host != "legacy.example" {
+		t.Fatalf("upgraded event = (%d, %q, %q), want (0, \"\", \"legacy.example\")", serverID, serverName, host)
+	}
+
+	var indexName string
+	if err := upgraded.QueryRow(`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_access_events_server_ts'`).Scan(&indexName); err != nil {
+		t.Fatalf("server index missing after upgrade: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- defer the new access-event server index until after legacy SQLite databases receive the `server_id` and `server_name` columns
- return an actionable error if index creation fails
- add a regression test that opens and upgrades the pre-v2.25.0 analytics schema while preserving existing events

## Incident

Upgrading an existing SQLite installation from v2.24.0 to v2.25.0 failed during startup because the base schema attempted to create `idx_access_events_server_ts` before the idempotent migration added `access_events.server_id`. Fresh databases and MariaDB were unaffected.

## Verification

- `go test -race ./...`
- `go vet ./...`
- live database restored after a timestamped backup by applying the same additive migration; CaddyUI `/login` returns HTTP 200 locally and through Caddy
