### PR TITLE
fix: harden observability logging and certificate status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.25.2] - 2026-08-14 - Observability reliability follow-up
+
+### Fixed
+
+- Analytics and fleet access-log forwarding no longer select a CaddyUI-owned logger as an HTTP server's default. Existing console, journal, file, and per-host logger configuration is preserved, while legacy v2.25.0/v2.25.1 overrides are repaired automatically.
+- Certificate lifecycle success can no longer regress to **Obtaining** when Caddy emits its post-issuance `releasing lock` cleanup line. Structured certificate events are also recognized as authoritative lifecycle signals.
+- Managed certificates with missing or stale obtaining/renewing history are reconciled at startup and periodically from the certificate actually served by each managed Caddy node. Retry, error, and revoked states remain visible until Caddy reports a real recovery.
+- Server Logs now shows whether its live stream is connected or reconnecting and provides a one-click **Refresh / reconnect** action.
+
+### Added
+
+- Sortable columns on the Server Logs, custom certificate, and Caddy-managed certificate tables.
+- A **Refresh status** action on the Certificates page.
+- Regression coverage for existing Caddy logging preservation, lifecycle cleanup ordering, startup certificate reconciliation, and the new operational UI controls. ([#26](https://github.com/X4Applegate/caddyui/issues/26))
+
 ## [2.25.1] - 2026-08-14 - SQLite upgrade hotfix
 
 ### Fixed

--- a/cmd/caddyui/main.go
+++ b/cmd/caddyui/main.go
@@ -133,6 +133,7 @@ Fix by:
 	if err := srv.ReconcileCertificateLogs(); err != nil {
 		log.Printf("certificate monitoring: startup reconciliation: %v", err)
 	}
+	srv.StartCertificateLifecycleReconciler(pollerCtx)
 
 	// Opt-in startup sync. Default: no initial sync — pushing an empty config
 	// would wipe Caddy's existing routes. Set CADDYUI_SYNC_ON_START=1 once all

--- a/internal/caddy/accesslog.go
+++ b/internal/caddy/accesslog.go
@@ -80,19 +80,25 @@ func (c *Client) installNamedLog(name string, logger map[string]any) error {
 		return err
 	}
 
-	logs := map[string]any{name: logger}
-	if cfg, _, cfgErr := c.FetchConfig(); cfgErr == nil {
-		if logging, _ := cfg["logging"].(map[string]any); logging != nil {
-			if existing, _ := logging["logs"].(map[string]any); existing != nil {
-				for key, value := range existing {
-					if key != name {
-						logs[key] = value
-					}
-				}
-			}
+	logging := map[string]any{}
+	cfg, _, cfgErr := c.FetchConfig()
+	if cfgErr != nil {
+		return fmt.Errorf("fetch config before logging bootstrap: %w", cfgErr)
+	}
+	if existing, _ := cfg["logging"].(map[string]any); existing != nil {
+		for key, value := range existing {
+			logging[key] = value
 		}
 	}
-	return c.PutPath("/config/logging", map[string]any{"logs": logs})
+	logs := map[string]any{}
+	if existing, _ := logging["logs"].(map[string]any); existing != nil {
+		for key, value := range existing {
+			logs[key] = value
+		}
+	}
+	logs[name] = logger
+	logging["logs"] = logs
+	return c.PutPath("/config/logging", logging)
 }
 
 // EnableAccessLogs configures the live Caddy instance to stream its access
@@ -106,13 +112,13 @@ func (c *Client) installNamedLog(name string, logger map[string]any) error {
 //  1. logging.logs.caddyui_access is created (or replaced) with a net-writer
 //     that points at target. Only logs tagged http.log.access are routed
 //     there, so Caddy's own admin / app logs aren't shipped.
-//  2. Every entry under apps.http.servers is patched to have a non-empty
-//     logs block — Caddy only emits http.log.access events for servers
-//     with logs enabled, so without this step our logger sits unused.
-//  3. apps.http.servers.<name>.logs.default_logger_name is set to
-//     caddyui_access so requests without an explicit per-host logger go
-//     to us. Per-host `log` directives in the Caddyfile will continue to
-//     win when present — this just sets the default.
+//  2. Every entry under apps.http.servers is guaranteed to have a logs block.
+//     Caddy only emits http.log.access events for servers with logs enabled.
+//     Existing blocks and logger selections are preserved.
+//  3. Configs written by v2.25.0/v2.25.1 are repaired by removing only their
+//     caddyui_access default_logger_name override. The named logger's include
+//     rule receives a duplicate event while the existing/default logger keeps
+//     writing to stdout, a journal, or the user's configured file.
 //
 // Returns an error if Caddy's admin API rejects any step. Callers should
 // fall back to DisableAccessLogs on failure to avoid leaving the config in
@@ -134,12 +140,9 @@ func (c *Client) EnableAccessLogs(target string, opts AccessLogOptions) error {
 		return fmt.Errorf("install access-log logger: %w", err)
 	}
 
-	// Step 2+3: fetch the server names, then patch each one's logs block.
-	// We can't patch .../servers/*/logs with a wildcard — Caddy's admin API
-	// is path-oriented, not pattern-oriented — so we enumerate servers and
-	// issue one PUT per server. Typical caddyui deployments have one
-	// server, so this is a one-request loop in practice.
-	servers, err := c.listHTTPServerNames()
+	// Step 2+3: enable access-log emission without selecting CaddyUI as the
+	// server's default logger. The global include above tees matching events.
+	servers, err := c.listHTTPServerConfigs()
 	if err != nil {
 		return fmt.Errorf("list http servers for access-log enable: %w", err)
 	}
@@ -148,12 +151,18 @@ func (c *Client) EnableAccessLogs(target string, opts AccessLogOptions) error {
 		// descriptive error so the admin knows to add a site block first.
 		return fmt.Errorf("access-log logger installed but no http servers exist in Caddy config")
 	}
-	for _, srv := range servers {
-		logsCfg := map[string]any{
-			"default_logger_name": AccessLogLoggerName,
+	for name, server := range servers {
+		logsCfg, _ := server["logs"].(map[string]any)
+		if logsCfg == nil {
+			if err := c.PutPath("/config/apps/http/servers/"+name+"/logs", map[string]any{}); err != nil {
+				return fmt.Errorf("enable logs on server %q: %w", name, err)
+			}
+			continue
 		}
-		if err := c.PutPath("/config/apps/http/servers/"+srv+"/logs", logsCfg); err != nil {
-			return fmt.Errorf("enable logs on server %q: %w", srv, err)
+		if logsCfg["default_logger_name"] == AccessLogLoggerName {
+			if err := c.deletePathIgnoreMissing("/config/apps/http/servers/" + name + "/logs/default_logger_name"); err != nil {
+				return fmt.Errorf("restore default logger on server %q: %w", name, err)
+			}
 		}
 	}
 	return nil
@@ -217,66 +226,71 @@ func (c *Client) DisableRuntimeLogs() error {
 	return nil
 }
 
-// DisableAccessLogs reverses EnableAccessLogs. Removes the caddyui_access
-// logger and deletes the logs block on every http server. Missing paths
-// are not treated as errors — a DELETE on a path that Caddy doesn't know
-// about returns 404 and we swallow it, so repeated disable calls are
-// idempotent and safe after a partial-enable rollback.
+// DisableAccessLogs removes only CaddyUI's named logger. Server logs blocks
+// remain enabled so console/journal/file output is never disabled as a side
+// effect. The v2.25.0/v2.25.1 default_logger_name override is removed if it
+// is present; unrelated default or per-host logger choices are preserved.
 func (c *Client) DisableAccessLogs() error {
-	// Step 1: remove the logger. If the admin toggled off the feature
-	// while Caddy was also holding a per-server `logs` block, skipping
-	// this leaves the logger attached to servers that no longer have a
-	// writer — which Caddy treats as "log nowhere", silently.
 	if err := c.deletePathIgnoreMissing("/config/logging/logs/" + AccessLogLoggerName); err != nil {
 		return fmt.Errorf("remove access-log logger: %w", err)
 	}
+	return c.RepairDefaultLoggerOverrides(AccessLogLoggerName)
+}
 
-	// Step 2: clear the logs block on each http server. Caddyfile sites
-	// with their own explicit `log` directive will re-install a logs
-	// block on next adapt — that's fine, we only want to undo our own
-	// automatic wiring here.
-	servers, err := c.listHTTPServerNames()
-	if err != nil {
-		// If we can't enumerate servers, we can't be sure nothing is
-		// still pointing at the logger — but the logger is already
-		// gone, so access logs are effectively off. Surface the error
-		// but don't fail hard.
-		return fmt.Errorf("list http servers for access-log disable: %w", err)
+// RepairDefaultLoggerOverrides removes only HTTP-server default selections
+// that point at one of the supplied CaddyUI-owned named loggers. It is used on
+// startup to repair persisted v2.25.0/v2.25.1 configs without changing the
+// named stream itself or any unrelated console, journal, file, and per-host
+// logger choices.
+func (c *Client) RepairDefaultLoggerOverrides(ownedNames ...string) error {
+	owned := make(map[string]bool, len(ownedNames))
+	for _, name := range ownedNames {
+		if name = strings.TrimSpace(name); name != "" {
+			owned[name] = true
+		}
 	}
-	for _, srv := range servers {
-		if err := c.deletePathIgnoreMissing("/config/apps/http/servers/" + srv + "/logs"); err != nil {
-			return fmt.Errorf("clear logs on server %q: %w", srv, err)
+	if len(owned) == 0 {
+		return nil
+	}
+	servers, err := c.listHTTPServerConfigs()
+	if err != nil {
+		return fmt.Errorf("list http servers for default-logger repair: %w", err)
+	}
+	for name, server := range servers {
+		logsCfg, _ := server["logs"].(map[string]any)
+		defaultName, _ := logsCfg["default_logger_name"].(string)
+		if logsCfg != nil && owned[defaultName] {
+			if err := c.deletePathIgnoreMissing("/config/apps/http/servers/" + name + "/logs/default_logger_name"); err != nil {
+				return fmt.Errorf("restore default logger on server %q: %w", name, err)
+			}
 		}
 	}
 	return nil
 }
 
-// listHTTPServerNames returns the keys under apps.http.servers. Empty slice
-// means Caddy has no HTTP app configured (possible on a fresh boot before
-// the first sync). The admin API returns null for missing paths, which we
-// normalise to an empty slice so callers don't have to special-case it.
-func (c *Client) listHTTPServerNames() ([]string, error) {
+// listHTTPServerConfigs returns the live server objects keyed by name. An
+// empty map means Caddy has no HTTP app configured yet.
+func (c *Client) listHTTPServerConfigs() (map[string]map[string]any, error) {
 	cfg, _, err := c.FetchConfig()
 	if err != nil {
 		return nil, err
 	}
 	apps, _ := cfg["apps"].(map[string]any)
 	if apps == nil {
-		return nil, nil
+		return map[string]map[string]any{}, nil
 	}
 	httpApp, _ := apps["http"].(map[string]any)
 	if httpApp == nil {
-		return nil, nil
+		return map[string]map[string]any{}, nil
 	}
-	servers, _ := httpApp["servers"].(map[string]any)
-	if servers == nil {
-		return nil, nil
+	rawServers, _ := httpApp["servers"].(map[string]any)
+	out := make(map[string]map[string]any, len(rawServers))
+	for name, raw := range rawServers {
+		if server, _ := raw.(map[string]any); server != nil {
+			out[name] = server
+		}
 	}
-	names := make([]string, 0, len(servers))
-	for k := range servers {
-		names = append(names, k)
-	}
-	return names, nil
+	return out, nil
 }
 
 // deletePathIgnoreMissing issues a DELETE on a config path and treats 404

--- a/internal/caddy/accesslog_test.go
+++ b/internal/caddy/accesslog_test.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
 
 func TestEnableAccessLogsConfiguresSoftStartAndDialTimeout(t *testing.T) {
 	var logger map[string]any
+	var serverLogs map[string]any
 	admin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/config/logging/logs/"+AccessLogLoggerName:
@@ -21,6 +23,9 @@ func TestEnableAccessLogsConfiguresSoftStartAndDialTimeout(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"apps":{"http":{"servers":{"srv0":{}}}}}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/config/apps/http/servers/srv0/logs":
+			if err := json.NewDecoder(r.Body).Decode(&serverLogs); err != nil {
+				t.Fatalf("decode server logs: %v", err)
+			}
 			w.WriteHeader(http.StatusOK)
 		default:
 			http.Error(w, "unexpected request", http.StatusNotFound)
@@ -58,6 +63,139 @@ func TestEnableAccessLogsConfiguresSoftStartAndDialTimeout(t *testing.T) {
 	fields, _ := encoder["fields"].(map[string]any)
 	if fields["caddyui_server_id"] != float64(9) || fields["caddyui_server_name"] != "edge-west" {
 		t.Fatalf("source fields = %#v", fields)
+	}
+	if len(serverLogs) != 0 {
+		t.Fatalf("server logs = %#v, want empty block preserving default console output", serverLogs)
+	}
+}
+
+func TestInstallNamedLogFallbackPreservesWholeLoggingConfig(t *testing.T) {
+	var installed map[string]any
+	admin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/config/logging/logs/"+CertificateLogLoggerName:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"config path not found"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/config/":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"logging":{"sink":{"writer":{"output":"stderr"}},"logs":{"default":{"level":"DEBUG"}}}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/config/logging":
+			if err := json.NewDecoder(r.Body).Decode(&installed); err != nil {
+				t.Fatal(err)
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer admin.Close()
+
+	client := New(admin.URL, "", "")
+	if err := client.EnableCertificateLogs("caddyui:9019", AccessLogOptions{ServerID: 1, ServerName: "edge"}); err != nil {
+		t.Fatal(err)
+	}
+	if installed["sink"] == nil {
+		t.Fatalf("logging sink was discarded: %#v", installed)
+	}
+	logs, _ := installed["logs"].(map[string]any)
+	if logs["default"] == nil || logs[CertificateLogLoggerName] == nil {
+		t.Fatalf("logging entries were not merged: %#v", logs)
+	}
+}
+
+func TestInstallNamedLogDoesNotReplaceLoggingWhenFallbackFetchFails(t *testing.T) {
+	var replaced bool
+	admin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/config/logging/logs/"+CertificateLogLoggerName:
+			http.Error(w, `{"error":"config path not found"}`, http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/config/":
+			http.Error(w, "temporary failure", http.StatusBadGateway)
+		case r.Method == http.MethodPost && r.URL.Path == "/config/logging":
+			replaced = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer admin.Close()
+
+	client := New(admin.URL, "", "")
+	if err := client.EnableCertificateLogs("caddyui:9019", AccessLogOptions{}); err == nil {
+		t.Fatal("expected fallback fetch error")
+	}
+	if replaced {
+		t.Fatal("logging subtree was replaced without first reading the existing config")
+	}
+}
+
+func TestEnableAccessLogsRepairsOwnedDefaultAndPreservesCustomLogger(t *testing.T) {
+	var deleted []string
+	var serverLogsWrites int
+	admin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/config/logging/logs/"+AccessLogLoggerName:
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/config/":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"apps":{"http":{"servers":{"legacy":{"logs":{"default_logger_name":"caddyui_access","logger_names":{"host.example":"custom"}}},"custom":{"logs":{"default_logger_name":"console_access"}}}}}}`))
+		case r.Method == http.MethodDelete:
+			deleted = append(deleted, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/config/apps/http/servers/"):
+			serverLogsWrites++
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer admin.Close()
+
+	client := New(admin.URL, "", "")
+	if err := client.EnableAccessLogs("caddyui:9019", AccessLogOptions{ServerID: 1, ServerName: "edge"}); err != nil {
+		t.Fatal(err)
+	}
+	if serverLogsWrites != 0 {
+		t.Fatalf("existing server logging was replaced %d time(s)", serverLogsWrites)
+	}
+	want := "/config/apps/http/servers/legacy/logs/default_logger_name"
+	if len(deleted) != 1 || deleted[0] != want {
+		t.Fatalf("deleted paths = %#v, want [%q]", deleted, want)
+	}
+}
+
+func TestRepairDefaultLoggerOverridesRemovesOnlyOwnedSelections(t *testing.T) {
+	var deleted []string
+	admin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/config/":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"apps":{"http":{"servers":{"analytics":{"logs":{"default_logger_name":"caddyui_access"}},"fleet":{"logs":{"default_logger_name":"caddyui_file_access"}},"custom":{"logs":{"default_logger_name":"customer_file","logger_names":{"app.example":"app_logger"}}}}}}}`))
+		case r.Method == http.MethodDelete:
+			deleted = append(deleted, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer admin.Close()
+
+	client := New(admin.URL, "", "")
+	if err := client.RepairDefaultLoggerOverrides(AccessLogLoggerName, "caddyui_file_access"); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{
+		"/config/apps/http/servers/analytics/logs/default_logger_name": true,
+		"/config/apps/http/servers/fleet/logs/default_logger_name":     true,
+	}
+	if len(deleted) != len(want) {
+		t.Fatalf("deleted paths = %#v", deleted)
+	}
+	for _, path := range deleted {
+		if !want[path] {
+			t.Fatalf("unexpected deletion %q; custom logger must be preserved", path)
+		}
 	}
 }
 

--- a/internal/caddylogs/hub.go
+++ b/internal/caddylogs/hub.go
@@ -226,31 +226,39 @@ func stringField(value any) string {
 }
 
 func certificateStates(entry Entry, raw map[string]any) []models.CertificateLifecycleStatus {
-	if entry.ServerID <= 0 || !strings.HasPrefix(entry.Logger, "tls") {
+	eventName := strings.ToLower(strings.TrimSpace(stringField(raw["name"])))
+	isTLSEvent := strings.HasPrefix(entry.Logger, "tls")
+	isCertificateEvent := entry.Logger == "events" && strings.HasPrefix(eventName, "cert_")
+	if entry.ServerID <= 0 || (!isTLSEvent && !isCertificateEvent) {
 		return nil
 	}
 	message := strings.ToLower(entry.Message)
 	phase := ""
 	switch {
-	case strings.Contains(message, "revoked"):
+	case eventName == "cert_revoked" || strings.Contains(message, "revoked"):
 		phase = "revoked"
-	case strings.Contains(message, "certificate obtained") ||
+	case eventName == "cert_obtained" || eventName == "cert_cached" ||
+		strings.Contains(message, "certificate obtained") ||
 		strings.Contains(message, "certificate renewed") ||
 		strings.Contains(message, "renewed certificate") ||
 		strings.Contains(message, "cached managed certificate") ||
-		strings.Contains(message, "loaded certificate"):
+		strings.Contains(message, "loaded certificate") ||
+		strings.Contains(message, "certificate loaded"):
 		phase = "active"
 	case strings.Contains(message, "will retry"):
 		phase = "retrying"
-	case entry.Level == "ERROR" || strings.Contains(message, "could not get certificate") ||
+	case eventName == "cert_failed" || entry.Level == "ERROR" || strings.Contains(message, "could not get certificate") ||
 		strings.Contains(message, "failed") || strings.Contains(message, "giving up"):
 		phase = "error"
-	case strings.Contains(entry.Logger, "renew") || strings.Contains(message, "renewing certificate"):
+	case strings.Contains(message, "renewing certificate") || strings.Contains(message, "started certificate renewal"):
 		phase = "renewing"
-	case strings.Contains(entry.Logger, "issuance") || strings.Contains(entry.Logger, "obtain") ||
-		strings.Contains(message, "obtaining certificate") || strings.Contains(message, "trying to solve challenge"):
+	case strings.Contains(message, "obtaining certificate") || strings.Contains(message, "trying to solve challenge") ||
+		strings.Contains(message, "starting certificate issuance"):
 		phase = "obtaining"
 	default:
+		// Namespace-only classification is deliberately avoided. Follow-up
+		// lines such as tls.obtain/releasing lock arrive after success and used
+		// to regress an Issued certificate back to Obtaining.
 		return nil
 	}
 
@@ -289,13 +297,19 @@ func certificateIdentifiers(raw map[string]any) []string {
 			out = append(out, value)
 		}
 	}
-	add(stringField(raw["identifier"]))
-	for _, key := range []string{"identifiers", "subjects", "sans"} {
-		if values, ok := raw[key].([]any); ok {
-			for _, value := range values {
-				add(stringField(value))
+	collect := func(fields map[string]any) {
+		add(stringField(fields["identifier"]))
+		for _, key := range []string{"identifiers", "subjects", "sans", "names"} {
+			if values, ok := fields[key].([]any); ok {
+				for _, value := range values {
+					add(stringField(value))
+				}
 			}
 		}
+	}
+	collect(raw)
+	if data, _ := raw["data"].(map[string]any); data != nil {
+		collect(data)
 	}
 	return out
 }

--- a/internal/caddylogs/hub_test.go
+++ b/internal/caddylogs/hub_test.go
@@ -54,10 +54,20 @@ func TestHubPersistsCertificateLifecycleAndKeepsRuntimeLogsInMemory(t *testing.T
 	if len(states) != 1 || states[0].Phase != "active" || states[0].Error != "" {
 		t.Fatalf("success state = %#v, want active without an error", states)
 	}
+	// tls.obtain emits cleanup lines after success. Logger namespace alone
+	// must not regress the certificate back to Obtaining.
+	hub.AcceptLine([]byte(`{"level":"info","ts":1700000003,"logger":"tls.obtain","msg":"releasing lock","identifier":"example.test","caddyui_server_id":2,"caddyui_server_name":"edge"}`))
+	states, err = models.ListCertificateLifecycle(conn, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].Phase != "active" {
+		t.Fatalf("post-success cleanup regressed lifecycle state: %#v", states)
+	}
 
 	entries := hub.Since(0, 2, 20)
-	if len(entries) != 4 {
-		t.Fatalf("runtime entries = %d, want 4", len(entries))
+	if len(entries) != 5 {
+		t.Fatalf("runtime entries = %d, want 5", len(entries))
 	}
 	var count int
 	if err := conn.QueryRow(`SELECT COUNT(*) FROM certificate_lifecycle`).Scan(&count); err != nil {
@@ -65,6 +75,24 @@ func TestHubPersistsCertificateLifecycleAndKeepsRuntimeLogsInMemory(t *testing.T
 	}
 	if count != 1 {
 		t.Fatalf("persisted lifecycle rows = %d, want compact single row", count)
+	}
+}
+
+func TestHubPersistsStructuredCertObtainedEvent(t *testing.T) {
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	hub := New(conn)
+	hub.AcceptLine([]byte(`{"level":"debug","ts":1700000004,"logger":"events","msg":"event","name":"cert_obtained","data":{"identifier":"event.example","issuer":"acme.example","renewal":false},"caddyui_server_id":7,"caddyui_server_name":"west"}`))
+	states, err := models.ListCertificateLifecycle(conn, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].Identifier != "event.example" || states[0].Phase != "active" {
+		t.Fatalf("cert_obtained state = %#v, want active event.example", states)
 	}
 }
 

--- a/internal/server/analytics.go
+++ b/internal/server/analytics.go
@@ -200,21 +200,52 @@ func (s *Server) applyAnalyticsToggle(cfg analyticsConfig) error {
 	return nil
 }
 
-// ReconcileAnalyticsAccessLogs refreshes an enabled analytics logger during
-// CaddyUI startup. This is important for upgrades: it writes newly introduced
-// writer safeguards such as soft_start into Caddy's persisted config without
-// requiring an admin to revisit Settings and click Save. Disabled analytics is
-// left untouched here; the explicit Settings toggle remains responsible for
-// removing a previously enabled logger.
+// ReconcileAnalyticsAccessLogs repairs legacy CaddyUI default-logger overrides
+// on every managed node, then refreshes an enabled analytics stream. The repair
+// is unconditional because fleet file logging can be enabled independently of
+// analytics, and both v2.25.0/v2.25.1 logger names could redirect normal Caddy
+// console or file output.
 func (s *Server) ReconcileAnalyticsAccessLogs() error {
 	cfg := loadAnalyticsConfig(s.DB)
+	repairErr := s.repairCaddyUIDefaultLoggers()
 	if !cfg.Enabled {
 		if s.analyticsIngest != nil {
 			s.analyticsIngest.SetExcludeIPs(cfg.ExcludeIPs)
 		}
-		return nil
+		return repairErr
 	}
-	return s.applyAnalyticsToggle(cfg)
+	toggleErr := s.applyAnalyticsToggle(cfg)
+	if repairErr != nil && toggleErr != nil {
+		return fmt.Errorf("repair logger defaults: %v; refresh analytics logger: %w", repairErr, toggleErr)
+	}
+	if repairErr != nil {
+		return repairErr
+	}
+	return toggleErr
+}
+
+func (s *Server) repairCaddyUIDefaultLoggers() error {
+	servers, err := models.ListCaddyServers(s.DB)
+	if err != nil {
+		return fmt.Errorf("list caddy servers for logger repair: %w", err)
+	}
+	if len(servers) == 0 {
+		return s.Caddy.RepairDefaultLoggerOverrides(caddy.AccessLogLoggerName, fleetAccessLoggerName)
+	}
+	var errMsgs []string
+	for _, server := range servers {
+		if server.Type != models.CaddyServerTypeManaged {
+			continue
+		}
+		client := newCaddyClient(server.AdminURL, server.AdminUsername, server.AdminPassword)
+		if err := client.RepairDefaultLoggerOverrides(caddy.AccessLogLoggerName, fleetAccessLoggerName); err != nil {
+			errMsgs = append(errMsgs, fmt.Sprintf("server %q (%s): %v", server.Name, server.AdminURL, err))
+		}
+	}
+	if len(errMsgs) > 0 {
+		return fmt.Errorf("default-logger repair: %s", strings.Join(errMsgs, "; "))
+	}
+	return nil
 }
 
 // userAllowedHosts returns the list of host strings (as Caddy would see them

--- a/internal/server/caddy_logs.go
+++ b/internal/server/caddy_logs.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -8,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/X4Applegate/caddyui/internal/caddy"
@@ -18,7 +20,14 @@ import (
 const (
 	runtimeLogCaptureTTL   = 15 * time.Minute
 	runtimeLogCleanupRetry = 30 * time.Second
+	certificateProbeEvery  = time.Hour
+	staleCertificatePhase  = 15 * time.Minute
 )
+
+type certificateProbeTarget struct {
+	Certificate models.Certificate
+	Identifiers []string
+}
 
 func caddyLogOptions(server models.CaddyServer, cfg analyticsConfig) caddy.AccessLogOptions {
 	return caddy.AccessLogOptions{
@@ -53,6 +62,219 @@ func (s *Server) ReconcileCertificateLogs() error {
 		return fmt.Errorf("certificate log monitoring: %s", strings.Join(failures, "; "))
 	}
 	return nil
+}
+
+// StartCertificateLifecycleReconciler bootstraps lifecycle state for
+// certificates issued before log monitoring existed, then periodically heals
+// missed/stale obtaining states. A successful live TLS probe is stronger
+// evidence than the "automatic management enabled" log line: it proves the
+// selected Caddy node is actually serving a valid matching certificate.
+func (s *Server) StartCertificateLifecycleReconciler(ctx context.Context) {
+	go func() {
+		run := func() {
+			updated, err := s.reconcileCertificateLifecycle()
+			if err != nil {
+				log.Printf("certificate lifecycle: live reconciliation: %v", err)
+			} else if updated > 0 {
+				log.Printf("certificate lifecycle: confirmed %d previously unknown/stale subject(s)", updated)
+			}
+		}
+		run()
+		ticker := time.NewTicker(certificateProbeEvery)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				run()
+			}
+		}
+	}()
+}
+
+func (s *Server) reconcileCertificateLifecycle() (int, error) {
+	servers, err := models.ListCaddyServers(s.DB)
+	if err != nil {
+		return 0, err
+	}
+	states, err := models.ListCertificateLifecycle(s.DB, 0)
+	if err != nil {
+		return 0, err
+	}
+	stateByServerIdentifier := make(map[string]models.CertificateLifecycleStatus, len(states))
+	for _, state := range states {
+		key := fmt.Sprintf("%d:%s", state.ServerID, models.NormalizeHostname(state.Identifier))
+		stateByServerIdentifier[key] = state
+	}
+
+	type probeJob struct {
+		server      models.CaddyServer
+		target      certificateProbeTarget
+		identifiers []string
+	}
+	var jobs []probeJob
+	now := time.Now().UTC()
+	for _, server := range servers {
+		if server.Type != models.CaddyServerTypeManaged {
+			continue
+		}
+		targets, targetErr := s.certificateProbeTargets(server.ID)
+		if targetErr != nil {
+			return 0, fmt.Errorf("%s: collect certificate probes: %w", server.Name, targetErr)
+		}
+		for _, target := range targets {
+			pending := make([]string, 0, len(target.Identifiers))
+			for _, identifier := range target.Identifiers {
+				key := fmt.Sprintf("%d:%s", server.ID, models.NormalizeHostname(identifier))
+				state, found := stateByServerIdentifier[key]
+				if !found || ((state.Phase == "obtaining" || state.Phase == "renewing") && now.Sub(state.UpdatedAt) >= staleCertificatePhase) {
+					pending = append(pending, identifier)
+				}
+			}
+			if len(pending) > 0 {
+				jobs = append(jobs, probeJob{server: server, target: target, identifiers: pending})
+			}
+		}
+	}
+
+	probe := s.certificateProbeFn
+	if probe == nil {
+		probe = s.probeManagedCertificate
+	}
+	sem := make(chan struct{}, 8)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	updated := 0
+	var failures []string
+	for _, job := range jobs {
+		job := job
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			result := probe(job.server, job.target.Certificate)
+			<-sem
+			if result.Status != "healthy" && result.Status != "expiring" {
+				return
+			}
+			message := "certificate confirmed by live TLS probe"
+			if strings.TrimSpace(result.Issuer) != "" {
+				message += " (issuer: " + strings.TrimSpace(result.Issuer) + ")"
+			}
+			for _, identifier := range job.identifiers {
+				state := models.CertificateLifecycleStatus{
+					ServerID: job.server.ID, ServerName: job.server.Name,
+					Identifier: identifier, Phase: "active", Level: "INFO",
+					Message: message, UpdatedAt: now,
+				}
+				if err := models.UpsertCertificateLifecycle(s.DB, state); err != nil {
+					mu.Lock()
+					failures = append(failures, fmt.Sprintf("%s/%s: %v", job.server.Name, identifier, err))
+					mu.Unlock()
+					continue
+				}
+				mu.Lock()
+				updated++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if len(failures) > 0 {
+		return updated, fmt.Errorf("store probe results: %s", strings.Join(failures, "; "))
+	}
+	return updated, nil
+}
+
+func (s *Server) certificateProbeTargets(serverID int64) ([]certificateProbeTarget, error) {
+	byProbeName := map[string]certificateProbeTarget{}
+	add := func(cert models.Certificate, identifiers []string) {
+		normalized := make([]string, 0, len(identifiers))
+		for _, identifier := range identifiers {
+			if identifier = models.NormalizeHostname(identifier); identifier != "" {
+				normalized = append(normalized, identifier)
+			}
+		}
+		if len(normalized) == 0 {
+			return
+		}
+		cert.Domains = strings.Join(normalized, ",")
+		probeName := managedCertificateProbeName(cert)
+		if probeName == "" {
+			return
+		}
+		if existing, found := byProbeName[probeName]; found {
+			seen := map[string]bool{}
+			for _, identifier := range existing.Identifiers {
+				seen[identifier] = true
+			}
+			for _, identifier := range normalized {
+				if !seen[identifier] {
+					existing.Identifiers = append(existing.Identifiers, identifier)
+				}
+			}
+			byProbeName[probeName] = existing
+			return
+		}
+		byProbeName[probeName] = certificateProbeTarget{Certificate: cert, Identifiers: normalized}
+	}
+
+	certificates, err := models.ListCertificates(s.DB, serverID)
+	if err != nil {
+		return nil, err
+	}
+	for _, cert := range certificates {
+		if cert.Source == models.CertSourceManaged {
+			add(cert, cert.DomainList())
+		}
+	}
+	proxyHosts, err := models.ListProxyHosts(s.DB, serverID, 0, true, nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, host := range proxyHosts {
+		if host.Enabled && host.SSLEnabled && host.CertificateID == 0 {
+			for _, domain := range host.DomainList() {
+				add(models.Certificate{Name: "Auto TLS", Source: models.CertSourceManaged}, []string{domain})
+			}
+		}
+	}
+	redirects, err := models.ListRedirectionHosts(s.DB, serverID, 0, true, nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, redirect := range redirects {
+		if redirect.Enabled && redirect.SSLEnabled && redirect.CertificateID == 0 {
+			for _, domain := range redirect.DomainList() {
+				add(models.Certificate{Name: "Auto TLS", Source: models.CertSourceManaged}, []string{domain})
+			}
+		}
+	}
+	rawRoutes, err := models.ListRawRoutes(s.DB, serverID, 0, true, nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, route := range rawRoutes {
+		if route.Enabled && route.CertificateID == 0 {
+			for _, domain := range rawRouteHosts(route) {
+				add(models.Certificate{Name: "Auto TLS", Source: models.CertSourceManaged}, []string{domain})
+			}
+		}
+	}
+
+	probeNames := make([]string, 0, len(byProbeName))
+	for probeName := range byProbeName {
+		probeNames = append(probeNames, probeName)
+	}
+	sort.Strings(probeNames)
+	out := make([]certificateProbeTarget, 0, len(probeNames))
+	for _, probeName := range probeNames {
+		target := byProbeName[probeName]
+		sort.Strings(target.Identifiers)
+		out = append(out, target)
+	}
+	return out, nil
 }
 
 // ResetRuntimeLogs removes streams left in Caddy's persisted config by a

--- a/internal/server/caddy_logs_test.go
+++ b/internal/server/caddy_logs_test.go
@@ -3,12 +3,83 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/X4Applegate/caddyui/internal/caddylogs"
+	appdb "github.com/X4Applegate/caddyui/internal/db"
 	"github.com/X4Applegate/caddyui/internal/models"
 )
+
+func TestReconcileCertificateLifecycleHealsStaleObtainingButPreservesRetry(t *testing.T) {
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	serverID, err := models.CreateCaddyServer(conn, &models.CaddyServer{
+		Name: "edge", AdminURL: "http://edge:2019", Type: models.CaddyServerTypeManaged,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := models.CreateCertificate(conn, serverID, 0, &models.Certificate{
+		Name: "example", Domains: "example.test", Source: models.CertSourceManaged,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := models.UpsertCertificateLifecycle(conn, models.CertificateLifecycleStatus{
+		ServerID: serverID, ServerName: "edge", Identifier: "example.test",
+		Phase: "obtaining", Level: "INFO", Message: "obtaining certificate",
+		UpdatedAt: time.Now().Add(-time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	probeCalls := 0
+	s := &Server{DB: conn, certificateProbeFn: func(server models.CaddyServer, cert models.Certificate) managedCertificateServerStatus {
+		probeCalls++
+		return managedCertificateServerStatus{ServerID: server.ID, ServerName: server.Name, Status: "healthy", Issuer: "Test CA"}
+	}}
+	updated, err := s.reconcileCertificateLifecycle()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != 1 || probeCalls != 1 {
+		t.Fatalf("updated=%d probeCalls=%d, want 1/1", updated, probeCalls)
+	}
+	states, err := models.ListCertificateLifecycle(conn, serverID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].Phase != "active" || states[0].Identifier != "example.test" {
+		t.Fatalf("reconciled state = %#v", states)
+	}
+
+	if err := models.UpsertCertificateLifecycle(conn, models.CertificateLifecycleStatus{
+		ServerID: serverID, ServerName: "edge", Identifier: "example.test",
+		Phase: "retrying", Level: "ERROR", Message: "will retry", Error: "challenge failed",
+		UpdatedAt: time.Now().Add(time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	probeCalls = 0
+	updated, err = s.reconcileCertificateLifecycle()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != 0 || probeCalls != 0 {
+		t.Fatalf("retry state was probed/overwritten: updated=%d probeCalls=%d", updated, probeCalls)
+	}
+	states, err = models.ListCertificateLifecycle(conn, serverID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].Phase != "retrying" {
+		t.Fatalf("retry state changed: %#v", states)
+	}
+}
 
 func TestDisableRuntimeLogCaptureRetainsStateAfterRemoteFailure(t *testing.T) {
 	admin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/fleet_integrations.go
+++ b/internal/server/fleet_integrations.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/X4Applegate/caddyui/internal/caddy"
 	"github.com/X4Applegate/caddyui/internal/models"
 )
 
@@ -624,23 +625,27 @@ func applyFleetAccessLog(cfg map[string]any, access fleetAccessLogConfig, analyt
 		if !ok {
 			continue
 		}
-		applies := enabled && (access.Scope == "all" || (access.Scope == "https" && name == "srv0") || (access.Scope == "http" && name == "caddyui_http"))
+		fleetApplies := enabled && (access.Scope == "all" || (access.Scope == "https" && name == "srv0") || (access.Scope == "http" && name == "caddyui_http"))
+		applies := analyticsEnabled || fleetApplies
 		logsCfg, _ := srv["logs"].(map[string]any)
 		if applies {
 			if logsCfg == nil {
 				logsCfg = map[string]any{}
 				srv["logs"] = logsCfg
 			}
-			currentLogger, _ := logsCfg["default_logger_name"].(string)
-			if !analyticsEnabled && strings.TrimSpace(currentLogger) == "" {
-				logsCfg["default_logger_name"] = fleetAccessLoggerName
+			// v2.25.0/v2.25.1 selected a CaddyUI-owned logger as the HTTP
+			// server default, which redirected access output away from the
+			// user's console/file logger. Named include rules already tee the
+			// event, so remove only our legacy override and preserve all others.
+			if logsCfg["default_logger_name"] == fleetAccessLoggerName || logsCfg["default_logger_name"] == caddy.AccessLogLoggerName {
+				delete(logsCfg, "default_logger_name")
 			}
 			continue
 		}
 		if logsCfg == nil {
 			continue
 		}
-		if logsCfg["default_logger_name"] == fleetAccessLoggerName {
+		if logsCfg["default_logger_name"] == fleetAccessLoggerName || logsCfg["default_logger_name"] == caddy.AccessLogLoggerName {
 			delete(logsCfg, "default_logger_name")
 		}
 		if len(logsCfg) == 0 {

--- a/internal/server/fleet_integrations_test.go
+++ b/internal/server/fleet_integrations_test.go
@@ -8,7 +8,10 @@ func TestApplyFleetAccessLogPreservesAnalytics(t *testing.T) {
 			"caddyui_access": map[string]any{"include": []any{"http.log.access"}},
 		}},
 		"apps": map[string]any{"http": map[string]any{"servers": map[string]any{
-			"srv0":         map[string]any{"logs": map[string]any{"default_logger_name": "caddyui_access"}},
+			"srv0": map[string]any{"logs": map[string]any{
+				"default_logger_name": "caddyui_access",
+				"logger_names":        map[string]any{"host.example": "custom"},
+			}},
 			"caddyui_http": map[string]any{"listen": []any{":80"}},
 		}}},
 	}
@@ -28,8 +31,11 @@ func TestApplyFleetAccessLogPreservesAnalytics(t *testing.T) {
 	}
 	servers := cfg["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	srv0Logs := servers["srv0"].(map[string]any)["logs"].(map[string]any)
-	if got := srv0Logs["default_logger_name"]; got != "caddyui_access" {
-		t.Fatalf("analytics default logger changed: %v", got)
+	if got := srv0Logs["default_logger_name"]; got != nil {
+		t.Fatalf("legacy analytics default logger remains: %v", got)
+	}
+	if srv0Logs["logger_names"] == nil {
+		t.Fatal("custom per-host logger mapping was removed")
 	}
 	if _, ok := servers["caddyui_http"].(map[string]any)["logs"].(map[string]any); !ok {
 		t.Fatal("HTTP server access logs were not enabled")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -95,9 +95,10 @@ type Server struct {
 	// Runtime Caddy logs share the analytics NDJSON socket but stay in a
 	// bounded in-memory hub. Only the latest certificate lifecycle projection
 	// is persisted. Temporary full-log captures are guarded by expiry timers.
-	caddyLogHub      *caddylogs.Hub
-	runtimeLogMu     sync.Mutex
-	runtimeLogTimers map[int64]*time.Timer
+	caddyLogHub        *caddylogs.Hub
+	runtimeLogMu       sync.Mutex
+	runtimeLogTimers   map[int64]*time.Timer
+	certificateProbeFn func(models.CaddyServer, models.Certificate) managedCertificateServerStatus
 
 	// v2.9.2: HTTP client used by the background per-proxy-host health checker.
 	healthClient *http.Client

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -74,3 +74,39 @@ func TestSettingsPrometheusMetricsControls(t *testing.T) {
 		}
 	}
 }
+
+func TestOperationalTablesExposeRefreshAndSortingControls(t *testing.T) {
+	certificatesHTML, err := FS.ReadFile("templates/certificates.html")
+	if err != nil {
+		t.Fatalf("read certificates.html: %v", err)
+	}
+	certificates := string(certificatesHTML)
+	for _, marker := range []string{
+		`id="refresh-certificate-status"`,
+		`id="certificates-table"`,
+		`id="auto-certificates-table"`,
+		`data-sort-table`,
+		`data-sort-index=`,
+	} {
+		if !strings.Contains(certificates, marker) {
+			t.Fatalf("certificates template missing %s", marker)
+		}
+	}
+
+	serverLogsHTML, err := FS.ReadFile("templates/server_logs.html")
+	if err != nil {
+		t.Fatalf("read server_logs.html: %v", err)
+	}
+	serverLogs := string(serverLogsHTML)
+	for _, marker := range []string{
+		`id="stream-status"`,
+		`id="refresh-logs"`,
+		`data-log-sort="0"`,
+		`data-log-sort="5"`,
+		`source.onopen`,
+	} {
+		if !strings.Contains(serverLogs, marker) {
+			t.Fatalf("server logs template missing %s", marker)
+		}
+	}
+}

--- a/web/templates/certificates.html
+++ b/web/templates/certificates.html
@@ -5,10 +5,11 @@
     <h1 class="text-2xl font-semibold tracking-tight text-ink-900">Certificates</h1>
     <p class="text-sm text-ink-500 mt-1">Upload a certificate or have Caddy obtain and renew one with ACME DNS-01.</p>
   </div>
-  {{/* v2.7.2: + New visible to admin and user roles. View-only accounts
-       can still see the table for reference but can't create a cert. */}}
-  {{if ne .User.Role "view"}}
   <div class="flex items-center gap-2 self-start shrink-0">
+    <button id="refresh-certificate-status" type="button" class="ui-button ui-button--quiet">Refresh status</button>
+    {{/* v2.7.2: + New visible to admin and user roles. View-only accounts
+         can still see the table for reference but can't create a cert. */}}
+    {{if ne .User.Role "view"}}
     {{if .PorkbunConfigured}}
     <a href="/certificates/import/porkbun" class="inline-flex items-center gap-1.5 bg-white hover:bg-ink-50 text-ink-700 text-sm font-medium px-3 py-2 rounded-lg border border-ink-300 shadow-sm transition">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
@@ -19,8 +20,8 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
       New
     </a>
+    {{end}}
   </div>
-  {{end}}
 </div>
 
 {{if eq .UsageFilter "unused"}}
@@ -162,24 +163,24 @@
      windows scroll the other columns under the pinned Actions cell.
      v2.7.2: added Owner column, admin-only, between Source and Expires. */}}
 <div class="hidden lg:block bg-ink-50 border border-ink-200 rounded-xl shadow-card overflow-x-auto">
-  <table class="w-full text-sm min-w-[820px]">
+  <table id="certificates-table" class="w-full text-sm min-w-[820px]" data-sort-table>
     <thead class="bg-ink-100 text-left border-b border-ink-200">
       <tr class="text-xs uppercase tracking-wider text-ink-500">
         {{/* v2.11.10: select-all for bulk-delete. */}}
         <th class="pl-5 py-3 w-8"><input type="checkbox" id="select-all" class="w-4 h-4 rounded border-gray-300"></th>
-        <th class="px-5 py-3 font-medium">Name</th>
-        <th class="px-5 py-3 font-medium">Domains</th>
-        <th class="px-5 py-3 font-medium">Source</th>
-        {{if eq .User.Role "admin"}}<th class="px-5 py-3 font-medium">Owner</th>{{end}}
-        <th class="px-5 py-3 font-medium">Expires</th>
+        <th class="px-5 py-3 font-medium"><button type="button" data-sort-index="1" class="inline-flex items-center gap-1 hover:text-ink-800">Name <span aria-hidden="true">↕</span></button></th>
+        <th class="px-5 py-3 font-medium"><button type="button" data-sort-index="2" class="inline-flex items-center gap-1 hover:text-ink-800">Domains <span aria-hidden="true">↕</span></button></th>
+        <th class="px-5 py-3 font-medium"><button type="button" data-sort-index="3" class="inline-flex items-center gap-1 hover:text-ink-800">Source <span aria-hidden="true">↕</span></button></th>
+        {{if eq .User.Role "admin"}}<th class="px-5 py-3 font-medium"><button type="button" data-sort-index="4" class="inline-flex items-center gap-1 hover:text-ink-800">Owner <span aria-hidden="true">↕</span></button></th>{{end}}
+        <th class="px-5 py-3 font-medium"><button type="button" data-sort-index="{{if eq .User.Role "admin"}}5{{else}}4{{end}}" class="inline-flex items-center gap-1 hover:text-ink-800">Expires / status <span aria-hidden="true">↕</span></button></th>
         <th class="px-5 py-3 font-medium text-center sticky right-0 bg-ink-100 shadow-[-6px_0_8px_-4px_rgba(0,0,0,0.06)] z-10">Actions</th>
       </tr>
     </thead>
-    <tbody class="divide-y divide-ink-200">
+    <tbody class="divide-y divide-ink-200" data-sort-body>
       {{range .Certs}}
-      <tr class="bg-white hover:bg-brand-50/30 transition" data-search="{{.Name}} {{.Domains}} {{.OwnerEmail}}">
+      <tr class="bg-white hover:bg-brand-50/30 transition" data-search="{{.Name}} {{.Domains}} {{.OwnerEmail}}" data-sort-row>
         <td class="pl-5 py-3 w-8">{{if .CanEdit}}<input type="checkbox" class="bulk-check w-4 h-4 rounded border-gray-300" value="{{.ID}}">{{end}}</td>
-        <td class="px-5 py-3">
+        <td class="px-5 py-3" data-sort-value="{{.Name}}">
           <span class="inline-flex items-center gap-1">
             <span class="font-mono text-xs text-ink-800">{{.Name}}</span>
             {{if .IsUnused}}<span class="ui-status ui-status--neutral">Unused</span>{{end}}
@@ -193,8 +194,8 @@
             {{end}}
           </span>
         </td>
-        <td class="px-5 py-3 font-mono text-xs text-ink-600">{{.Domains}}</td>
-        <td class="px-5 py-3">
+        <td class="px-5 py-3 font-mono text-xs text-ink-600" data-sort-value="{{.Domains}}">{{.Domains}}</td>
+        <td class="px-5 py-3" data-sort-value="{{.Source}}">
           {{if eq .Source "managed"}}
             <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700">Managed ACME / DNS-01</span>
           {{else if eq .Source "pem"}}
@@ -204,7 +205,7 @@
           {{end}}
         </td>
         {{if eq $.User.Role "admin"}}
-        <td class="px-5 py-3">
+        <td class="px-5 py-3" data-sort-value="{{if .OwnerEmail}}{{.OwnerEmail}}{{else}}Global{{end}}">
           {{if .OwnerEmail}}
             <span class="inline-flex items-center gap-1 text-xs text-ink-600" title="Owned by {{.OwnerEmail}}">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3 h-3 text-ink-400"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
@@ -218,7 +219,7 @@
           {{end}}
         </td>
         {{end}}
-        <td class="px-5 py-3">
+        <td class="px-5 py-3" data-sort-value="{{if .ExpiresAt}}{{.DaysLeft}}{{else if .Lifecycle}}{{.Lifecycle.Phase}}{{else}}unknown{{end}}">
           {{if .ExpiresAt}}
             {{if lt .DaysLeft 0}}
               <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">Expired</span>
@@ -300,19 +301,19 @@
     <span class="text-xs text-ink-400">Auto-issued by Let's Encrypt / ZeroSSL</span>
   </div>
   <div class="bg-ink-50 border border-ink-200 rounded-xl shadow-card overflow-hidden">
-    <table class="w-full text-sm hidden lg:table">
+    <table id="auto-certificates-table" class="w-full text-sm hidden lg:table" data-sort-table>
       <thead class="bg-ink-100 text-left border-b border-ink-200">
         <tr class="text-xs uppercase tracking-wider text-ink-500">
-          <th class="px-5 py-3 font-medium">Domain</th>
-          <th class="px-5 py-3 font-medium">Certificate</th>
-          <th class="px-5 py-3 font-medium">Managed by</th>
+          <th class="px-5 py-3 font-medium"><button type="button" data-sort-index="0" class="inline-flex items-center gap-1 hover:text-ink-800">Domain <span aria-hidden="true">↕</span></button></th>
+          <th class="px-5 py-3 font-medium"><button type="button" data-sort-index="1" class="inline-flex items-center gap-1 hover:text-ink-800">Certificate <span aria-hidden="true">↕</span></button></th>
+          <th class="px-5 py-3 font-medium"><button type="button" data-sort-index="2" class="inline-flex items-center gap-1 hover:text-ink-800">Managed by <span aria-hidden="true">↕</span></button></th>
         </tr>
       </thead>
-      <tbody class="divide-y divide-ink-200">
+      <tbody class="divide-y divide-ink-200" data-sort-body>
         {{range .AutoDomains}}
-        <tr class="bg-white hover:bg-brand-50/30 transition">
-          <td class="px-5 py-3 font-mono text-xs text-ink-800">{{.Domain}}</td>
-          <td class="px-5 py-3">
+        <tr class="bg-white hover:bg-brand-50/30 transition" data-sort-row>
+          <td class="px-5 py-3 font-mono text-xs text-ink-800" data-sort-value="{{.Domain}}">{{.Domain}}</td>
+          <td class="px-5 py-3" data-sort-value="{{if .UsesWildcard}}{{.CertificateName}}{{else}}{{.Domain}}{{end}}">
             {{if .UsesWildcard}}
               <span class="inline-flex items-center gap-1.5 text-xs text-ink-700" title="Auto TLS is reusing this managed wildcard certificate">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5 text-brand-500"><path d="M12 2v20M2 12h20M4.9 4.9l14.2 14.2M19.1 4.9L4.9 19.1"/></svg>
@@ -322,7 +323,7 @@
               <span class="text-xs text-ink-500" title="Caddy obtains a certificate specifically for this domain">Direct certificate</span>
             {{end}}
           </td>
-          <td class="px-5 py-3">
+          <td class="px-5 py-3" data-sort-value="{{if .Lifecycle}}{{.Lifecycle.Phase}}{{else}}unknown{{end}}">
             {{if .Lifecycle}}
               {{if eq .Lifecycle.Phase "active"}}<span class="ui-status ui-status--success" title="{{.Lifecycle.Message}}">Issued</span>
               {{else if eq .Lifecycle.Phase "obtaining"}}<span class="ui-status ui-status--info" title="{{.Lifecycle.Message}}">Obtaining…</span>
@@ -413,6 +414,48 @@
       syncBar();
     });
   }
+})();
+
+// v2.25.2: client-side status refresh and sortable certificate tables.
+(function() {
+  var refresh = document.getElementById('refresh-certificate-status');
+  if (refresh) refresh.addEventListener('click', function() { window.location.reload(); });
+
+  document.querySelectorAll('[data-sort-table]').forEach(function(table) {
+    var body = table.querySelector('[data-sort-body]');
+    if (!body) return;
+    var activeColumn = -1;
+    var direction = 1;
+
+    function sortRows(column) {
+      var rows = Array.from(body.querySelectorAll('[data-sort-row]'));
+      rows.sort(function(a, b) {
+        var aCell = a.children[column];
+        var bCell = b.children[column];
+        if (!aCell || !bCell) return 0;
+        var aValue = (aCell.dataset.sortValue || aCell.textContent || '').trim();
+        var bValue = (bCell.dataset.sortValue || bCell.textContent || '').trim();
+        var aNumber = Number(aValue);
+        var bNumber = Number(bValue);
+        if (aValue !== '' && bValue !== '' && !isNaN(aNumber) && !isNaN(bNumber)) {
+          return (aNumber - bNumber) * direction;
+        }
+        return aValue.localeCompare(bValue, undefined, {numeric: true, sensitivity: 'base'}) * direction;
+      });
+      rows.forEach(function(row) { body.appendChild(row); });
+    }
+
+    table.querySelectorAll('[data-sort-index]').forEach(function(button) {
+      button.addEventListener('click', function() {
+        var column = parseInt(button.dataset.sortIndex, 10);
+        if (activeColumn === column) direction *= -1;
+        else { activeColumn = column; direction = 1; }
+        table.querySelectorAll('[data-sort-index]').forEach(function(other) { other.removeAttribute('aria-sort'); });
+        button.setAttribute('aria-sort', direction === 1 ? 'ascending' : 'descending');
+        sortRows(column);
+      });
+    });
+  });
 })();
 </script>
 <script>

--- a/web/templates/server_logs.html
+++ b/web/templates/server_logs.html
@@ -9,6 +9,8 @@
   </div>
   <div class="flex items-center gap-2 flex-wrap">
     <span id="capture-status" class="ui-status ui-status--neutral">Checking…</span>
+    <span id="stream-status" class="ui-status ui-status--neutral">Stream connecting…</span>
+    <button id="refresh-logs" type="button" class="ui-button ui-button--quiet">Refresh / reconnect</button>
     <button id="clear-logs" type="button" class="ui-button ui-button--quiet">Clear screen</button>
   </div>
 </div>
@@ -66,12 +68,12 @@
   <table class="w-full text-sm min-w-[980px]">
     <thead class="bg-ink-50/50 text-left">
       <tr class="text-xs uppercase tracking-wider text-ink-500">
-        <th class="px-4 py-3 font-medium">Time</th>
-        <th class="px-4 py-3 font-medium">Server</th>
-        <th class="px-4 py-3 font-medium">Level</th>
-        <th class="px-4 py-3 font-medium">Logger</th>
-        <th class="px-4 py-3 font-medium">Message</th>
-        <th class="px-4 py-3 font-medium">Fields</th>
+        <th class="px-4 py-3 font-medium"><button type="button" data-log-sort="0" class="inline-flex items-center gap-1 hover:text-ink-800">Time <span aria-hidden="true">↕</span></button></th>
+        <th class="px-4 py-3 font-medium"><button type="button" data-log-sort="1" class="inline-flex items-center gap-1 hover:text-ink-800">Server <span aria-hidden="true">↕</span></button></th>
+        <th class="px-4 py-3 font-medium"><button type="button" data-log-sort="2" class="inline-flex items-center gap-1 hover:text-ink-800">Level <span aria-hidden="true">↕</span></button></th>
+        <th class="px-4 py-3 font-medium"><button type="button" data-log-sort="3" class="inline-flex items-center gap-1 hover:text-ink-800">Logger <span aria-hidden="true">↕</span></button></th>
+        <th class="px-4 py-3 font-medium"><button type="button" data-log-sort="4" class="inline-flex items-center gap-1 hover:text-ink-800">Message <span aria-hidden="true">↕</span></button></th>
+        <th class="px-4 py-3 font-medium"><button type="button" data-log-sort="5" class="inline-flex items-center gap-1 hover:text-ink-800">Fields <span aria-hidden="true">↕</span></button></th>
       </tr>
     </thead>
     <tbody id="server-log-body" class="divide-y divide-ink-100 font-mono text-xs"></tbody>
@@ -89,6 +91,7 @@
   var empty = document.getElementById('server-log-empty');
   var count = document.getElementById('log-count');
   var badge = document.getElementById('capture-status');
+  var streamBadge = document.getElementById('stream-status');
   var detail = document.getElementById('capture-detail');
   var enable = document.getElementById('enable-capture');
   var disable = document.getElementById('disable-capture');
@@ -96,12 +99,19 @@
   var cursor = 0;
   var captures = [];
   var maxRows = 500;
+  var sortColumn = -1;
+  var sortDirection = 1;
 
   function selectedID() { return parseInt(server && server.value || '0', 10); }
 
   function setStatus(message, kind) {
     badge.textContent = message;
     badge.className = 'ui-status ' + (kind === 'active' ? 'ui-status--success' : kind === 'error' ? 'ui-status--danger' : 'ui-status--neutral');
+  }
+
+  function setStreamStatus(message, kind) {
+    streamBadge.textContent = message;
+    streamBadge.className = 'ui-status ' + (kind === 'active' ? 'ui-status--success' : kind === 'error' ? 'ui-status--warning' : 'ui-status--neutral');
   }
 
   function refreshStatus() {
@@ -142,12 +152,29 @@
     return 'bg-emerald-50 text-emerald-700';
   }
 
-  function addCell(row, text, className) {
+  function addCell(row, text, className, sortValue) {
     var cell = document.createElement('td');
     cell.className = className || 'px-4 py-2.5 align-top text-ink-600';
     cell.textContent = text || '—';
+    if (sortValue !== undefined) cell.dataset.sortValue = String(sortValue);
     row.appendChild(cell);
     return cell;
+  }
+
+  function sortRows() {
+    if (sortColumn < 0) return;
+    var rows = Array.from(body.querySelectorAll('tr'));
+    rows.sort(function(a, b) {
+      var aCell = a.children[sortColumn];
+      var bCell = b.children[sortColumn];
+      var aValue = (aCell.dataset.sortValue || aCell.textContent || '').trim();
+      var bValue = (bCell.dataset.sortValue || bCell.textContent || '').trim();
+      var aNumber = Number(aValue);
+      var bNumber = Number(bValue);
+      if (aValue !== '' && bValue !== '' && !isNaN(aNumber) && !isNaN(bNumber)) return (aNumber - bNumber) * sortDirection;
+      return aValue.localeCompare(bValue, undefined, {numeric: true, sensitivity: 'base'}) * sortDirection;
+    });
+    rows.forEach(function(row) { body.appendChild(row); });
   }
 
   function applyFilter(row) {
@@ -165,7 +192,7 @@
     var fieldText = entry.fields && Object.keys(entry.fields).length ? JSON.stringify(entry.fields) : '';
     row.dataset.search = ((entry.logger || '') + ' ' + (entry.message || '') + ' ' + fieldText).toLowerCase();
     row.className = 'hover:bg-ink-50/60 transition';
-    addCell(row, new Date(entry.ts).toLocaleTimeString(), 'px-4 py-2.5 align-top whitespace-nowrap text-ink-500');
+    addCell(row, new Date(entry.ts).toLocaleTimeString(), 'px-4 py-2.5 align-top whitespace-nowrap text-ink-500', Date.parse(entry.ts));
     addCell(row, entry.server_name || ('Server ' + entry.server_id), 'px-4 py-2.5 align-top whitespace-nowrap text-ink-700');
     var levelCell = addCell(row, '', 'px-4 py-2.5 align-top');
     var levelBadge = document.createElement('span');
@@ -178,6 +205,7 @@
     applyFilter(row);
     body.appendChild(row);
     while (body.children.length > maxRows) body.removeChild(body.firstChild);
+    sortRows();
   }
 
   function updateCount() {
@@ -189,7 +217,9 @@
   function connect() {
     if (!server || !server.value) return;
     if (source) source.close();
+    setStreamStatus('Stream connecting…', 'neutral');
     source = new EventSource('/api/server-logs/stream?server=' + encodeURIComponent(server.value) + '&since=' + cursor);
+    source.onopen = function() { setStreamStatus('Stream live', 'active'); };
     source.onmessage = function(event) {
       var entries;
       try { entries = JSON.parse(event.data); } catch (_) { return; }
@@ -197,7 +227,7 @@
       entries.forEach(function(entry) { if (entry.id > cursor) cursor = entry.id; addEntry(entry); });
       updateCount();
     };
-    source.onerror = function() { if (!captures.length) setStatus('Stream reconnecting…', 'error'); };
+    source.onerror = function() { setStreamStatus('Stream reconnecting…', 'error'); };
   }
 
   if (server) server.addEventListener('change', function() {
@@ -210,6 +240,17 @@
   filter.addEventListener('input', function() { body.querySelectorAll('tr').forEach(applyFilter); });
   visibleLevel.addEventListener('change', function() { body.querySelectorAll('tr').forEach(applyFilter); });
   document.getElementById('clear-logs').addEventListener('click', function() { body.replaceChildren(); updateCount(); });
+  document.getElementById('refresh-logs').addEventListener('click', function() { refreshStatus(); connect(); });
+  document.querySelectorAll('[data-log-sort]').forEach(function(button) {
+    button.addEventListener('click', function() {
+      var nextColumn = parseInt(button.dataset.logSort, 10);
+      if (sortColumn === nextColumn) sortDirection *= -1;
+      else { sortColumn = nextColumn; sortDirection = 1; }
+      document.querySelectorAll('[data-log-sort]').forEach(function(other) { other.removeAttribute('aria-sort'); });
+      button.setAttribute('aria-sort', sortDirection === 1 ? 'ascending' : 'descending');
+      sortRows();
+    });
+  });
   enable.addEventListener('click', function() { post('/api/server-logs/enable'); });
   disable.addEventListener('click', function() { post('/api/server-logs/disable'); });
   refreshStatus();


### PR DESCRIPTION
## Summary

- preserve Caddy's existing default, console, journal, file, and per-host loggers while teeing access events to CaddyUI
- repair the legacy `caddyui_access` / `caddyui_file_access` default-logger overrides written by v2.25.0 and v2.25.1
- keep successful certificate issuance in the Issued state after `tls.obtain` cleanup events
- bootstrap missing or stale lifecycle state from a live TLS certificate probe at startup and hourly
- add stream connection state, manual refresh/reconnect, and sortable certificate/log tables

## Verification

- `go test ./internal/caddy ./internal/caddylogs ./internal/server ./web`
- `go test -race ./...`
- `go vet ./...`
- `go build ./cmd/caddyui`
- MariaDB 11.4 schema and SQLite-to-MariaDB migration tests
- isolated Caddy 2.11.4 config validation and access-log tee smoke test

Follow-up to #26.
