### PR TITLE
fix: scope Operations data to selected node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.25.4] - 2026-08-18 - Operations fleet-node scoping
+
+### Fixed
+
+- Operations traffic totals and sparklines now filter by the selected fleet node as well as hostname, so shared domains no longer merge traffic from multiple Caddy servers.
+- The Operations Caddy-version lookup and upstream telemetry now use the selected node's Admin API and saved Basic Auth credentials instead of the bootstrap Caddy client or an unauthenticated request.
+- The System health panel now clearly separates CaddyUI-host uptime/load/memory from selected-node Caddy request/upstream telemetry, and the certificate tile is labeled as selected-node certificate definitions.
+
 ## [2.25.3] - 2026-08-15 - Certificate and log-stream review follow-up
 
 ### Fixed

--- a/internal/caddy/client.go
+++ b/internal/caddy/client.go
@@ -120,10 +120,11 @@ type CaddyVersion struct {
 	Version string `json:"version"`
 }
 
-// GetVersion fetches Caddy's version from the admin API root endpoint.
-// Falls back to the CADDY_VERSION environment variable when the admin API
-// does not expose a version endpoint (custom builds, older instances).
-func (c *Client) GetVersion(ctx context.Context) (string, error) {
+// GetVersionFromAdmin fetches Caddy's version from this client's admin API
+// root endpoint without consulting process-local environment variables. Fleet
+// callers need this strict form so a failed remote lookup cannot accidentally
+// report the CaddyUI host's CADDY_VERSION for a different node.
+func (c *Client) GetVersionFromAdmin(ctx context.Context) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.AdminURL+"/", nil)
 	if err == nil {
 		c.applyAuth(req)
@@ -137,6 +138,16 @@ func (c *Client) GetVersion(ctx context.Context) (string, error) {
 				}
 			}
 		}
