### PR TITLE
fix: address observability review follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.25.3] - 2026-08-15 - Certificate and log-stream review follow-up
+
+### Fixed
+
+- The persistent certificate monitor now receives Caddy's DEBUG `events/cert_obtained` records through a dedicated named logger while filtering unrelated event and TLS debug traffic out of the in-memory Server Logs ring.
+- Startup certificate reconciliation probes and verifies every identifier independently. A valid certificate for one name in a multi-domain managed definition can no longer mark unverified sibling names as Issued.
+- Server Logs retention now evicts the oldest entry ID when the 500-row display limit is reached, regardless of the active visual sort order.
+
+### Changed
+
+- Added regression coverage for all three late automated review findings on PR #31.
+
 ## [2.25.2] - 2026-08-14 - Observability reliability follow-up
 
 ### Fixed

--- a/internal/caddy/accesslog.go
+++ b/internal/caddy/accesslog.go
@@ -14,12 +14,14 @@ import (
 // toggles don't leak duplicate loggers into the Caddy config.
 const AccessLogLoggerName = "caddyui_access"
 
-// CertificateLogLoggerName is the low-volume, always-on stream CaddyUI uses
-// to observe certificate issuance and renewal. RuntimeLogLoggerName is the
-// temporary, admin-controlled stream used by the Server Logs page.
+// CertificateLogLoggerName and CertificateEventLogLoggerName are the
+// always-on streams CaddyUI uses to observe INFO TLS lifecycle messages and
+// DEBUG structured certificate events respectively. RuntimeLogLoggerName is
+// the temporary, admin-controlled stream used by the Server Logs page.
 const (
-	CertificateLogLoggerName = "caddyui_certificates"
-	RuntimeLogLoggerName     = "caddyui_runtime"
+	CertificateLogLoggerName      = "caddyui_certificates"
+	CertificateEventLogLoggerName = "caddyui_certificate_events"
+	RuntimeLogLoggerName          = "caddyui_runtime"
 )
 
 // AccessLogDeleteMethod is exposed so callers can tell what HTTP verb the
@@ -57,10 +59,13 @@ func networkLogWriter(target string, opts AccessLogOptions) map[string]any {
 // server that produced it. The append encoder is part of Caddy core and uses
 // a JSON encoder underneath, so the ingest path receives normal structured
 // logs plus stable source metadata without changing route handlers.
-func annotatedJSONEncoder(opts AccessLogOptions) map[string]any {
+func annotatedJSONEncoder(opts AccessLogOptions, stream string) map[string]any {
 	fields := map[string]any{
 		"caddyui_server_id":   opts.ServerID,
 		"caddyui_server_name": strings.TrimSpace(opts.ServerName),
+	}
+	if stream = strings.TrimSpace(stream); stream != "" {
+		fields["caddyui_stream"] = stream
 	}
 	return map[string]any{
 		"format": "append",
@@ -133,7 +138,7 @@ func (c *Client) EnableAccessLogs(target string, opts AccessLogOptions) error {
 	// the call is create-or-replace — PATCH would 404 on first run.
 	logger := map[string]any{
 		"writer":  networkLogWriter(target, opts),
-		"encoder": annotatedJSONEncoder(opts),
+		"encoder": annotatedJSONEncoder(opts, ""),
 		"include": []string{"http.log.access"},
 	}
 	if err := c.installNamedLog(AccessLogLoggerName, logger); err != nil {
@@ -168,11 +173,11 @@ func (c *Client) EnableAccessLogs(target string, opts AccessLogOptions) error {
 	return nil
 }
 
-// EnableCertificateLogs duplicates Caddy's TLS runtime log namespace to the
-// CaddyUI ingest socket. Caddy's default logger remains unchanged, so normal
-// container/journal logs continue to receive the same messages. The stream is
-// intentionally INFO-level and low-volume; CaddyUI persists only the latest
-// lifecycle state per server and certificate identifier.
+// EnableCertificateLogs duplicates Caddy's INFO TLS namespace plus its DEBUG
+// structured events namespace to the CaddyUI ingest socket. The separate
+// event logger is required because cert_obtained is emitted by logger=events
+// at DEBUG rather than beneath the tls namespace. Caddy's default logger
+// remains unchanged, and the ingest hub discards unrelated event/debug lines.
 func (c *Client) EnableCertificateLogs(target string, opts AccessLogOptions) error {
 	target = strings.TrimSpace(target)
 	if target == "" {
@@ -180,12 +185,21 @@ func (c *Client) EnableCertificateLogs(target string, opts AccessLogOptions) err
 	}
 	logger := map[string]any{
 		"writer":  networkLogWriter(target, opts),
-		"encoder": annotatedJSONEncoder(opts),
+		"encoder": annotatedJSONEncoder(opts, "certificates"),
 		"include": []string{"tls"},
 		"level":   "INFO",
 	}
 	if err := c.installNamedLog(CertificateLogLoggerName, logger); err != nil {
 		return fmt.Errorf("install certificate logger: %w", err)
+	}
+	eventLogger := map[string]any{
+		"writer":  networkLogWriter(target, opts),
+		"encoder": annotatedJSONEncoder(opts, "certificates"),
+		"include": []string{"events"},
+		"level":   "DEBUG",
+	}
+	if err := c.installNamedLog(CertificateEventLogLoggerName, eventLogger); err != nil {
+		return fmt.Errorf("install certificate event logger: %w", err)
 	}
 	return nil
 }
@@ -207,7 +221,7 @@ func (c *Client) EnableRuntimeLogs(target, level string, opts AccessLogOptions) 
 	}
 	logger := map[string]any{
 		"writer":  networkLogWriter(target, opts),
-		"encoder": annotatedJSONEncoder(opts),
+		"encoder": annotatedJSONEncoder(opts, ""),
 		"exclude": []string{"http.log.access", "tls"},
 		"level":   level,
 	}

--- a/internal/caddy/accesslog_test.go
+++ b/internal/caddy/accesslog_test.go
@@ -85,6 +85,8 @@ func TestInstallNamedLogFallbackPreservesWholeLoggingConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/config/logging/logs/"+CertificateEventLogLoggerName:
+			w.WriteHeader(http.StatusOK)
 		default:
 			http.Error(w, "unexpected request", http.StatusNotFound)
 		}
@@ -208,6 +210,8 @@ func TestRuntimeAndCertificateLoggersAreAdditiveAndScoped(t *testing.T) {
 			name = RuntimeLogLoggerName
 		case "/config/logging/logs/" + CertificateLogLoggerName:
 			name = CertificateLogLoggerName
+		case "/config/logging/logs/" + CertificateEventLogLoggerName:
+			name = CertificateEventLogLoggerName
 		}
 		if r.Method != http.MethodPost || name == "" {
 			http.Error(w, "unexpected request", http.StatusNotFound)
@@ -234,6 +238,19 @@ func TestRuntimeAndCertificateLoggersAreAdditiveAndScoped(t *testing.T) {
 	include, _ := certificate["include"].([]any)
 	if len(include) != 1 || include[0] != "tls" {
 		t.Fatalf("certificate include = %#v", certificate["include"])
+	}
+	if certificate["level"] != "INFO" {
+		t.Fatalf("certificate level = %#v, want INFO", certificate["level"])
+	}
+	events := loggers[CertificateEventLogLoggerName]
+	eventInclude, _ := events["include"].([]any)
+	if len(eventInclude) != 1 || eventInclude[0] != "events" || events["level"] != "DEBUG" {
+		t.Fatalf("certificate event logger = %#v", events)
+	}
+	eventEncoder, _ := events["encoder"].(map[string]any)
+	eventFields, _ := eventEncoder["fields"].(map[string]any)
+	if eventFields["caddyui_stream"] != "certificates" {
+		t.Fatalf("certificate event stream field = %#v", eventFields)
 	}
 	runtime := loggers[RuntimeLogLoggerName]
 	if runtime["level"] != "DEBUG" {

--- a/internal/caddylogs/hub.go
+++ b/internal/caddylogs/hub.go
@@ -17,6 +17,8 @@ import (
 
 const maxEntries = 1000
 
+const certificateMonitorStream = "certificates"
+
 type Entry struct {
 	ID         uint64         `json:"id"`
 	TS         time.Time      `json:"ts"`
@@ -80,6 +82,13 @@ func (h *Hub) AcceptLine(line []byte) {
 	if entry.Level == "" {
 		entry.Level = "INFO"
 	}
+	states := certificateStates(entry, raw)
+	// The always-on certificate event logger must subscribe to logger=events
+	// at DEBUG to receive cert_obtained. Do not let unrelated structured events
+	// or verbose TLS diagnostics fill the operational in-memory ring.
+	if strings.TrimSpace(stringField(raw["caddyui_stream"])) == certificateMonitorStream && len(states) == 0 {
+		return
+	}
 
 	h.mu.Lock()
 	h.nextID++
@@ -91,7 +100,6 @@ func (h *Hub) AcceptLine(line []byte) {
 	}
 	h.mu.Unlock()
 
-	states := certificateStates(entry, raw)
 	if len(states) == 0 || h.DB == nil {
 		return
 	}
@@ -157,7 +165,7 @@ func remainingFields(raw map[string]any) map[string]any {
 	fields := make(map[string]any, len(raw))
 	for key, value := range raw {
 		switch key {
-		case "ts", "level", "logger", "msg", "caddyui_server_id", "caddyui_server_name":
+		case "ts", "level", "logger", "msg", "caddyui_server_id", "caddyui_server_name", "caddyui_stream":
 			continue
 		}
 		fields[key] = value

--- a/internal/caddylogs/hub_test.go
+++ b/internal/caddylogs/hub_test.go
@@ -86,13 +86,24 @@ func TestHubPersistsStructuredCertObtainedEvent(t *testing.T) {
 	t.Cleanup(func() { _ = conn.Close() })
 
 	hub := New(conn)
-	hub.AcceptLine([]byte(`{"level":"debug","ts":1700000004,"logger":"events","msg":"event","name":"cert_obtained","data":{"identifier":"event.example","issuer":"acme.example","renewal":false},"caddyui_server_id":7,"caddyui_server_name":"west"}`))
+	hub.AcceptLine([]byte(`{"level":"debug","ts":1700000004,"logger":"events","msg":"event","name":"config_loaded","caddyui_stream":"certificates","caddyui_server_id":7,"caddyui_server_name":"west"}`))
+	if entries := hub.Since(0, 7, 20); len(entries) != 0 {
+		t.Fatalf("unrelated persistent event leaked into runtime ring: %#v", entries)
+	}
+	hub.AcceptLine([]byte(`{"level":"debug","ts":1700000005,"logger":"events","msg":"event","name":"cert_obtained","data":{"identifier":"event.example","issuer":"acme.example","renewal":false},"caddyui_stream":"certificates","caddyui_server_id":7,"caddyui_server_name":"west"}`))
 	states, err := models.ListCertificateLifecycle(conn, 7)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(states) != 1 || states[0].Identifier != "event.example" || states[0].Phase != "active" {
 		t.Fatalf("cert_obtained state = %#v, want active event.example", states)
+	}
+	entries := hub.Since(0, 7, 20)
+	if len(entries) != 1 || entries[0].Logger != "events" {
+		t.Fatalf("certificate event entries = %#v", entries)
+	}
+	if _, leaked := entries[0].Fields["caddyui_stream"]; leaked {
+		t.Fatalf("internal stream marker leaked into displayed fields: %#v", entries[0].Fields)
 	}
 }
 

--- a/internal/server/caddy_logs.go
+++ b/internal/server/caddy_logs.go
@@ -26,7 +26,7 @@ const (
 
 type certificateProbeTarget struct {
 	Certificate models.Certificate
-	Identifiers []string
+	Identifier  string
 }
 
 func caddyLogOptions(server models.CaddyServer, cfg analyticsConfig) caddy.AccessLogOptions {
@@ -109,9 +109,8 @@ func (s *Server) reconcileCertificateLifecycle() (int, error) {
 	}
 
 	type probeJob struct {
-		server      models.CaddyServer
-		target      certificateProbeTarget
-		identifiers []string
+		server models.CaddyServer
+		target certificateProbeTarget
 	}
 	var jobs []probeJob
 	now := time.Now().UTC()
@@ -124,16 +123,10 @@ func (s *Server) reconcileCertificateLifecycle() (int, error) {
 			return 0, fmt.Errorf("%s: collect certificate probes: %w", server.Name, targetErr)
 		}
 		for _, target := range targets {
-			pending := make([]string, 0, len(target.Identifiers))
-			for _, identifier := range target.Identifiers {
-				key := fmt.Sprintf("%d:%s", server.ID, models.NormalizeHostname(identifier))
-				state, found := stateByServerIdentifier[key]
-				if !found || ((state.Phase == "obtaining" || state.Phase == "renewing") && now.Sub(state.UpdatedAt) >= staleCertificatePhase) {
-					pending = append(pending, identifier)
-				}
-			}
-			if len(pending) > 0 {
-				jobs = append(jobs, probeJob{server: server, target: target, identifiers: pending})
+			key := fmt.Sprintf("%d:%s", server.ID, models.NormalizeHostname(target.Identifier))
+			state, found := stateByServerIdentifier[key]
+			if !found || ((state.Phase == "obtaining" || state.Phase == "renewing") && now.Sub(state.UpdatedAt) >= staleCertificatePhase) {
+				jobs = append(jobs, probeJob{server: server, target: target})
 			}
 		}
 	}
@@ -162,22 +155,21 @@ func (s *Server) reconcileCertificateLifecycle() (int, error) {
 			if strings.TrimSpace(result.Issuer) != "" {
 				message += " (issuer: " + strings.TrimSpace(result.Issuer) + ")"
 			}
-			for _, identifier := range job.identifiers {
-				state := models.CertificateLifecycleStatus{
-					ServerID: job.server.ID, ServerName: job.server.Name,
-					Identifier: identifier, Phase: "active", Level: "INFO",
-					Message: message, UpdatedAt: now,
-				}
-				if err := models.UpsertCertificateLifecycle(s.DB, state); err != nil {
-					mu.Lock()
-					failures = append(failures, fmt.Sprintf("%s/%s: %v", job.server.Name, identifier, err))
-					mu.Unlock()
-					continue
-				}
-				mu.Lock()
-				updated++
-				mu.Unlock()
+			identifier := job.target.Identifier
+			state := models.CertificateLifecycleStatus{
+				ServerID: job.server.ID, ServerName: job.server.Name,
+				Identifier: identifier, Phase: "active", Level: "INFO",
+				Message: message, UpdatedAt: now,
 			}
+			if err := models.UpsertCertificateLifecycle(s.DB, state); err != nil {
+				mu.Lock()
+				failures = append(failures, fmt.Sprintf("%s/%s: %v", job.server.Name, identifier, err))
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			updated++
+			mu.Unlock()
 		}()
 	}
 	wg.Wait()
@@ -188,36 +180,23 @@ func (s *Server) reconcileCertificateLifecycle() (int, error) {
 }
 
 func (s *Server) certificateProbeTargets(serverID int64) ([]certificateProbeTarget, error) {
-	byProbeName := map[string]certificateProbeTarget{}
+	byIdentifier := map[string]certificateProbeTarget{}
 	add := func(cert models.Certificate, identifiers []string) {
-		normalized := make([]string, 0, len(identifiers))
 		for _, identifier := range identifiers {
-			if identifier = models.NormalizeHostname(identifier); identifier != "" {
-				normalized = append(normalized, identifier)
+			identifier = models.NormalizeHostname(identifier)
+			if identifier == "" {
+				continue
 			}
-		}
-		if len(normalized) == 0 {
-			return
-		}
-		cert.Domains = strings.Join(normalized, ",")
-		probeName := managedCertificateProbeName(cert)
-		if probeName == "" {
-			return
-		}
-		if existing, found := byProbeName[probeName]; found {
-			seen := map[string]bool{}
-			for _, identifier := range existing.Identifiers {
-				seen[identifier] = true
+			if _, found := byIdentifier[identifier]; found {
+				continue
 			}
-			for _, identifier := range normalized {
-				if !seen[identifier] {
-					existing.Identifiers = append(existing.Identifiers, identifier)
-				}
+			probeCert := cert
+			probeCert.Domains = identifier
+			if managedCertificateProbeName(probeCert) == "" {
+				continue
 			}
-			byProbeName[probeName] = existing
-			return
+			byIdentifier[identifier] = certificateProbeTarget{Certificate: probeCert, Identifier: identifier}
 		}
-		byProbeName[probeName] = certificateProbeTarget{Certificate: cert, Identifiers: normalized}
 	}
 
 	certificates, err := models.ListCertificates(s.DB, serverID)
@@ -263,16 +242,14 @@ func (s *Server) certificateProbeTargets(serverID int64) ([]certificateProbeTarg
 		}
 	}
 
-	probeNames := make([]string, 0, len(byProbeName))
-	for probeName := range byProbeName {
-		probeNames = append(probeNames, probeName)
+	identifiers := make([]string, 0, len(byIdentifier))
+	for identifier := range byIdentifier {
+		identifiers = append(identifiers, identifier)
 	}
-	sort.Strings(probeNames)
-	out := make([]certificateProbeTarget, 0, len(probeNames))
-	for _, probeName := range probeNames {
-		target := byProbeName[probeName]
-		sort.Strings(target.Identifiers)
-		out = append(out, target)
+	sort.Strings(identifiers)
+	out := make([]certificateProbeTarget, 0, len(identifiers))
+	for _, identifier := range identifiers {
+		out = append(out, byIdentifier[identifier])
 	}
 	return out, nil
 }

--- a/internal/server/caddy_logs_test.go
+++ b/internal/server/caddy_logs_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -78,6 +79,49 @@ func TestReconcileCertificateLifecycleHealsStaleObtainingButPreservesRetry(t *te
 	}
 	if len(states) != 1 || states[0].Phase != "retrying" {
 		t.Fatalf("retry state changed: %#v", states)
+	}
+}
+
+func TestReconcileCertificateLifecycleProbesEveryIdentifierIndependently(t *testing.T) {
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	serverID, err := models.CreateCaddyServer(conn, &models.CaddyServer{
+		Name: "edge", AdminURL: "http://edge:2019", Type: models.CaddyServerTypeManaged,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := models.CreateCertificate(conn, serverID, 0, &models.Certificate{
+		Name: "multi-domain", Domains: "active.example, pending.example", Source: models.CertSourceManaged,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var probeCalls atomic.Int32
+	s := &Server{DB: conn, certificateProbeFn: func(server models.CaddyServer, cert models.Certificate) managedCertificateServerStatus {
+		probeCalls.Add(1)
+		status := "unavailable"
+		if cert.Domains == "active.example" {
+			status = "healthy"
+		}
+		return managedCertificateServerStatus{ServerID: server.ID, ServerName: server.Name, Status: status}
+	}}
+	updated, err := s.reconcileCertificateLifecycle()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != 1 || probeCalls.Load() != 2 {
+		t.Fatalf("updated=%d probeCalls=%d, want 1/2", updated, probeCalls.Load())
+	}
+	states, err := models.ListCertificateLifecycle(conn, serverID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].Identifier != "active.example" || states[0].Phase != "active" {
+		t.Fatalf("independent probe states = %#v", states)
 	}
 }
 

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -104,9 +104,14 @@ func TestOperationalTablesExposeRefreshAndSortingControls(t *testing.T) {
 		`data-log-sort="0"`,
 		`data-log-sort="5"`,
 		`source.onopen`,
+		`body.querySelectorAll('[data-entry-id]')`,
+		`Number(item.dataset.entryId)`,
 	} {
 		if !strings.Contains(serverLogs, marker) {
 			t.Fatalf("server logs template missing %s", marker)
 		}
+	}
+	if strings.Contains(serverLogs, "removeChild(body.firstChild)") {
+		t.Fatal("server log retention must evict by entry ID, not visual sort order")
 	}
 }

--- a/web/templates/server_logs.html
+++ b/web/templates/server_logs.html
@@ -204,7 +204,14 @@
     addCell(row, fieldText, 'px-4 py-2.5 align-top text-ink-500 break-all max-w-md');
     applyFilter(row);
     body.appendChild(row);
-    while (body.children.length > maxRows) body.removeChild(body.firstChild);
+    while (body.children.length > maxRows) {
+      var oldest = Array.from(body.querySelectorAll('[data-entry-id]')).reduce(function(candidate, item) {
+        if (!candidate) return item;
+        return Number(item.dataset.entryId) < Number(candidate.dataset.entryId) ? item : candidate;
+      }, null);
+      if (!oldest) break;
+      oldest.remove();
+    }
     sortRows();
   }
 


### PR DESCRIPTION
## Summary

- capture structured certificate events through a dedicated DEBUG logger while filtering unrelated persistent traffic
- probe each managed certificate identifier independently during startup reconciliation
- evict the oldest Server Logs entry by ID regardless of visual sort order
- add regression coverage and the v2.25.3 changelog entry

## Validation

- go test ./...
- go test -race ./...
- go vet ./...
- go build ./cmd/caddyui
- MariaDB schema/core/migration tests against an isolated database
- Caddy 2.11.4 config validation and isolated HTTP/logger smoke test

## Context

Addresses the three late automated review findings on PR #31:

- https://github.com/X4Applegate/caddyui/pull/31#discussion_r3788778766
- https://github.com/X4Applegate/caddyui/pull/31#discussion_r3788778767
- https://github.com/X4Applegate/caddyui/pull/31#discussion_r3788778768