+	}
+	return "", fmt.Errorf("caddy version unavailable")
+}
+
+// GetVersion fetches Caddy's version from the admin API root endpoint.
+// Falls back to the CADDY_VERSION environment variable when the admin API
+// does not expose a version endpoint (custom builds, older instances).
+func (c *Client) GetVersion(ctx context.Context) (string, error) {
+	if version, err := c.GetVersionFromAdmin(ctx); err == nil {
+		return version, nil
 	}
 	// Admin API root unavailable — fall back to CADDY_VERSION env var.
 	if ev := os.Getenv("CADDY_VERSION"); ev != "" {
@@ -2921,8 +2932,8 @@ func BuildProxyRoute(p models.ProxyHost, advancedHandlers []any) map[string]any 
 		switch rule.Type {
 		case "strip_prefix":
 			// Rewrite /prefix/rest → /rest
-				handlers = append(handlers, map[string]any{
-					"handler":            "rewrite",
+			handlers = append(handlers, map[string]any{
+				"handler":           "rewrite",
 				"strip_path_prefix": from,
 			})
 		case "add_prefix":
@@ -3074,7 +3085,12 @@ func BuildProxyRoute(p models.ProxyHost, advancedHandlers []any) map[string]any 
 		maintenanceBody := `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Maintenance</title><style>*{box-sizing:border-box}body{font-family:system-ui,sans-serif;background:#f8fafc;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}.card{background:#fff;border-radius:16px;padding:40px 48px;text-align:center;box-shadow:0 4px 32px rgba(0,0,0,.08);max-width:480px}h1{font-size:1.5rem;color:#1e293b;margin:16px 0 8px}p{color:#64748b;font-size:.95rem;line-height:1.6;margin:0}</style></head><body><div class="card"><svg width="48" height="48" fill="none" stroke="#f59e0b" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 010-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 01-1.44-4.282m3.102.069a18.03 18.03 0 01-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 018.835 2.535M10.34 6.66a23.847 23.847 0 008.835-2.535m0 0A23.74 23.74 0 0018.795 3m.38 1.125a23.91 23.91 0 011.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 001.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 010 3.46"/></svg><h1>Down for Maintenance</h1><p>` + htmlEscape(msgOrDefault(p.MaintenanceMsg, "We're making improvements and will be back shortly. Thank you for your patience.")) + `</p></div></body></html>`
 		maintHeaders := map[string]any{
 			"Content-Type": []any{"text/html; charset=utf-8"},
-			"Retry-After":  []any{func() string { if p.MaintenanceRetryAfterSec > 0 { return strconv.Itoa(p.MaintenanceRetryAfterSec) }; return "3600" }()},
+			"Retry-After": []any{func() string {
+				if p.MaintenanceRetryAfterSec > 0 {
+					return strconv.Itoa(p.MaintenanceRetryAfterSec)
+				}
+				return "3600"
+			}()},
 		}
 		// v2.9.100: maintenance_custom_headers — extra "Name: Value" headers on the 503 response.
 		if p.MaintenanceCustomHeaders != "" {

--- a/internal/caddy/client_test.go
+++ b/internal/caddy/client_test.go
@@ -1,0 +1,24 @@
+package caddy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetVersionFromAdminDoesNotUseProcessFallback(t *testing.T) {
+	t.Setenv("CADDY_VERSION", "v2.99.0-local")
+	admin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "version unavailable", http.StatusServiceUnavailable)
+	}))
+	defer admin.Close()
+
+	client := New(admin.URL, "", "")
+	if version, err := client.GetVersionFromAdmin(context.Background()); err == nil || version != "" {
+		t.Fatalf("strict admin version = %q, err=%v; want an error without local fallback", version, err)
+	}
+	if version, err := client.GetVersion(context.Background()); err != nil || version != "v2.99.0-local" {
+		t.Fatalf("compatibility version = %q, err=%v; want process fallback", version, err)
+	}
+}

--- a/internal/server/dashboard_scope_test.go
+++ b/internal/server/dashboard_scope_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/X4Applegate/caddyui/internal/auth"
+	"github.com/X4Applegate/caddyui/internal/caddy"
+	appdb "github.com/X4Applegate/caddyui/internal/db"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+func TestOperationsTrafficAndCertificatesUseSelectedFleetServer(t *testing.T) {
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	primaryID, err := models.CreateCaddyServer(conn, &models.CaddyServer{
+		Name: "primary", AdminURL: "http://primary.invalid:2019",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selectedID, err := models.CreateCaddyServer(conn, &models.CaddyServer{
+		Name: "selected", AdminURL: "http://selected.invalid:2019",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, serverID := range []int64{primaryID, selectedID} {
+		if _, err := models.CreateProxyHost(conn, serverID, 0, &models.ProxyHost{
+			Domains: "shared.test", ForwardScheme: "http", ForwardHost: "backend", ForwardPort: 8080, Enabled: true,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := models.CreateCertificate(conn, primaryID, 0, &models.Certificate{Name: "primary-cert"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"selected-cert-a", "selected-cert-b"} {
+		if _, err := models.CreateCertificate(conn, selectedID, 0, &models.Certificate{Name: name}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Keep fixtures inside today's UTC bucket even when the test starts during
+	// the first minute after midnight.
+	now := time.Now().UTC().Truncate(24 * time.Hour).Add(time.Hour)
+	events := []models.AccessEvent{
+		{TS: now, ServerID: primaryID, ServerName: "primary", Host: "shared.test", ClientIP: "192.0.2.1", BytesOut: 100},
+		{TS: now, ServerID: selectedID, ServerName: "selected", Host: "shared.test", ClientIP: "192.0.2.2", BytesOut: 20},
+		{TS: now.Add(time.Second), ServerID: selectedID, ServerName: "selected", Host: "shared.test", ClientIP: "192.0.2.3", BytesOut: 30},
+	}
+	for _, event := range events {
+		if err := models.InsertAccessEvent(conn, event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dashboardTemplate := template.Must(template.New("dashboard.html").Parse(
+		`{{define "layout"}}{{.TodayViews}}|{{.TodayVisitors}}|{{.TodayBandwidth}}|{{.CertCount}}{{end}}`,
+	))
+	s := &Server{
+		DB: conn,
+		Templates: map[string]*template.Template{
+			"dashboard.html": dashboardTemplate,
+		},
+	}
+	admin := &models.User{ID: 1, Email: "admin@example.com", IsAdmin: true, Role: models.RoleAdmin}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: serverCookie, Value: strconv.FormatInt(selectedID, 10)})
+	req = req.WithContext(context.WithValue(req.Context(), auth.ContextUserKey, admin))
+	rec := httptest.NewRecorder()
+	s.dashboard(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "2|2|50|2" {
+		t.Fatalf("selected dashboard totals = %q, want 2|2|50|2", got)
+	}
+
+	sparkReq := httptest.NewRequest(http.MethodGet, "/api/dashboard-sparklines", nil)
+	sparkReq.AddCookie(&http.Cookie{Name: serverCookie, Value: strconv.FormatInt(selectedID, 10)})
+	sparkReq = sparkReq.WithContext(context.WithValue(sparkReq.Context(), auth.ContextUserKey, admin))
+	sparkRec := httptest.NewRecorder()
+	s.apiDashboardSparklines(sparkRec, sparkReq)
+	var spark struct {
+		Days []struct {
+			Views     int   `json:"views"`
+			Visitors  int   `json:"visitors"`
+			Bandwidth int64 `json:"bandwidth"`
+		} `json:"days"`
+	}
+	if err := json.NewDecoder(sparkRec.Body).Decode(&spark); err != nil {
+		t.Fatal(err)
+	}
+	if len(spark.Days) != 7 {
+		t.Fatalf("sparkline days = %d, want 7", len(spark.Days))
+	}
+	today := spark.Days[len(spark.Days)-1]
+	if today.Views != 2 || today.Visitors != 2 || today.Bandwidth != 50 {
+		t.Fatalf("selected sparkline today = %#v, want 2 views, 2 visitors, 50 bytes", today)
+	}
+}
+
+func TestOperationsLiveCaddyDataUsesSelectedServerAndCredentials(t *testing.T) {
+	var primaryCalls int
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		primaryCalls++
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v2.9.0-primary"})
+	}))
+	defer primary.Close()
+
+	var versionCalls, upstreamCalls int
+	selected := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, password, ok := r.BasicAuth()
+		if !ok || user != "monitor" || password != "secret" {
+			http.Error(w, "missing selected-node credentials", http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Path {
+		case "/":
+			versionCalls++
+			_ = json.NewEncoder(w).Encode(map[string]string{"version": "v2.11.4-selected"})
+		case "/reverse_proxy/upstreams":
+			upstreamCalls++
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"address": "app-a:8080", "num_requests": 3, "fails": 0},
+				{"address": "app-b:8080", "num_requests": 4, "fails": 1},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer selected.Close()
+
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if _, err := models.CreateCaddyServer(conn, &models.CaddyServer{Name: "primary", AdminURL: primary.URL}); err != nil {
+		t.Fatal(err)
+	}
+	selectedID, err := models.CreateCaddyServer(conn, &models.CaddyServer{
+		Name: "selected", AdminURL: selected.URL, AdminUsername: "monitor", AdminPassword: "secret",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{DB: conn, Caddy: caddy.New(primary.URL, "", "")}
+	selectedCookie := &http.Cookie{Name: serverCookie, Value: strconv.FormatInt(selectedID, 10)}
+
+	versionReq := httptest.NewRequest(http.MethodGet, "/api/caddy-version", nil)
+	versionReq.AddCookie(selectedCookie)
+	versionRec := httptest.NewRecorder()
+	s.apiCaddyVersion(versionRec, versionReq)
+	var versionBody map[string]any
+	if err := json.NewDecoder(versionRec.Body).Decode(&versionBody); err != nil {
+		t.Fatal(err)
+	}
+	if versionBody["version"] != "v2.11.4-selected" || int64(versionBody["server_id"].(float64)) != selectedID {
+		t.Fatalf("selected version response = %#v", versionBody)
+	}
+	stored, err := models.GetCaddyServer(conn, selectedID)
+	if err != nil || stored.Version != "v2.11.4-selected" {
+		t.Fatalf("stored selected version = %#v, err=%v", stored, err)
+	}
+
+	statsReq := httptest.NewRequest(http.MethodGet, "/api/system-stats", nil)
+	statsReq.AddCookie(selectedCookie)
+	statsReq = statsReq.WithContext(context.WithValue(statsReq.Context(), auth.ContextUserKey, &models.User{
+		ID: 1, Email: "admin@example.com", IsAdmin: true, Role: models.RoleAdmin,
+	}))
+	statsRec := httptest.NewRecorder()
+	s.apiSystemStats(statsRec, statsReq)
+	var stats map[string]any
+	if err := json.NewDecoder(statsRec.Body).Decode(&stats); err != nil {
+		t.Fatal(err)
+	}
+	if stats["selected_server_name"] != "selected" || stats["active_requests"] != float64(7) {
+		t.Fatalf("selected system stats = %#v", stats)
+	}
+	if stats["healthy_upstreams"] != float64(1) || stats["total_upstreams"] != float64(2) {
+		t.Fatalf("selected upstream stats = %#v", stats)
+	}
+	if stats["host_scope"] != "caddyui" {
+		t.Fatalf("host scope = %#v", stats["host_scope"])
+	}
+	if primaryCalls != 0 || versionCalls != 1 || upstreamCalls != 1 {
+		t.Fatalf("calls primary=%d version=%d upstream=%d", primaryCalls, versionCalls, upstreamCalls)
+	}
+}

--- a/internal/server/dashboard_scope_test.go
+++ b/internal/server/dashboard_scope_test.go
@@ -40,7 +40,7 @@ func TestOperationsTrafficAndCertificatesUseSelectedFleetServer(t *testing.T) {
 
 	for _, serverID := range []int64{primaryID, selectedID} {
 		if _, err := models.CreateProxyHost(conn, serverID, 0, &models.ProxyHost{
-			Domains: "shared.test", ForwardScheme: "http", ForwardHost: "backend", ForwardPort: 8080, Enabled: true,
+			Domains: "Shared.TEST", ForwardScheme: "http", ForwardHost: "backend", ForwardPort: 8080, Enabled: true,
 		}); err != nil {
 			t.Fatal(err)
 		}
@@ -58,9 +58,9 @@ func TestOperationsTrafficAndCertificatesUseSelectedFleetServer(t *testing.T) {
 	// the first minute after midnight.
 	now := time.Now().UTC().Truncate(24 * time.Hour).Add(time.Hour)
 	events := []models.AccessEvent{
-		{TS: now, ServerID: primaryID, ServerName: "primary", Host: "shared.test", ClientIP: "192.0.2.1", BytesOut: 100},
-		{TS: now, ServerID: selectedID, ServerName: "selected", Host: "shared.test", ClientIP: "192.0.2.2", BytesOut: 20},
-		{TS: now.Add(time.Second), ServerID: selectedID, ServerName: "selected", Host: "shared.test", ClientIP: "192.0.2.3", BytesOut: 30},
+		{TS: now, ServerID: primaryID, ServerName: "primary", Host: "Shared.TEST", ClientIP: "192.0.2.1", BytesOut: 100},
+		{TS: now, ServerID: selectedID, ServerName: "selected", Host: "Shared.TEST", ClientIP: "192.0.2.2", BytesOut: 20},
+		{TS: now.Add(time.Second), ServerID: selectedID, ServerName: "selected", Host: "Shared.TEST", ClientIP: "192.0.2.3", BytesOut: 30},
 	}
 	for _, event := range events {
 		if err := models.InsertAccessEvent(conn, event); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2417,14 +2417,15 @@ func (s *Server) dashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	seenTrafficHosts := map[string]struct{}{}
 	for _, host := range hostsForActive {
-		host = strings.ToLower(strings.TrimSpace(host))
+		host = strings.TrimSpace(host)
 		if host == "" {
 			continue
 		}
-		if _, seen := seenTrafficHosts[host]; seen {
+		hostKey := strings.ToLower(host)
+		if _, seen := seenTrafficHosts[hostKey]; seen {
 			continue
 		}
-		seenTrafficHosts[host] = struct{}{}
+		seenTrafficHosts[hostKey] = struct{}{}
 		if t, err := models.AccessTotalsSince(s.DB, todayStart, host, sid); err == nil {
 			todayViews += t.Views
 			todayVisitors += t.Visitors
@@ -12743,14 +12744,15 @@ func (s *Server) apiDashboardSparklines(w http.ResponseWriter, r *http.Request) 
 	seenTrafficHosts := map[string]struct{}{}
 	uniqueTrafficHosts := make([]string, 0, len(hostsForActive))
 	for _, host := range hostsForActive {
-		host = strings.ToLower(strings.TrimSpace(host))
+		host = strings.TrimSpace(host)
 		if host == "" {
 			continue
 		}
-		if _, seen := seenTrafficHosts[host]; seen {
+		hostKey := strings.ToLower(host)
+		if _, seen := seenTrafficHosts[hostKey]; seen {
 			continue
 		}
-		seenTrafficHosts[host] = struct{}{}
+		seenTrafficHosts[hostKey] = struct{}{}
 		uniqueTrafficHosts = append(uniqueTrafficHosts, host)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2398,12 +2398,10 @@ func (s *Server) dashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Today's analytics stats — v2.12.8: scoped to the active server's
-	// hostnames so the dashboard cards match what the picker has
-	// selected. Previously called AccessTotalsSince("") which sums the
-	// whole fleet, leaking other-server traffic into the active-server
-	// view (confusing on multi-server installs). Sums per-host the way
-	// /analytics already does when ?server=<id> is set.
+	// Today's analytics stats are scoped by both visible hostname and the
+	// selected fleet server. Hostname-only filtering is insufficient when two
+	// nodes serve the same domain: it would merge both nodes back together even
+	// after the operator switched environments.
 	todayStart := time.Now().UTC().Truncate(24 * time.Hour)
 	todayViews, todayVisitors := 0, 0
 	var todayBandwidth int64
@@ -2417,12 +2415,21 @@ func (s *Server) dashboard(w http.ResponseWriter, r *http.Request) {
 	for _, rr := range raws {
 		hostsForActive = append(hostsForActive, rawRouteHosts(rr)...)
 	}
+	seenTrafficHosts := map[string]struct{}{}
 	for _, host := range hostsForActive {
-		if t, err := models.AccessTotalsSince(s.DB, todayStart, host); err == nil {
+		host = strings.ToLower(strings.TrimSpace(host))
+		if host == "" {
+			continue
+		}
+		if _, seen := seenTrafficHosts[host]; seen {
+			continue
+		}
+		seenTrafficHosts[host] = struct{}{}
+		if t, err := models.AccessTotalsSince(s.DB, todayStart, host, sid); err == nil {
 			todayViews += t.Views
 			todayVisitors += t.Visitors
 		}
-		if bw, err := models.BandwidthSince(s.DB, todayStart, host); err == nil {
+		if bw, err := models.BandwidthSince(s.DB, todayStart, host, sid); err == nil {
 			todayBandwidth += bw
 		}
 	}
@@ -12607,6 +12614,12 @@ func (s *Server) apiSystemStats(w http.ResponseWriter, r *http.Request) {
 
 	stats := map[string]any{}
 
+	// The first four values intentionally describe the machine/container that
+	// runs CaddyUI. A remote Caddy admin API does not expose host load, total
+	// memory, or host uptime. The response names both scopes so the Operations
+	// page can distinguish these values from the selected-node Caddy telemetry.
+	stats["host_scope"] = "caddyui"
+
 	// Uptime from /proc/uptime (always the CaddyUI host machine).
 	if data, err := os.ReadFile("/proc/uptime"); err == nil {
 		fields := strings.Fields(string(data))
@@ -12654,25 +12667,32 @@ func (s *Server) apiSystemStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Per-server Caddy stats: active upstream requests + healthy upstream count.
-	// Uses the server ID from the ?sid query param, falling back to the cookie.
-	sidStr := r.URL.Query().Get("sid")
-	sid, err := strconv.ParseInt(sidStr, 10, 64)
-	if err != nil || sid <= 0 {
-		sid = s.currentServerID(r)
-	}
+	// The active-server cookie is authoritative, matching every other dashboard
+	// value and preventing a stale or hand-edited query parameter from mixing
+	// scopes inside one Operations page.
+	sid := s.currentServerID(r)
 	if srv, err := models.GetCaddyServer(s.DB, sid); err == nil {
-		upstreams := fetchCaddyUpstreams(srv.AdminURL)
+		stats["selected_server_id"] = srv.ID
+		stats["selected_server_name"] = srv.Name
+		ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		upstreams, upstreamErr := caddy.New(srv.AdminURL, srv.AdminUsername, srv.AdminPassword).GetUpstreamHealth(ctx)
+		cancel()
+		if upstreamErr != nil {
+			stats["caddy_error"] = upstreamErr.Error()
+		}
 		activeReqs := 0
 		healthy := 0
 		for _, u := range upstreams {
 			activeReqs += u.NumRequests
-			if u.Fails == 0 {
+			if u.Healthy {
 				healthy++
 			}
 		}
-		stats["active_requests"] = activeReqs
-		stats["healthy_upstreams"] = healthy
-		stats["total_upstreams"] = len(upstreams)
+		if upstreamErr == nil {
+			stats["active_requests"] = activeReqs
+			stats["healthy_upstreams"] = healthy
+			stats["total_upstreams"] = len(upstreams)
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -12720,18 +12740,33 @@ func (s *Server) apiDashboardSparklines(w http.ResponseWriter, r *http.Request) 
 
 	now := time.Now().UTC()
 	days := make([]DayPoint, 7)
+	seenTrafficHosts := map[string]struct{}{}
+	uniqueTrafficHosts := make([]string, 0, len(hostsForActive))
+	for _, host := range hostsForActive {
+		host = strings.ToLower(strings.TrimSpace(host))
+		if host == "" {
+			continue
+		}
+		if _, seen := seenTrafficHosts[host]; seen {
+			continue
+		}
+		seenTrafficHosts[host] = struct{}{}
+		uniqueTrafficHosts = append(uniqueTrafficHosts, host)
+	}
+
 	for i := 6; i >= 0; i-- {
 		day := now.AddDate(0, 0, -i).Truncate(24 * time.Hour)
 		dayEnd := day.Add(24 * time.Hour)
 		pt := DayPoint{Date: day.Format("2006-01-02")}
-		for _, host := range hostsForActive {
-			if t, err := models.AccessTotalsBetween(s.DB, day, dayEnd, host); err == nil {
+		for _, host := range uniqueTrafficHosts {
+			if t, err := models.AccessTotalsBetween(s.DB, day, dayEnd, host, sid); err == nil {
 				pt.Views += t.Views
 				pt.Visitors += t.Visitors
 			}
-			if bw, err := models.BandwidthSince(s.DB, day, host); err == nil {
-				// BandwidthSince sums from `day` to now — approximate for dashboard
-				pt.Bandwidth += bw
+			if buckets, err := models.BandwidthBuckets(s.DB, day, dayEnd, 24*60*60, host, sid); err == nil {
+				for _, bucket := range buckets {
+					pt.Bandwidth += bucket.BytesOut
+				}
 			}
 		}
 		days[6-i] = pt
@@ -12741,17 +12776,36 @@ func (s *Server) apiDashboardSparklines(w http.ResponseWriter, r *http.Request) 
 	json.NewEncoder(w).Encode(map[string]any{"days": days})
 }
 
-// apiCaddyVersion returns the running Caddy version from the admin API.
+// apiCaddyVersion returns the running Caddy version from the selected fleet
+// node's admin API. The former bootstrap-client lookup made every environment
+// show the primary node's version.
 func (s *Server) apiCaddyVersion(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
-	defer cancel()
-	version, err := s.Caddy.GetVersion(ctx)
+	sid := s.currentServerID(r)
+	srv, serverErr := models.GetCaddyServer(s.DB, sid)
 	w.Header().Set("Content-Type", "application/json")
-	if err != nil {
-		json.NewEncoder(w).Encode(map[string]any{"version": "unknown", "error": err.Error()})
+	if serverErr != nil {
+		json.NewEncoder(w).Encode(map[string]any{"version": "unknown", "error": serverErr.Error()})
 		return
 	}
-	json.NewEncoder(w).Encode(map[string]any{"version": version})
+	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+	defer cancel()
+	version, err := caddy.New(srv.AdminURL, srv.AdminUsername, srv.AdminPassword).GetVersionFromAdmin(ctx)
+	if err != nil {
+		if strings.TrimSpace(srv.Version) != "" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"version": srv.Version, "server_id": srv.ID, "server_name": srv.Name, "source": "saved",
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"version": "unknown", "server_id": srv.ID, "server_name": srv.Name, "error": err.Error(),
+		})
+		return
+	}
+	_ = models.SetCaddyServerVersion(s.DB, sid, version)
+	json.NewEncoder(w).Encode(map[string]any{
+		"version": version, "server_id": srv.ID, "server_name": srv.Name,
+	})
 }
 
 // apiVersionCheck returns the running version and the latest Docker Hub tag,

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -115,3 +115,25 @@ func TestOperationalTablesExposeRefreshAndSortingControls(t *testing.T) {
 		t.Fatal("server log retention must evict by entry ID, not visual sort order")
 	}
 }
+
+func TestDashboardClarifiesFleetTelemetryScopes(t *testing.T) {
+	dashboardHTML, err := FS.ReadFile("templates/dashboard.html")
+	if err != nil {
+		t.Fatalf("read dashboard.html: %v", err)
+	}
+	dashboard := string(dashboardHTML)
+	for _, marker := range []string{
+		"Certificate definitions",
+		"CaddyUI host resources · Caddy telemetry from",
+		"CaddyUI host uptime",
+		"Node active requests",
+		"fetch('/api/system-stats')",
+	} {
+		if !strings.Contains(dashboard, marker) {
+			t.Fatalf("dashboard template missing scope marker %q", marker)
+		}
+	}
+	if strings.Contains(dashboard, "/api/system-stats?sid=") {
+		t.Fatal("dashboard system stats must follow the active-server cookie, not a separate query parameter")
+	}
+}

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -133,7 +133,7 @@
       </a>
       <a href="/certificates" class="ops-route-metric">
         <div class="ops-route-metric__value tabular-nums">{{.CertCount}}</div>
-        <div class="ops-route-metric__label">Certificates</div>
+        <div class="ops-route-metric__label">Certificate definitions</div>
       </a>
     </div>
 
@@ -154,7 +154,7 @@
     <section class="ui-panel" aria-labelledby="traffic-overview-title">
       <div class="px-4 py-3 border-b border-ink-100">
         <h2 class="ui-section-header__title" id="traffic-overview-title">Traffic today</h2>
-        <p class="ui-section-header__description">Active-server analytics since midnight UTC</p>
+        <p class="ui-section-header__description">{{if .CurrentServer}}{{.CurrentServer.Name}}{{else}}Active node{{end}} analytics since midnight UTC</p>
       </div>
       <div class="ops-metrics-grid">
         <div class="ui-metric">
@@ -192,37 +192,37 @@
     {{end}}
 
     {{if eq .User.Role "admin"}}
-    <section class="ui-panel" id="sys-stats" data-sid="{{if .CurrentServer}}{{.CurrentServer.ID}}{{else}}1{{end}}" aria-labelledby="system-health-title">
+    <section class="ui-panel" id="sys-stats" aria-labelledby="system-health-title">
       <div class="px-4 py-3 border-b border-ink-100">
         <h2 class="ui-section-header__title" id="system-health-title">System health</h2>
-        <p class="ui-section-header__description">Live host and upstream telemetry</p>
+        <p class="ui-section-header__description">CaddyUI host resources · Caddy telemetry from {{if .CurrentServer}}{{.CurrentServer.Name}}{{else}}the selected node{{end}}</p>
       </div>
       <div class="ops-system-grid">
         <div class="ops-system-metric">
-          <div class="ops-system-metric__label">Uptime</div>
+          <div class="ops-system-metric__label">CaddyUI host uptime</div>
           <div class="ops-system-metric__value tabular-nums truncate" id="stat-uptime">—</div>
         </div>
         <div class="ops-system-metric">
-          <div class="ops-system-metric__label">Load 1m / 5m</div>
+          <div class="ops-system-metric__label">CaddyUI load 1m / 5m</div>
           <div class="ops-system-metric__value tabular-nums" id="stat-load">—</div>
         </div>
         <div class="ops-system-metric">
-          <div class="ops-system-metric__label">Memory</div>
+          <div class="ops-system-metric__label">CaddyUI memory</div>
           <div class="ops-system-metric__value tabular-nums truncate" id="stat-mem">—</div>
         </div>
         <div class="ops-system-metric">
-          <div class="ops-system-metric__label">Memory use</div>
+          <div class="ops-system-metric__label">CaddyUI memory use</div>
           <div class="flex items-center gap-2 mt-2">
             <div class="flex-1 bg-ink-100 rounded-full h-1.5 overflow-hidden"><div class="mem-gradient-bar h-1.5 rounded-full" id="stat-mem-bar" style="width:0%"></div></div>
             <span class="ops-system-metric__value mt-0 tabular-nums" id="stat-mem-pct">0%</span>
           </div>
         </div>
         <div class="ops-system-metric">
-          <div class="ops-system-metric__label">Active requests</div>
+          <div class="ops-system-metric__label">Node active requests</div>
           <div class="ops-system-metric__value tabular-nums" id="stat-reqs">—</div>
         </div>
         <div class="ops-system-metric">
-          <div class="ops-system-metric__label">Upstreams</div>
+          <div class="ops-system-metric__label">Node upstreams</div>
           <div class="ops-system-metric__value tabular-nums" id="stat-ups">—</div>
         </div>
       </div>
@@ -460,8 +460,7 @@
 (function() {
   var stats = document.getElementById('sys-stats');
   if (!stats) return;
-  var sid = stats.dataset.sid || '1';
-  fetch('/api/system-stats?sid=' + sid)
+  fetch('/api/system-stats')
     .then(function(r){ return r.json(); })
     .then(function(d){
       if (d.uptime)       document.getElementById('stat-uptime').textContent = d.uptime;
@@ -472,13 +471,15 @@
         document.getElementById('stat-mem-pct').textContent  = d.mem_pct + '%';
       }
       var reqs = d.active_requests;
-      document.getElementById('stat-reqs').textContent = (reqs !== undefined) ? reqs : '—';
+      document.getElementById('stat-reqs').textContent = (reqs !== undefined) ? reqs : (d.caddy_error ? 'Unavailable' : '—');
       var h = d.healthy_upstreams, t = d.total_upstreams;
       if (t !== undefined) {
         var el = document.getElementById('stat-ups');
         el.textContent = h + ' / ' + t + ' healthy';
         el.classList.toggle('text-red-600', h < t);
         el.classList.toggle('text-brand-700', h === t && t > 0);
+      } else if (d.caddy_error) {
+        document.getElementById('stat-ups').textContent = 'Unavailable';
       }
     })
     .catch(function(){});


### PR DESCRIPTION
## Summary

- scope Operations traffic totals and seven-day sparklines by the selected fleet server ID, including shared-hostname deployments
- fetch Caddy version and upstream telemetry from the selected node with its saved Basic Auth credentials
- distinguish CaddyUI-host OS metrics from selected-node Caddy telemetry and clarify that the certificate count is certificate definitions
- prevent remote version failures from falling back to the CaddyUI process's local `CADDY_VERSION`

## Verification

- `go test ./...`
- `go vet ./...`
- `go build ./cmd/caddyui`
- `go test -race ./internal/caddy ./internal/server ./internal/models`

Closes #34
