### PR TITLE
feat: add live Caddyfile route preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.26.0] - 2026-08-18 - Live route configuration preview
+
+### Added
+
+- Proxy-host forms now provide an in-browser Caddyfile excerpt alongside the generated Caddy route JSON, both updated from unsaved form changes and copyable without downloading a file. ([#33](https://github.com/X4Applegate/caddyui/issues/33))
+- A **Configured** form mode hides option sections with no configured values while keeping the live configuration preview available.
+
+### Fixed
+
+- The existing route JSON preview now opens and refreshes correctly; its client-side lookup previously referenced an ID that was not present in the form.
+
 ## [2.25.4] - 2026-08-18 - Operations fleet-node scoping
 
 ### Fixed

--- a/internal/server/proxy_host_preview_test.go
+++ b/internal/server/proxy_host_preview_test.go
@@ -134,6 +134,16 @@ func TestRedactPreviewURLFailsClosedForMalformedQueryKey(t *testing.T) {
 	}
 }
 
+func TestRedactPreviewURLScrubsUserinfoBeforeParsing(t *testing.T) {
+	got := redactPreviewURL("http://live-user:live-password@proxy.internal/%ZZ?mode=full")
+	if strings.Contains(got, "live-user") || strings.Contains(got, "live-password") {
+		t.Fatalf("malformed URL leaked userinfo: %q", got)
+	}
+	if !strings.Contains(got, "redacted:redacted@proxy.internal") || !strings.Contains(got, "mode=full") {
+		t.Fatalf("malformed URL did not preserve its safe structure: %q", got)
+	}
+}
+
 func TestAPIProxyHostPreviewIncludesAdaptedAdvancedHandlers(t *testing.T) {
 	adapter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/adapt" {

--- a/internal/server/proxy_host_preview_test.go
+++ b/internal/server/proxy_host_preview_test.go
@@ -14,25 +14,27 @@ import (
 
 func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
 	form := url.Values{
-		"domains":                  {"preview.example.com"},
-		"forward_scheme":           {"https"},
-		"forward_host":             {"app.internal"},
-		"forward_port":             {"8443"},
-		"ssl_enabled":              {"on"},
-		"enabled":                  {"on"},
-		"extra_upstream":           {"app-backup.internal:8443"},
-		"basicauth_enabled":        {"on"},
-		"basicauth_realm":          {"Members"},
-		"basicauth_user":           {"alice"},
-		"basicauth_hash":           {"saved-secret-bcrypt-hash"},
-		"api_key_header":           {"X-Preview-Key"},
-		"api_key_value":            {"live-api-secret"},
-		"sticky_sessions":          {"on"},
-		"lb_cookie_secret":         {"live-cookie-secret"},
-		"http_basic_auth_upstream": {"upstream-user:upstream-pass"},
-		"health_check_uri":         {"/health"},
-		"health_check_basic_auth":  {"probe-user:probe-pass"},
-		"forward_proxy_url":        {"http://proxy-user:proxy-pass@proxy.internal:3128"},
+		"domains":                   {"preview.example.com"},
+		"forward_scheme":            {"https"},
+		"forward_host":              {"app.internal"},
+		"forward_port":              {"8443"},
+		"ssl_enabled":               {"on"},
+		"enabled":                   {"on"},
+		"extra_upstream":            {"app-backup.internal:8443"},
+		"basicauth_enabled":         {"on"},
+		"basicauth_realm":           {"Members"},
+		"basicauth_user":            {"alice"},
+		"basicauth_hash":            {"saved-secret-bcrypt-hash"},
+		"api_key_header":            {"X-Preview-Key"},
+		"api_key_value":             {"live-api-secret"},
+		"sticky_sessions":           {"on"},
+		"lb_cookie_secret":          {"live-cookie-secret"},
+		"http_basic_auth_upstream":  {"upstream-user:upstream-pass"},
+		"health_check_uri":          {"/health"},
+		"health_check_query_params": {"token=health-query-secret&mode=full"},
+		"health_check_basic_auth":   {"probe-user:probe-pass"},
+		"forward_proxy_url":         {"http://proxy-user:proxy-pass@proxy.internal:3128?api_key=proxy-query-secret"},
+		"forward_auth_url":          {"https://auth.internal/check?credential=auth-query-secret&mode=strict"},
 	}
 	req := httptest.NewRequest(http.MethodPost, "/api/proxy-hosts/preview", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -109,10 +111,16 @@ func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
 		base64.StdEncoding.EncodeToString([]byte("probe-user:probe-pass")),
 		"proxy-user",
 		"proxy-pass",
+		"health-query-secret",
+		"proxy-query-secret",
+		"auth-query-secret",
 	} {
 		if strings.Contains(responseJSON, secret) {
 			t.Fatalf("route preview leaked credential %q", secret)
 		}
+	}
+	if !strings.Contains(responseJSON, "mode=full") || !strings.Contains(responseJSON, "mode=strict") {
+		t.Fatalf("route preview removed non-sensitive URL query parameters: %s", responseJSON)
 	}
 }
 

--- a/internal/server/proxy_host_preview_test.go
+++ b/internal/server/proxy_host_preview_test.go
@@ -31,7 +31,7 @@ func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
 		"lb_cookie_secret":          {"live-cookie-secret"},
 		"http_basic_auth_upstream":  {"upstream-user:upstream-pass"},
 		"health_check_uri":          {"/health"},
-		"health_check_query_params": {"token=health-query-secret&mode=full"},
+		"health_check_query_params": {"token=health-query-secret;mode=full"},
 		"health_check_basic_auth":   {"probe-user:probe-pass"},
 		"forward_proxy_url":         {"http://proxy-user:proxy-pass@proxy.internal:3128?api_key=proxy-query-secret"},
 		"forward_auth_url":          {"https://auth.internal/check?credential=auth-query-secret&mode=strict"},

--- a/internal/server/proxy_host_preview_test.go
+++ b/internal/server/proxy_host_preview_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
+	form := url.Values{
+		"domains":        {"preview.example.com"},
+		"forward_scheme": {"https"},
+		"forward_host":   {"app.internal"},
+		"forward_port":   {"8443"},
+		"ssl_enabled":    {"on"},
+		"enabled":        {"on"},
+		"extra_upstream": {"app-backup.internal:8443"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/proxy-hosts/preview", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+
+	(&Server{}).apiPreviewProxyHost(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("preview status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	var response struct {
+		Caddyfile string         `json:"caddyfile"`
+		Route     map[string]any `json:"route"`
+		Error     string         `json:"error"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode preview response: %v", err)
+	}
+	if response.Error != "" {
+		t.Fatalf("preview error = %q", response.Error)
+	}
+	for _, expected := range []string{
+		"preview.example.com {",
+		"reverse_proxy https://app.internal:8443 app-backup.internal:8443",
+	} {
+		if !strings.Contains(response.Caddyfile, expected) {
+			t.Fatalf("Caddyfile preview missing %q:\n%s", expected, response.Caddyfile)
+		}
+	}
+	if len(response.Route) == 0 {
+		t.Fatal("route JSON preview is empty")
+	}
+}
+
+func TestAPIProxyHostPreviewPadsIncompleteRequiredFields(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/proxy-hosts/preview", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+
+	(&Server{}).apiPreviewProxyHost(recorder, req)
+
+	var response struct {
+		Caddyfile string `json:"caddyfile"`
+		Error     string `json:"error"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode preview response: %v", err)
+	}
+	if response.Error != "" {
+		t.Fatalf("preview error = %q", response.Error)
+	}
+	for _, expected := range []string{"example.com {", "(your-upstream):0"} {
+		if !strings.Contains(response.Caddyfile, expected) {
+			t.Fatalf("placeholder Caddyfile missing %q:\n%s", expected, response.Caddyfile)
+		}
+	}
+}

--- a/internal/server/proxy_host_preview_test.go
+++ b/internal/server/proxy_host_preview_test.go
@@ -124,6 +124,16 @@ func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
 	}
 }
 
+func TestRedactPreviewURLFailsClosedForMalformedQueryKey(t *testing.T) {
+	got := redactPreviewURL("/health?to%ZZken=malformed-query-secret;mode=full")
+	if strings.Contains(got, "malformed-query-secret") {
+		t.Fatalf("malformed URL query leaked its value: %q", got)
+	}
+	if !strings.Contains(got, "mode=full") {
+		t.Fatalf("malformed URL query removed harmless parameters: %q", got)
+	}
+}
+
 func TestAPIProxyHostPreviewIncludesAdaptedAdvancedHandlers(t *testing.T) {
 	adapter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/adapt" {

--- a/internal/server/proxy_host_preview_test.go
+++ b/internal/server/proxy_host_preview_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,17 +14,25 @@ import (
 
 func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
 	form := url.Values{
-		"domains":           {"preview.example.com"},
-		"forward_scheme":    {"https"},
-		"forward_host":      {"app.internal"},
-		"forward_port":      {"8443"},
-		"ssl_enabled":       {"on"},
-		"enabled":           {"on"},
-		"extra_upstream":    {"app-backup.internal:8443"},
-		"basicauth_enabled": {"on"},
-		"basicauth_realm":   {"Members"},
-		"basicauth_user":    {"alice"},
-		"basicauth_hash":    {"saved-secret-bcrypt-hash"},
+		"domains":                  {"preview.example.com"},
+		"forward_scheme":           {"https"},
+		"forward_host":             {"app.internal"},
+		"forward_port":             {"8443"},
+		"ssl_enabled":              {"on"},
+		"enabled":                  {"on"},
+		"extra_upstream":           {"app-backup.internal:8443"},
+		"basicauth_enabled":        {"on"},
+		"basicauth_realm":          {"Members"},
+		"basicauth_user":           {"alice"},
+		"basicauth_hash":           {"saved-secret-bcrypt-hash"},
+		"api_key_header":           {"X-Preview-Key"},
+		"api_key_value":            {"live-api-secret"},
+		"sticky_sessions":          {"on"},
+		"lb_cookie_secret":         {"live-cookie-secret"},
+		"http_basic_auth_upstream": {"upstream-user:upstream-pass"},
+		"health_check_uri":         {"/health"},
+		"health_check_basic_auth":  {"probe-user:probe-pass"},
+		"forward_proxy_url":        {"http://proxy-user:proxy-pass@proxy.internal:3128"},
 	}
 	req := httptest.NewRequest(http.MethodPost, "/api/proxy-hosts/preview", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -67,7 +76,17 @@ func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
 	if !ok || len(handlers) == 0 {
 		t.Fatalf("route handlers missing from preview: %#v", response.Route)
 	}
-	authHandler, _ := handlers[0].(map[string]any)
+	var authHandler map[string]any
+	for _, handler := range handlers {
+		candidate, _ := handler.(map[string]any)
+		if candidate["handler"] == "authentication" {
+			authHandler = candidate
+			break
+		}
+	}
+	if authHandler == nil {
+		t.Fatalf("Basic Auth handler missing from preview: %#v", handlers)
+	}
 	providers, _ := authHandler["providers"].(map[string]any)
 	httpBasic, _ := providers["http_basic"].(map[string]any)
 	accounts, _ := httpBasic["accounts"].([]any)
@@ -80,6 +99,20 @@ func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
 	}
 	if strings.Contains(responseJSON, "saved-secret-bcrypt-hash") {
 		t.Fatal("Basic Auth preview leaked the saved bcrypt hash")
+	}
+	for _, secret := range []string{
+		"live-api-secret",
+		"live-cookie-secret",
+		"upstream-user:upstream-pass",
+		base64.StdEncoding.EncodeToString([]byte("upstream-user:upstream-pass")),
+		"probe-user:probe-pass",
+		base64.StdEncoding.EncodeToString([]byte("probe-user:probe-pass")),
+		"proxy-user",
+		"proxy-pass",
+	} {
+		if strings.Contains(responseJSON, secret) {
+			t.Fatalf("route preview leaked credential %q", secret)
+		}
 	}
 }
 

--- a/internal/server/proxy_host_preview_test.go
+++ b/internal/server/proxy_host_preview_test.go
@@ -140,6 +140,40 @@ func TestAPIProxyHostPreviewIncludesAdaptedAdvancedHandlers(t *testing.T) {
 	}
 }
 
+func TestAPIProxyHostPreviewRejectsTerminalAdvancedHandlers(t *testing.T) {
+	form := url.Values{
+		"domains":         {"terminal.example.com"},
+		"forward_scheme":  {"http"},
+		"forward_host":    {"app.internal"},
+		"forward_port":    {"8080"},
+		"advanced_config": {"respond \"not deployable here\" 200"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/proxy-hosts/preview", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+
+	(&Server{}).apiPreviewProxyHost(recorder, req)
+
+	var response struct {
+		Route         map[string]any `json:"route"`
+		AdvancedError string         `json:"advanced_error"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode terminal advanced preview response: %v", err)
+	}
+	if !strings.Contains(response.AdvancedError, "can't contain `respond`") {
+		t.Fatalf("advanced preview error = %q, want terminal-directive rejection", response.AdvancedError)
+	}
+	handlers, _ := response.Route["handle"].([]any)
+	if len(handlers) != 1 {
+		t.Fatalf("terminal preview handlers = %#v, want only reverse proxy", handlers)
+	}
+	reverseProxy, _ := handlers[0].(map[string]any)
+	if reverseProxy["handler"] != "reverse_proxy" {
+		t.Fatalf("terminal preview handler = %#v, want reverse proxy", reverseProxy)
+	}
+}
+
 func TestAPIProxyHostPreviewPadsIncompleteRequiredFields(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/proxy-hosts/preview", strings.NewReader(""))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/internal/server/proxy_host_preview_test.go
+++ b/internal/server/proxy_host_preview_test.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/X4Applegate/caddyui/internal/caddy"
 )
 
 func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
@@ -78,6 +80,63 @@ func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
 	}
 	if strings.Contains(responseJSON, "saved-secret-bcrypt-hash") {
 		t.Fatal("Basic Auth preview leaked the saved bcrypt hash")
+	}
+}
+
+func TestAPIProxyHostPreviewIncludesAdaptedAdvancedHandlers(t *testing.T) {
+	adapter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/adapt" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{
+				"apps": map[string]any{
+					"http": map[string]any{
+						"servers": map[string]any{
+							"srv0": map[string]any{
+								"routes": []any{map[string]any{
+									"handle": []any{map[string]any{"handler": "headers"}},
+								}},
+							},
+						},
+					},
+				},
+			},
+		})
+	}))
+	t.Cleanup(adapter.Close)
+
+	form := url.Values{
+		"domains":         {"advanced.example.com"},
+		"forward_scheme":  {"http"},
+		"forward_host":    {"app.internal"},
+		"forward_port":    {"8080"},
+		"advanced_config": {"header X-Preview yes"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/proxy-hosts/preview", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+
+	(&Server{Caddy: caddy.New(adapter.URL, "", "")}).apiPreviewProxyHost(recorder, req)
+
+	var response struct {
+		Route         map[string]any `json:"route"`
+		AdvancedError string         `json:"advanced_error"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode advanced preview response: %v", err)
+	}
+	if response.AdvancedError != "" {
+		t.Fatalf("advanced preview error = %q", response.AdvancedError)
+	}
+	handlers, _ := response.Route["handle"].([]any)
+	if len(handlers) < 2 {
+		t.Fatalf("advanced preview handlers = %#v, want advanced + reverse proxy", handlers)
+	}
+	advanced, _ := handlers[0].(map[string]any)
+	if advanced["handler"] != "headers" {
+		t.Fatalf("first preview handler = %#v, want adapted headers handler", advanced)
 	}
 }
 

--- a/internal/server/proxy_host_preview_test.go
+++ b/internal/server/proxy_host_preview_test.go
@@ -11,13 +11,17 @@ import (
 
 func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
 	form := url.Values{
-		"domains":        {"preview.example.com"},
-		"forward_scheme": {"https"},
-		"forward_host":   {"app.internal"},
-		"forward_port":   {"8443"},
-		"ssl_enabled":    {"on"},
-		"enabled":        {"on"},
-		"extra_upstream": {"app-backup.internal:8443"},
+		"domains":           {"preview.example.com"},
+		"forward_scheme":    {"https"},
+		"forward_host":      {"app.internal"},
+		"forward_port":      {"8443"},
+		"ssl_enabled":       {"on"},
+		"enabled":           {"on"},
+		"extra_upstream":    {"app-backup.internal:8443"},
+		"basicauth_enabled": {"on"},
+		"basicauth_realm":   {"Members"},
+		"basicauth_user":    {"alice"},
+		"basicauth_hash":    {"saved-secret-bcrypt-hash"},
 	}
 	req := httptest.NewRequest(http.MethodPost, "/api/proxy-hosts/preview", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -42,6 +46,7 @@ func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
 	for _, expected := range []string{
 		"preview.example.com {",
 		"reverse_proxy https://app.internal:8443 app-backup.internal:8443",
+		"basic auth users",
 	} {
 		if !strings.Contains(response.Caddyfile, expected) {
 			t.Fatalf("Caddyfile preview missing %q:\n%s", expected, response.Caddyfile)
@@ -49,6 +54,30 @@ func TestAPIProxyHostPreviewReturnsCaddyfileAndRouteJSON(t *testing.T) {
 	}
 	if len(response.Route) == 0 {
 		t.Fatal("route JSON preview is empty")
+	}
+	responseJSON := recorder.Body.String()
+	for _, expected := range []string{`"handler": "authentication"`, `"username": "alice"`, `"realm": "Members"`} {
+		if !strings.Contains(responseJSON, expected) {
+			t.Fatalf("Basic Auth preview missing %q:\n%s", expected, responseJSON)
+		}
+	}
+	handlers, ok := response.Route["handle"].([]any)
+	if !ok || len(handlers) == 0 {
+		t.Fatalf("route handlers missing from preview: %#v", response.Route)
+	}
+	authHandler, _ := handlers[0].(map[string]any)
+	providers, _ := authHandler["providers"].(map[string]any)
+	httpBasic, _ := providers["http_basic"].(map[string]any)
+	accounts, _ := httpBasic["accounts"].([]any)
+	if len(accounts) != 1 {
+		t.Fatalf("Basic Auth accounts = %#v, want one redacted account", accounts)
+	}
+	account, _ := accounts[0].(map[string]any)
+	if account["password"] != "<redacted>" {
+		t.Fatalf("Basic Auth password preview = %#v, want redacted", account["password"])
+	}
+	if strings.Contains(responseJSON, "saved-secret-bcrypt-hash") {
+		t.Fatal("Basic Auth preview leaked the saved bcrypt hash")
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10932,11 +10932,29 @@ func (s *Server) apiPreviewProxyHost(w http.ResponseWriter, r *http.Request) {
 			previewHandlers = append(previewHandlers, authHandler)
 		}
 	}
+	advancedError := ""
+	if strings.TrimSpace(p.AdvancedConfig) != "" {
+		caddyClient := s.Caddy
+		if s.DB != nil {
+			caddyClient = s.caddyForRequest(r)
+		}
+		if caddyClient == nil {
+			advancedError = "Caddy adapter is unavailable"
+		} else if handlers, adaptErr := s.adaptProxyAdvancedWithClient(caddyClient, *p); adaptErr != nil {
+			advancedError = adaptErr.Error()
+		} else {
+			previewHandlers = append(previewHandlers, handlers...)
+		}
+	}
 	route := caddy.BuildProxyRoute(*p, previewHandlers)
 	caddyfile := caddy.RenderProxyHostCaddyfile(*p)
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(map[string]any{"route": route, "caddyfile": caddyfile})
+	response := map[string]any{"route": route, "caddyfile": caddyfile}
+	if advancedError != "" {
+		response["advanced_error"] = advancedError
+	}
+	_ = enc.Encode(response)
 }
 
 // globalSearch — v2.11.5: ⌘K / Ctrl+K command palette. Returns a flat list of

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3680,11 +3680,25 @@ func redactPreviewRawQuery(raw string) (string, bool) {
 }
 
 func redactPreviewURL(raw string) string {
+	queryChanged := false
+	if queryStart := strings.IndexByte(raw, '?'); queryStart >= 0 {
+		queryEnd := len(raw)
+		if fragmentStart := strings.IndexByte(raw[queryStart+1:], '#'); fragmentStart >= 0 {
+			queryEnd = queryStart + 1 + fragmentStart
+		}
+		redactedQuery, changed := redactPreviewRawQuery(raw[queryStart+1 : queryEnd])
+		if changed {
+			raw = raw[:queryStart+1] + redactedQuery + raw[queryEnd:]
+			queryChanged = true
+		}
+	}
 	parsed, err := url.Parse(raw)
 	if err != nil {
+		// The raw-query pass above still removes sensitive values when the URL
+		// itself is malformed and cannot be parsed safely.
 		return raw
 	}
-	changed := false
+	changed := queryChanged
 	if parsed.User != nil {
 		if _, hasPassword := parsed.User.Password(); hasPassword {
 			parsed.User = url.UserPassword("redacted", "redacted")
@@ -3693,12 +3707,9 @@ func redactPreviewURL(raw string) string {
 		}
 		changed = true
 	}
-	redactedQuery, queryChanged := redactPreviewRawQuery(parsed.RawQuery)
-	changed = changed || queryChanged
 	if !changed {
 		return raw
 	}
-	parsed.RawQuery = redactedQuery
 	return parsed.String()
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3641,6 +3641,44 @@ func buildBasicAuthPreviewHandler(users []models.BasicAuthUser, realm string) ma
 
 const previewRedacted = "<redacted>"
 
+func redactPreviewRawQuery(raw string) (string, bool) {
+	if raw == "" {
+		return raw, false
+	}
+	var redacted strings.Builder
+	redacted.Grow(len(raw))
+	changed := false
+	segmentStart := 0
+	for i := 0; i <= len(raw); i++ {
+		if i < len(raw) && raw[i] != '&' && raw[i] != ';' {
+			continue
+		}
+		segment := raw[segmentStart:i]
+		key := segment
+		if equals := strings.IndexByte(segment, '='); equals >= 0 {
+			key = segment[:equals]
+		}
+		decodedKey, err := url.QueryUnescape(key)
+		if err != nil {
+			// A malformed key cannot be classified safely. Preserve its name but
+			// fail closed on its value so a credential cannot slip into Copy JSON.
+			if equals := strings.IndexByte(segment, '='); equals >= 0 {
+				segment = segment[:equals+1] + url.QueryEscape(previewRedacted)
+				changed = true
+			}
+		} else if previewSensitiveKey(decodedKey) {
+			segment = key + "=" + url.QueryEscape(previewRedacted)
+			changed = true
+		}
+		redacted.WriteString(segment)
+		if i < len(raw) {
+			redacted.WriteByte(raw[i])
+		}
+		segmentStart = i + 1
+	}
+	return redacted.String(), changed
+}
+
 func redactPreviewURL(raw string) string {
 	parsed, err := url.Parse(raw)
 	if err != nil {
@@ -3655,21 +3693,12 @@ func redactPreviewURL(raw string) string {
 		}
 		changed = true
 	}
-	query := parsed.Query()
-	for key, values := range query {
-		if !previewSensitiveKey(key) {
-			continue
-		}
-		for i := range values {
-			values[i] = previewRedacted
-		}
-		query[key] = values
-		changed = true
-	}
+	redactedQuery, queryChanged := redactPreviewRawQuery(parsed.RawQuery)
+	changed = changed || queryChanged
 	if !changed {
 		return raw
 	}
-	parsed.RawQuery = query.Encode()
+	parsed.RawQuery = redactedQuery
 	return parsed.String()
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3586,6 +3586,59 @@ func parseBasicAuthUsers(r *http.Request) ([]models.BasicAuthUser, error) {
 	return result, nil
 }
 
+// previewBasicAuthUsers returns the complete Basic Auth rows represented by
+// the unsaved form without hashing or exposing either new passwords or saved
+// bcrypt hashes in the preview response.
+func previewBasicAuthUsers(r *http.Request) []models.BasicAuthUser {
+	usernames := r.Form["basicauth_user"]
+	passwords := r.Form["basicauth_pass"]
+	hashes := r.Form["basicauth_hash"]
+	users := make([]models.BasicAuthUser, 0, len(usernames))
+	for i, rawUsername := range usernames {
+		username := strings.TrimSpace(rawUsername)
+		if username == "" {
+			continue
+		}
+		passwordPresent := i < len(passwords) && strings.TrimSpace(passwords[i]) != ""
+		hashPresent := i < len(hashes) && strings.TrimSpace(hashes[i]) != ""
+		if !passwordPresent && !hashPresent {
+			continue
+		}
+		users = append(users, models.BasicAuthUser{Username: username, BcryptHash: "<redacted>"})
+	}
+	return users
+}
+
+// buildBasicAuthPreviewHandler mirrors the authentication handler returned by
+// Caddy's adapter while keeping credential material redacted. It avoids a
+// remote /adapt call on every editor keystroke.
+func buildBasicAuthPreviewHandler(users []models.BasicAuthUser, realm string) map[string]any {
+	if len(users) == 0 {
+		return nil
+	}
+	accounts := make([]any, 0, len(users))
+	for _, user := range users {
+		accounts = append(accounts, map[string]any{
+			"username": user.Username,
+			"password": user.BcryptHash,
+		})
+	}
+	httpBasic := map[string]any{
+		"accounts":   accounts,
+		"hash":       map[string]any{"algorithm": "bcrypt"},
+		"hash_cache": map[string]any{},
+	}
+	if realm != "" && realm != "Restricted" {
+		httpBasic["realm"] = realm
+	}
+	return map[string]any{
+		"handler": "authentication",
+		"providers": map[string]any{
+			"http_basic": httpBasic,
+		},
+	}
+}
+
 // buildBasicAuthHandler adapts a Caddyfile basicauth block for the given users
 // via Caddy's /adapt endpoint and returns the authentication JSON handler.
 // Returns nil if the user list is empty or if adaptation fails (error is logged).
@@ -10869,7 +10922,17 @@ func (s *Server) apiPreviewProxyHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p.ExtraUpstreams = marshalExtraUpstreams(r)
-	route := caddy.BuildProxyRoute(*p, nil)
+	var previewHandlers []any
+	if r.FormValue("basicauth_enabled") == "on" {
+		p.BasicAuthEnabled = true
+		users := previewBasicAuthUsers(r)
+		usersJSON, _ := json.Marshal(users)
+		p.BasicAuthUsers = string(usersJSON)
+		if authHandler := buildBasicAuthPreviewHandler(users, p.BasicAuthRealm); authHandler != nil {
+			previewHandlers = append(previewHandlers, authHandler)
+		}
+	}
+	route := caddy.BuildProxyRoute(*p, previewHandlers)
 	caddyfile := caddy.RenderProxyHostCaddyfile(*p)
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10833,10 +10833,10 @@ func toolBoolDefault(args map[string]any, key string, def bool) bool {
 	return def
 }
 
-// apiPreviewProxyHost — v2.11.13: live preview of the route JSON Caddy
-// would receive for the in-progress proxy-host edit form. Reuses the
-// same parseProxyHostForm + BuildProxyRoute path as createProxyHost so
-// what the user sees here is exactly what gets pushed on save.
+// apiPreviewProxyHost — live previews of both the readable Caddyfile excerpt
+// and generated route JSON for the in-progress proxy-host edit form. Reuses
+// the same form parser as createProxyHost so unsaved changes are represented
+// in both views.
 //
 // v2.11.17: pads required fields with visible placeholders so a partly-
 // filled form still renders a representative preview. The previous
@@ -10868,10 +10868,12 @@ func (s *Server) apiPreviewProxyHost(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
+	p.ExtraUpstreams = marshalExtraUpstreams(r)
 	route := caddy.BuildProxyRoute(*p, nil)
+	caddyfile := caddy.RenderProxyHostCaddyfile(*p)
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(map[string]any{"route": route})
+	_ = enc.Encode(map[string]any{"route": route, "caddyfile": caddyfile})
 }
 
 // globalSearch — v2.11.5: ⌘K / Ctrl+K command palette. Returns a flat list of

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3679,7 +3679,36 @@ func redactPreviewRawQuery(raw string) (string, bool) {
 	return redacted.String(), changed
 }
 
+func redactPreviewRawUserinfo(raw string) (string, bool) {
+	authorityStart := -1
+	if schemeSeparator := strings.Index(raw, "://"); schemeSeparator >= 0 {
+		authorityStart = schemeSeparator + 3
+	} else if strings.HasPrefix(raw, "//") {
+		authorityStart = 2
+	}
+	if authorityStart < 0 {
+		return raw, false
+	}
+	authorityEnd := len(raw)
+	if separator := strings.IndexAny(raw[authorityStart:], "/?#"); separator >= 0 {
+		authorityEnd = authorityStart + separator
+	}
+	authority := raw[authorityStart:authorityEnd]
+	at := strings.LastIndexByte(authority, '@')
+	if at < 0 {
+		return raw, false
+	}
+	userinfo := "redacted"
+	if strings.Contains(authority[:at], ":") {
+		userinfo = "redacted:redacted"
+	}
+	redactedAuthority := userinfo + authority[at:]
+	return raw[:authorityStart] + redactedAuthority + raw[authorityEnd:], true
+}
+
 func redactPreviewURL(raw string) string {
+	var userinfoChanged bool
+	raw, userinfoChanged = redactPreviewRawUserinfo(raw)
 	queryChanged := false
 	if queryStart := strings.IndexByte(raw, '?'); queryStart >= 0 {
 		queryEnd := len(raw)
@@ -3698,7 +3727,7 @@ func redactPreviewURL(raw string) string {
 		// itself is malformed and cannot be parsed safely.
 		return raw
 	}
-	changed := queryChanged
+	changed := userinfoChanged || queryChanged
 	if parsed.User != nil {
 		if _, hasPassword := parsed.User.Password(); hasPassword {
 			parsed.User = url.UserPassword("redacted", "redacted")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3643,14 +3643,33 @@ const previewRedacted = "<redacted>"
 
 func redactPreviewURL(raw string) string {
 	parsed, err := url.Parse(raw)
-	if err != nil || parsed.User == nil {
+	if err != nil {
 		return raw
 	}
-	if _, hasPassword := parsed.User.Password(); hasPassword {
-		parsed.User = url.UserPassword("redacted", "redacted")
-	} else {
-		parsed.User = url.User("redacted")
+	changed := false
+	if parsed.User != nil {
+		if _, hasPassword := parsed.User.Password(); hasPassword {
+			parsed.User = url.UserPassword("redacted", "redacted")
+		} else {
+			parsed.User = url.User("redacted")
+		}
+		changed = true
 	}
+	query := parsed.Query()
+	for key, values := range query {
+		if !previewSensitiveKey(key) {
+			continue
+		}
+		for i := range values {
+			values[i] = previewRedacted
+		}
+		query[key] = values
+		changed = true
+	}
+	if !changed {
+		return raw
+	}
+	parsed.RawQuery = query.Encode()
 	return parsed.String()
 }
 
@@ -3687,8 +3706,9 @@ func redactPreviewShape(value any) any {
 }
 
 // redactProxyRoutePreview scrubs known credential-bearing keys and headers
-// while preserving the route's structure. It also removes URL userinfo from
-// arbitrary string values, including adapted advanced handlers.
+// while preserving the route's structure. It also removes URL userinfo and
+// sensitive query parameters from arbitrary strings, including adapted
+// advanced handlers.
 func redactProxyRoutePreview(value any) any {
 	switch typed := value.(type) {
 	case map[string]any:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8636,6 +8636,16 @@ func (s *Server) validateProxyAdvanced(caddyCl *caddy.Client, p *models.ProxyHos
 	if strings.TrimSpace(p.AdvancedConfig) == "" {
 		return ""
 	}
+	if errMsg := validateProxyAdvancedDirectives(p.AdvancedConfig); errMsg != "" {
+		return errMsg
+	}
+	if _, err := s.adaptProxyAdvancedWithClient(caddyCl, *p); err != nil {
+		return "Advanced config rejected by Caddy: " + err.Error()
+	}
+	return ""
+}
+
+func validateProxyAdvancedDirectives(src string) string {
 	// Directives that terminate a route — reverse_proxy ships the request, redir
 	// writes a 3xx, respond writes a fixed body, file_server serves from disk.
 	// The proxy host route ALWAYS ends with its own reverse_proxy, so allowing
@@ -8643,11 +8653,8 @@ func (s *Server) validateProxyAdvanced(caddyCl *caddy.Client, p *models.ProxyHos
 	// handler before it, silently breaking routing. Reject at save time rather
 	// than waiting for the sync to succeed with a broken result.
 	banned := []string{"reverse_proxy", "redir", "respond", "file_server"}
-	if bad := scanTopLevelDirective(p.AdvancedConfig, banned); bad != "" {
+	if bad := scanTopLevelDirective(src, banned); bad != "" {
 		return fmt.Sprintf("Advanced config can't contain `%s` — this field runs BEFORE the proxy's own reverse_proxy handler. Put request-side directives here (header, encode, request_body, rewrite, etc.) and let the Forward host/port handle the upstream.", bad)
-	}
-	if _, err := s.adaptProxyAdvancedWithClient(caddyCl, *p); err != nil {
-		return "Advanced config rejected by Caddy: " + err.Error()
 	}
 	return ""
 }
@@ -10934,16 +10941,20 @@ func (s *Server) apiPreviewProxyHost(w http.ResponseWriter, r *http.Request) {
 	}
 	advancedError := ""
 	if strings.TrimSpace(p.AdvancedConfig) != "" {
-		caddyClient := s.Caddy
-		if s.DB != nil {
-			caddyClient = s.caddyForRequest(r)
-		}
-		if caddyClient == nil {
-			advancedError = "Caddy adapter is unavailable"
-		} else if handlers, adaptErr := s.adaptProxyAdvancedWithClient(caddyClient, *p); adaptErr != nil {
-			advancedError = adaptErr.Error()
+		if validationError := validateProxyAdvancedDirectives(p.AdvancedConfig); validationError != "" {
+			advancedError = validationError
 		} else {
-			previewHandlers = append(previewHandlers, handlers...)
+			caddyClient := s.Caddy
+			if s.DB != nil {
+				caddyClient = s.caddyForRequest(r)
+			}
+			if caddyClient == nil {
+				advancedError = "Caddy adapter is unavailable"
+			} else if handlers, adaptErr := s.adaptProxyAdvancedWithClient(caddyClient, *p); adaptErr != nil {
+				advancedError = adaptErr.Error()
+			} else {
+				previewHandlers = append(previewHandlers, handlers...)
+			}
 		}
 	}
 	route := caddy.BuildProxyRoute(*p, previewHandlers)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3639,6 +3639,97 @@ func buildBasicAuthPreviewHandler(users []models.BasicAuthUser, realm string) ma
 	}
 }
 
+const previewRedacted = "<redacted>"
+
+func redactPreviewURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.User == nil {
+		return raw
+	}
+	if _, hasPassword := parsed.User.Password(); hasPassword {
+		parsed.User = url.UserPassword("redacted", "redacted")
+	} else {
+		parsed.User = url.User("redacted")
+	}
+	return parsed.String()
+}
+
+func previewSensitiveKey(key string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(key, "_", "-"))
+	if normalized == "authorization" || normalized == "proxy-authorization" || normalized == "cookie" || normalized == "set-cookie" {
+		return true
+	}
+	return strings.Contains(normalized, "password") ||
+		strings.Contains(normalized, "secret") ||
+		strings.Contains(normalized, "token") ||
+		strings.Contains(normalized, "credential") ||
+		strings.Contains(normalized, "api-key") ||
+		strings.Contains(normalized, "apikey")
+}
+
+func redactPreviewShape(value any) any {
+	switch typed := value.(type) {
+	case []any:
+		redacted := make([]any, len(typed))
+		for i := range redacted {
+			redacted[i] = previewRedacted
+		}
+		return redacted
+	case []string:
+		redacted := make([]string, len(typed))
+		for i := range redacted {
+			redacted[i] = previewRedacted
+		}
+		return redacted
+	default:
+		return previewRedacted
+	}
+}
+
+// redactProxyRoutePreview scrubs known credential-bearing keys and headers
+// while preserving the route's structure. It also removes URL userinfo from
+// arbitrary string values, including adapted advanced handlers.
+func redactProxyRoutePreview(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if previewSensitiveKey(key) {
+				typed[key] = redactPreviewShape(child)
+			} else {
+				typed[key] = redactProxyRoutePreview(child)
+			}
+		}
+		return typed
+	case map[string][]string:
+		for key, child := range typed {
+			if previewSensitiveKey(key) {
+				typed[key] = redactPreviewShape(child).([]string)
+			}
+		}
+		return typed
+	case map[string][]any:
+		for key, child := range typed {
+			if previewSensitiveKey(key) {
+				typed[key] = redactPreviewShape(child).([]any)
+			} else {
+				for i := range child {
+					child[i] = redactProxyRoutePreview(child[i])
+				}
+			}
+		}
+		return typed
+	case []any:
+		for i := range typed {
+			typed[i] = redactProxyRoutePreview(typed[i])
+		}
+		return typed
+	case string:
+		return redactPreviewURL(typed)
+	default:
+		return typed
+	}
+}
+
 // buildBasicAuthHandler adapts a Caddyfile basicauth block for the given users
 // via Caddy's /adapt endpoint and returns the authentication JSON handler.
 // Returns nil if the user list is empty or if adaptation fails (error is logged).
@@ -10957,7 +11048,23 @@ func (s *Server) apiPreviewProxyHost(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	route := caddy.BuildProxyRoute(*p, previewHandlers)
+	previewProxy := *p
+	if previewProxy.APIKeyValue != "" {
+		previewProxy.APIKeyValue = previewRedacted
+	}
+	if previewProxy.LBCookieSecret != "" {
+		previewProxy.LBCookieSecret = previewRedacted
+	}
+	if previewProxy.HTTPBasicAuthUpstream != "" {
+		previewProxy.HTTPBasicAuthUpstream = "redacted:redacted"
+	}
+	if previewProxy.HealthCheckBasicAuth != "" {
+		previewProxy.HealthCheckBasicAuth = "redacted:redacted"
+	}
+	previewProxy.ForwardProxyURL = redactPreviewURL(previewProxy.ForwardProxyURL)
+	previewProxy.ForwardAuthURL = redactPreviewURL(previewProxy.ForwardAuthURL)
+	route := caddy.BuildProxyRoute(previewProxy, previewHandlers)
+	route = redactProxyRoutePreview(route).(map[string]any)
 	caddyfile := caddy.RenderProxyHostCaddyfile(*p)
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -137,3 +137,27 @@ func TestDashboardClarifiesFleetTelemetryScopes(t *testing.T) {
 		t.Fatal("dashboard system stats must follow the active-server cookie, not a separate query parameter")
 	}
 }
+
+func TestProxyHostFormHasLiveCaddyfilePreviewAndConfiguredFilter(t *testing.T) {
+	formHTML, err := FS.ReadFile("templates/proxy_host_form.html")
+	if err != nil {
+		t.Fatalf("read proxy host form: %v", err)
+	}
+	form := string(formHTML)
+	for _, marker := range []string{
+		`id="mode-configured"`,
+		`id="ph-preview-caddyfile"`,
+		`id="ph-preview-json"`,
+		`id="ph-preview-tab-caddyfile"`,
+		`document.getElementById('ph-preview')`,
+		`d.caddyfile`,
+		`dataset.configuredCount`,
+	} {
+		if !strings.Contains(form, marker) {
+			t.Fatalf("proxy host form missing preview/filter marker %q", marker)
+		}
+	}
+	if strings.Contains(form, `document.getElementById('ph-preview-details')`) {
+		t.Fatal("proxy host preview still looks up the stale ph-preview-details ID")
+	}
+}

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -160,6 +160,8 @@ func TestProxyHostFormHasLiveCaddyfilePreviewAndConfiguredFilter(t *testing.T) {
 		`data-config-default="checked"`,
 		`t === 'number' && value !== '' && Number(value) === 0`,
 		`setProxyFormMode(window.currentProxyFormMode)`,
+		`window.applyProxyFormSearch = applyFilter`,
+		`configuredDefault === '{}' && (value === '' || value === '{}')`,
 	} {
 		if !strings.Contains(form, marker) {
 			t.Fatalf("proxy host form missing preview/filter marker %q", marker)

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -152,6 +152,12 @@ func TestProxyHostFormHasLiveCaddyfilePreviewAndConfiguredFilter(t *testing.T) {
 		`document.getElementById('ph-preview')`,
 		`d.caddyfile`,
 		`dataset.configuredCount`,
+		`data-config-default="*"`,
+		`data-config-default="30"`,
+		`data-config-default="5"`,
+		`data-config-default="Restricted"`,
+		`data-config-default="{}"`,
+		`t === 'number' && value !== '' && Number(value) === 0`,
 	} {
 		if !strings.Contains(form, marker) {
 			t.Fatalf("proxy host form missing preview/filter marker %q", marker)

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -165,6 +165,7 @@ func TestProxyHostFormHasLiveCaddyfilePreviewAndConfiguredFilter(t *testing.T) {
 		`var requestGeneration = 0`,
 		`generation !== requestGeneration`,
 		`new MutationObserver`,
+		`This configuration cannot be saved:`,
 	} {
 		if !strings.Contains(form, marker) {
 			t.Fatalf("proxy host form missing preview/filter marker %q", marker)

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -162,6 +162,9 @@ func TestProxyHostFormHasLiveCaddyfilePreviewAndConfiguredFilter(t *testing.T) {
 		`setProxyFormMode(window.currentProxyFormMode)`,
 		`window.applyProxyFormSearch = applyFilter`,
 		`configuredDefault === '{}' && (value === '' || value === '{}')`,
+		`var requestGeneration = 0`,
+		`generation !== requestGeneration`,
+		`new MutationObserver`,
 	} {
 		if !strings.Contains(form, marker) {
 			t.Fatalf("proxy host form missing preview/filter marker %q", marker)

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -157,6 +157,7 @@ func TestProxyHostFormHasLiveCaddyfilePreviewAndConfiguredFilter(t *testing.T) {
 		`data-config-default="5"`,
 		`data-config-default="Restricted"`,
 		`data-config-default="{}"`,
+		`data-config-default="checked"`,
 		`t === 'number' && value !== '' && Number(value) === 0`,
 	} {
 		if !strings.Contains(form, marker) {

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -159,6 +159,7 @@ func TestProxyHostFormHasLiveCaddyfilePreviewAndConfiguredFilter(t *testing.T) {
 		`data-config-default="{}"`,
 		`data-config-default="checked"`,
 		`t === 'number' && value !== '' && Number(value) === 0`,
+		`setProxyFormMode(window.currentProxyFormMode)`,
 	} {
 		if !strings.Contains(form, marker) {
 			t.Fatalf("proxy host form missing preview/filter marker %q", marker)

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -3689,7 +3689,7 @@ document.addEventListener('DOMContentLoaded', function() {
     <summary class="cursor-pointer select-none text-xs uppercase tracking-wider text-ink-500 hover:text-ink-700 font-medium transition">
       Live configuration preview <span class="font-normal normal-case">(updates before save)</span>
     </summary>
-    <p class="text-xs text-ink-500 mt-3 mb-2">Updates as you edit. The Caddyfile tab is a readable excerpt; Route JSON shows the generated Caddy route structure. Empty required fields use visible placeholders so either preview remains useful while you fill in the form.</p>
+    <p class="text-xs text-ink-500 mt-3 mb-2">Updates as you edit. The Caddyfile tab is a readable excerpt; Route JSON shows the generated Caddy route structure with credentials redacted. Empty required fields use visible placeholders so either preview remains useful while you fill in the form.</p>
     <div class="flex items-center justify-between gap-3 mb-2">
       <div class="inline-flex items-center gap-1 bg-ink-100 rounded-lg p-0.5 text-xs" role="tablist" aria-label="Configuration preview format">
         <button type="button" id="ph-preview-tab-caddyfile" role="tab" aria-selected="true" aria-controls="ph-preview-caddyfile" class="px-3 py-1.5 rounded-md bg-white shadow-sm text-ink-800 font-medium">Caddyfile</button>
@@ -4357,11 +4357,13 @@ document.addEventListener('DOMContentLoaded', function() {
     var allDetails = form.querySelectorAll('details');
     var q = (rawQ || '').toLowerCase().trim();
     if (q === '') {
-      // Reset: show every field + every <details>. Don't touch open state —
-      // leave whatever the user had open before searching.
+      // Reset field matches, then restore the active form mode's section
+      // visibility. Don't touch open state — leave whatever the user had
+      // open before searching.
       fields.forEach(function(f) { f.block.style.display = ''; });
       allDetails.forEach(function(d) { d.style.display = ''; });
       counter.classList.add('hidden');
+      if (window.currentProxyFormMode) setProxyFormMode(window.currentProxyFormMode);
       return;
     }
     var hits = 0;

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -3799,7 +3799,7 @@ document.addEventListener('DOMContentLoaded', function() {
           caddyfilePre.textContent = '⚠ ' + d.error;
           jsonPre.textContent = '⚠ ' + d.error;
         } else {
-          caddyfilePre.textContent = d.caddyfile || '— no Caddyfile excerpt available —';
+          caddyfilePre.textContent = (d.advanced_error ? '⚠ This configuration cannot be saved: ' + d.advanced_error + '\n\n' : '') + (d.caddyfile || '— no Caddyfile excerpt available —');
           jsonPre.textContent = (d.advanced_error ? '⚠ Advanced config was not included: ' + d.advanced_error + '\n\n' : '') + JSON.stringify(d.route, null, 2);
         }
       })

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -984,7 +984,7 @@ document.addEventListener('DOMContentLoaded', function() {
         </label>
         <div id="cors_origins_row" class="flex items-center gap-3 ml-7" {{if not .Host.CORSEnabled}}style="display:none"{{end}}>
           <label class="text-sm text-gray-500 dark:text-gray-400 shrink-0">Allowed origins</label>
-          <input type="text" name="cors_origins" value="{{if .Host.CORSOrigins}}{{.Host.CORSOrigins}}{{else}}*{{end}}"
+          <input type="text" name="cors_origins" value="{{if .Host.CORSOrigins}}{{.Host.CORSOrigins}}{{else}}*{{end}}" data-config-default="*"
             placeholder="* or https://example.com,https://app.example.com"
             class="flex-1 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500">
         </div>
@@ -1346,7 +1346,7 @@ document.addEventListener('DOMContentLoaded', function() {
           <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Check interval</label>
           <div class="flex items-center gap-2">
             <input type="number" name="health_check_interval_sec" min="5" max="3600"
-              value="{{if .Host.HealthCheckIntervalSec}}{{.Host.HealthCheckIntervalSec}}{{else}}30{{end}}"
+              value="{{if .Host.HealthCheckIntervalSec}}{{.Host.HealthCheckIntervalSec}}{{else}}30{{end}}" data-config-default="30"
               class="w-28 text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
             <span class="text-sm text-gray-500 dark:text-gray-400">seconds</span>
           </div>
@@ -1366,13 +1366,13 @@ document.addEventListener('DOMContentLoaded', function() {
           <div class="w-32">
             <label class="block text-xs font-medium text-ink-700 mb-1">Timeout (s)</label>
             <input type="number" name="health_check_timeout_sec" min="1" max="60"
-              value="{{if .Host.HealthCheckTimeoutSec}}{{.Host.HealthCheckTimeoutSec}}{{else}}5{{end}}"
+              value="{{if .Host.HealthCheckTimeoutSec}}{{.Host.HealthCheckTimeoutSec}}{{else}}5{{end}}" data-config-default="5"
               class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
           </div>
         </div>
         <div>
           <label class="block text-xs font-medium text-ink-700 mb-1">Health Check Headers</label>
-          <textarea name="health_check_headers" rows="2"
+          <textarea name="health_check_headers" rows="2" data-config-default="{}"
             placeholder='{"Authorization":"Bearer token"}'
             class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm font-mono bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition resize-none">{{.Host.HealthCheckHeaders}}</textarea>
           <p class="text-xs text-ink-500 mt-1">JSON object of extra headers sent with each health-check probe (e.g. <code class="font-mono bg-ink-100 px-1 rounded">{"X-Health":"1"}</code>)</p>
@@ -3444,7 +3444,7 @@ document.addEventListener('DOMContentLoaded', function() {
       <p class="text-xs text-ink-400 mb-3">Users must authenticate via HTTP Basic Auth before reaching the upstream. Passwords are bcrypt-hashed and never stored in plain text.</p>
       <div id="basicauth-realm-row">
         <label class="block text-xs font-medium text-ink-700 mb-1">Auth realm <span class="text-ink-400 font-normal">(shown in browser prompt)</span></label>
-        <input type="text" name="basicauth_realm" value="{{if .Host.BasicAuthRealm}}{{.Host.BasicAuthRealm}}{{else}}Restricted{{end}}"
+        <input type="text" name="basicauth_realm" value="{{if .Host.BasicAuthRealm}}{{.Host.BasicAuthRealm}}{{else}}Restricted{{end}}" data-config-default="Restricted"
           class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
       </div>
       <div id="ba-users" class="space-y-2">
@@ -3859,7 +3859,11 @@ document.addEventListener('DOMContentLoaded', function() {
     if (input.tagName === 'SELECT') {
       return input.selectedIndex > 0 && input.value !== '';
     }
-    return (input.value || '').trim() !== '';
+    var value = (input.value || '').trim();
+    var configuredDefault = input.getAttribute('data-config-default');
+    if (configuredDefault !== null) return value !== configuredDefault;
+    if (t === 'number' && value !== '' && Number(value) === 0) return false;
+    return value !== '';
   }
   window.refreshProxyConfiguredSections = function() {
     document.querySelectorAll('form#proxy-host-form details').forEach(function(det) {

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -121,6 +121,10 @@ function setProxyFormMode(mode) {
   }
   window.currentProxyFormMode = mode;
   try { localStorage.setItem('caddyui-proxy-mode', mode); } catch(e) {}
+  var activeSearch = document.getElementById('ph-form-search');
+  if (activeSearch && activeSearch.value.trim() && window.applyProxyFormSearch) {
+    window.applyProxyFormSearch(activeSearch.value);
+  }
 }
 // On load: default to Advanced for existing hosts (edit), Simple for new hosts
 document.addEventListener('DOMContentLoaded', function() {
@@ -350,7 +354,7 @@ document.addEventListener('DOMContentLoaded', function() {
     </div>
 
     <label class="mt-3 flex items-start gap-2.5 text-sm text-ink-700 cursor-pointer">
-      <input id="dns-create-record" type="checkbox" name="dns_create_record" {{if not .Host.DNSSkipRecord}}checked{{end}} class="mt-0.5 rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
+      <input id="dns-create-record" type="checkbox" name="dns_create_record" data-config-default="checked" {{if not .Host.DNSSkipRecord}}checked{{end}} class="mt-0.5 rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
       <span>Create public A records<span class="block text-xs text-ink-500 mt-0.5 font-normal">Turn off for internal or split-DNS services. Route53 DNS-01 TXT records will still be created in the selected hosted zone.</span></span>
     </label>
 
@@ -3609,7 +3613,7 @@ document.addEventListener('DOMContentLoaded', function() {
     <label class="block text-sm font-medium text-ink-800 mb-2">Color label <span class="text-ink-400 font-normal">(optional, for visual grouping)</span></label>
     <div class="flex items-center gap-2 flex-wrap">
       <label class="cursor-pointer" title="No color">
-        <input type="radio" name="color" value="" {{if eq .Host.Color ""}}checked{{end}} class="sr-only peer" />
+        <input type="radio" name="color" value="" data-config-default="checked" {{if eq .Host.Color ""}}checked{{end}} class="sr-only peer" />
         <span class="inline-flex items-center justify-center w-7 h-7 rounded-full border-2 border-ink-300 peer-checked:border-brand-600 peer-checked:ring-2 peer-checked:ring-brand-400 bg-white text-ink-400 text-xs transition">✕</span>
       </label>
       <label class="cursor-pointer" title="Red">
@@ -3855,14 +3859,14 @@ document.addEventListener('DOMContentLoaded', function() {
     if (input.disabled) return false;
     var t = (input.type || '').toLowerCase();
     var configuredDefault = input.getAttribute('data-config-default');
-    if (t === 'checkbox' || t === 'radio') {
-      return configuredDefault === 'checked' ? !input.checked : input.checked;
-    }
+    if (t === 'radio') return configuredDefault === 'checked' ? false : input.checked;
+    if (t === 'checkbox') return configuredDefault === 'checked' ? !input.checked : input.checked;
     if (t === 'submit' || t === 'button' || t === 'reset' || t === 'hidden') return false;
     if (input.tagName === 'SELECT') {
       return input.selectedIndex > 0 && input.value !== '';
     }
     var value = (input.value || '').trim();
+    if (configuredDefault === '{}' && (value === '' || value === '{}')) return false;
     if (configuredDefault !== null) return value !== configuredDefault;
     if (t === 'number' && value !== '' && Number(value) === 0) return false;
     return value !== '';
@@ -4394,6 +4398,7 @@ document.addEventListener('DOMContentLoaded', function() {
     counter.textContent = hits + ' match' + (hits === 1 ? '' : 'es');
     counter.classList.remove('hidden');
   }
+  window.applyProxyFormSearch = applyFilter;
   input.addEventListener('input', function() { applyFilter(this.value); });
   // Esc clears the filter.
   input.addEventListener('keydown', function(e) {

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -2479,7 +2479,7 @@ document.addEventListener('DOMContentLoaded', function() {
         </label>
         <p class="text-xs text-gray-500 dark:text-gray-400">Enable TLS 1.3 early data (0-RTT) for upstream connections. May reduce latency for repeated connections.</p>
       </div>
-      <label class="flex items-center gap-2.5 text-sm text-ink-700 cursor-pointer"><input type="checkbox" name="http2_support" {{if .Host.HTTP2Support}}checked{{end}} class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" /> HTTP/2</label>
+      <label class="flex items-center gap-2.5 text-sm text-ink-700 cursor-pointer"><input type="checkbox" name="http2_support" data-config-default="checked" {{if .Host.HTTP2Support}}checked{{end}} class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" /> HTTP/2</label>
       <label class="flex items-center gap-2.5 text-sm text-ink-700 cursor-pointer"><input type="checkbox" name="websocket_support" {{if .Host.WebsocketSupport}}checked{{end}} class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" /> WebSocket support</label>
       <label class="flex items-start gap-2.5 text-sm text-ink-700 cursor-pointer sm:col-span-2"><input type="checkbox" name="forward_client_ip" {{if .Host.ForwardClientIP}}checked{{end}} class="mt-0.5 rounded border-ink-300 text-brand-600 focus:ring-brand-500" /> <span>Forward client IP (X-Real-IP)<span class="block text-xs text-ink-500 mt-0.5 font-normal">Adds an X-Real-IP header with the actual client IP address to every upstream request</span></span></label>
       <!-- v2.9.82: add_forwarded_header -->
@@ -3854,13 +3854,15 @@ document.addEventListener('DOMContentLoaded', function() {
   function isModified(input) {
     if (input.disabled) return false;
     var t = (input.type || '').toLowerCase();
-    if (t === 'checkbox' || t === 'radio') return input.checked;
+    var configuredDefault = input.getAttribute('data-config-default');
+    if (t === 'checkbox' || t === 'radio') {
+      return configuredDefault === 'checked' ? !input.checked : input.checked;
+    }
     if (t === 'submit' || t === 'button' || t === 'reset' || t === 'hidden') return false;
     if (input.tagName === 'SELECT') {
       return input.selectedIndex > 0 && input.value !== '';
     }
     var value = (input.value || '').trim();
-    var configuredDefault = input.getAttribute('data-config-default');
     if (configuredDefault !== null) return value !== configuredDefault;
     if (t === 'number' && value !== '' && Number(value) === 0) return false;
     return value !== '';

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -3769,7 +3769,8 @@ document.addEventListener('DOMContentLoaded', function() {
   var copyButton = document.getElementById('ph-preview-copy');
   if (!form || !caddyfilePre || !jsonPre || !details) return;
   var timer = null;
-  var lastSerialized = null;
+  var lastRenderedSerialized = null;
+  var requestGeneration = 0;
   var activeFormat = 'caddyfile';
   function setFormat(format) {
     activeFormat = format;
@@ -3787,25 +3788,29 @@ document.addEventListener('DOMContentLoaded', function() {
     var fd = new FormData(form);
     var serialized = '';
     for (var pair of fd.entries()) { serialized += pair[0] + '=' + pair[1] + '&'; }
-    if (serialized === lastSerialized) return;
-    lastSerialized = serialized;
+    if (serialized === lastRenderedSerialized) return;
+    var generation = ++requestGeneration;
     fetch('/api/proxy-hosts/preview', { method: 'POST', body: fd, credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
+        if (generation !== requestGeneration) return;
+        lastRenderedSerialized = serialized;
         if (d.error) {
           caddyfilePre.textContent = '⚠ ' + d.error;
           jsonPre.textContent = '⚠ ' + d.error;
         } else {
           caddyfilePre.textContent = d.caddyfile || '— no Caddyfile excerpt available —';
-          jsonPre.textContent = JSON.stringify(d.route, null, 2);
+          jsonPre.textContent = (d.advanced_error ? '⚠ Advanced config was not included: ' + d.advanced_error + '\n\n' : '') + JSON.stringify(d.route, null, 2);
         }
       })
       .catch(function() {
+        if (generation !== requestGeneration) return;
         caddyfilePre.textContent = '— preview unavailable —';
         jsonPre.textContent = '— preview unavailable —';
       });
   }
   function schedule() {
+    requestGeneration++; // immediately invalidate an older in-flight response
     if (timer) clearTimeout(timer);
     timer = setTimeout(refresh, 500);
   }
@@ -3903,6 +3908,18 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     form.addEventListener('input', updateConfiguredMode);
     form.addEventListener('change', updateConfiguredMode);
+    if ('MutationObserver' in window) {
+      new MutationObserver(function(mutations) {
+        var rowsChanged = mutations.some(function(mutation) {
+          return Array.prototype.some.call(mutation.addedNodes, function(node) {
+            return node.nodeType === 1 && !node.matches('[data-configured-badge]');
+          }) || Array.prototype.some.call(mutation.removedNodes, function(node) {
+            return node.nodeType === 1 && !node.matches('[data-configured-badge]');
+          });
+        });
+        if (rowsChanged) updateConfiguredMode();
+      }).observe(form, { childList: true, subtree: true });
+    }
   }
 })();
 </script>

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -45,7 +45,7 @@
      by where the section physically lives in the form. The most common
      proxy-host customizations (DNS, TLS, Security headers, custom
      headers, path routing) come first; advanced / debug-only sections
-     (Advanced raw config, Live JSON Preview) come last so they're not
+     (Advanced raw config, Live configuration preview) come last so they're not
      visually competing with the bread-and-butter stuff.
 
      The two groups are separated by a thin vertical divider so the
@@ -53,10 +53,11 @@
 
      The IIFE at the bottom of this file expands the corresponding
      <details> on click, so the user lands on an open section. */}}
-{{/* v2.15.0: Simple / Advanced mode toggle. Simple mode hides all the
+{{/* Simple / Advanced / Configured mode toggle. Simple mode hides all the
      <details> expansion sections so new users see only Domain, Forward
      Host/Port, and SSL — the three fields needed for 90% of proxy hosts.
-     Advanced mode (default for edit) shows everything. */}}
+     Advanced mode (default for edit) shows everything. Configured mode
+     keeps only sections that contain a non-default value, plus Preview. */}}
 {{if not .Guided}}
 <div class="flex items-center gap-3 mb-4 max-w-3xl">
   <span class="text-xs font-medium text-ink-500">Form mode:</span>
@@ -65,12 +66,16 @@
       class="px-3 py-1.5 rounded-md transition font-medium">Simple</button>
     <button type="button" id="mode-advanced" onclick="setProxyFormMode('advanced')"
       class="px-3 py-1.5 rounded-md transition font-medium">Advanced</button>
+    <button type="button" id="mode-configured" onclick="setProxyFormMode('configured')"
+      class="px-3 py-1.5 rounded-md transition font-medium">Configured</button>
   </div>
   <span id="mode-hint" class="text-xs text-ink-400"></span>
 </div>
 <script>
 function setProxyFormMode(mode) {
   var isSimple = mode === 'simple';
+  var isConfigured = mode === 'configured';
+  if (window.refreshProxyConfiguredSections) window.refreshProxyConfiguredSections();
   // In simple mode, keep Domain/DNS (#ph-dns) and TLS (#ph-tls) visible —
   // those are the two most-used sections. Hide everything else.
   var SIMPLE_KEEP = ['ph-dns', 'ph-tls'];
@@ -79,34 +84,54 @@ function setProxyFormMode(mode) {
   var hint = document.getElementById('mode-hint');
   var btnSimple = document.getElementById('mode-simple');
   var btnAdv = document.getElementById('mode-advanced');
+  var btnConfigured = document.getElementById('mode-configured');
   details.forEach(function(d) {
     if (isSimple) {
       d.style.display = SIMPLE_KEEP.indexOf(d.id) !== -1 ? '' : 'none';
+    } else if (isConfigured) {
+      d.style.display = d.id === 'ph-preview' || Number(d.dataset.configuredCount || 0) > 0 ? '' : 'none';
     } else {
       d.style.display = '';
     }
   });
   if (nav) nav.style.display = isSimple ? 'none' : '';
-  if (hint) hint.textContent = isSimple ? 'Showing: Domain, DNS & TLS only' : '';
+  if (nav && isConfigured) {
+    nav.querySelectorAll('a[href^="#ph-"]').forEach(function(a) {
+      var section = document.querySelector(a.getAttribute('href'));
+      a.style.display = section && section.style.display !== 'none' ? '' : 'none';
+    });
+  } else if (nav) {
+    nav.querySelectorAll('a[href^="#ph-"]').forEach(function(a) { a.style.display = ''; });
+  }
+  if (hint) {
+    hint.textContent = isSimple ? 'Showing: Domain, DNS & TLS only' :
+      (isConfigured ? 'Showing sections with configured values' : '');
+  }
   if (btnSimple) {
     btnSimple.className = 'px-3 py-1.5 rounded-md transition font-medium ' +
       (isSimple ? 'bg-white shadow-sm text-ink-800' : 'text-ink-500 hover:text-ink-700');
   }
   if (btnAdv) {
     btnAdv.className = 'px-3 py-1.5 rounded-md transition font-medium ' +
-      (!isSimple ? 'bg-white shadow-sm text-ink-800' : 'text-ink-500 hover:text-ink-700');
+      (mode === 'advanced' ? 'bg-white shadow-sm text-ink-800' : 'text-ink-500 hover:text-ink-700');
   }
+  if (btnConfigured) {
+    btnConfigured.className = 'px-3 py-1.5 rounded-md transition font-medium ' +
+      (isConfigured ? 'bg-white shadow-sm text-ink-800' : 'text-ink-500 hover:text-ink-700');
+  }
+  window.currentProxyFormMode = mode;
   try { localStorage.setItem('caddyui-proxy-mode', mode); } catch(e) {}
 }
 // On load: default to Advanced for existing hosts (edit), Simple for new hosts
-(function() {
+document.addEventListener('DOMContentLoaded', function() {
   var isNew = !document.querySelector('#proxy-host-form input[name="id"]') &&
               window.location.pathname.indexOf('/new') !== -1;
   var saved = '';
   try { saved = localStorage.getItem('caddyui-proxy-mode') || ''; } catch(e) {}
+  if (['simple', 'advanced', 'configured'].indexOf(saved) === -1) saved = '';
   var mode = saved || (isNew ? 'simple' : 'advanced');
   setProxyFormMode(mode);
-})();
+});
 </script>
 {{end}}
 {{if .Guided}}
@@ -144,7 +169,7 @@ function setProxyFormMode(mode) {
 
   {{/* Tier 3 — advanced / debug */}}
   <a href="#ph-advanced"       class="inline-flex items-center text-xs font-medium text-ink-500 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Advanced</a>
-  <a href="#ph-preview"        class="inline-flex items-center text-xs font-medium text-ink-500 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Live JSON Preview</a>
+  <a href="#ph-preview"        class="inline-flex items-center text-xs font-medium text-ink-500 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Live config preview</a>
 </nav>
 {{end}}
 
@@ -3659,13 +3684,21 @@ function setProxyFormMode(mode) {
     </div>
   </details>
 
-  {{/* v2.9.0: Security — compression + response headers + TLS min version */}}
+  {{/* Live Caddyfile excerpt + exact route JSON for the unsaved form state. */}}
   <details class="pt-4 border-t border-ink-100" id="ph-preview">
     <summary class="cursor-pointer select-none text-xs uppercase tracking-wider text-ink-500 hover:text-ink-700 font-medium transition">
-      Live route JSON preview <span class="font-normal normal-case">(what Caddy will see)</span>
+      Live configuration preview <span class="font-normal normal-case">(updates before save)</span>
     </summary>
-    <p class="text-xs text-ink-500 mt-3 mb-2">Updates as you edit. Reflects every field above. Empty required fields render as placeholders in the preview (<code class="bg-ink-100 px-1 rounded">example.com</code> / <code class="bg-ink-100 px-1 rounded">(your-upstream)</code> / port <code class="bg-ink-100 px-1 rounded">0</code>) so the JSON shape is still visible while you fill the form in.</p>
-    <pre id="ph-preview-json" class="bg-ink-900 text-ink-100 text-xs p-3 rounded-lg overflow-x-auto max-h-96">— start typing in the form to see the preview —</pre>
+    <p class="text-xs text-ink-500 mt-3 mb-2">Updates as you edit. The Caddyfile tab is a readable excerpt; Route JSON shows the generated Caddy route structure. Empty required fields use visible placeholders so either preview remains useful while you fill in the form.</p>
+    <div class="flex items-center justify-between gap-3 mb-2">
+      <div class="inline-flex items-center gap-1 bg-ink-100 rounded-lg p-0.5 text-xs" role="tablist" aria-label="Configuration preview format">
+        <button type="button" id="ph-preview-tab-caddyfile" role="tab" aria-selected="true" aria-controls="ph-preview-caddyfile" class="px-3 py-1.5 rounded-md bg-white shadow-sm text-ink-800 font-medium">Caddyfile</button>
+        <button type="button" id="ph-preview-tab-json" role="tab" aria-selected="false" aria-controls="ph-preview-json" class="px-3 py-1.5 rounded-md text-ink-500 hover:text-ink-700 font-medium">Route JSON</button>
+      </div>
+      <button type="button" id="ph-preview-copy" class="text-xs font-medium text-brand-600 hover:text-brand-700">Copy Caddyfile</button>
+    </div>
+    <pre id="ph-preview-caddyfile" role="tabpanel" aria-labelledby="ph-preview-tab-caddyfile" class="bg-ink-900 text-ink-100 text-xs p-3 rounded-lg overflow-x-auto max-h-96">— expand this section to load the preview —</pre>
+    <pre id="ph-preview-json" role="tabpanel" aria-labelledby="ph-preview-tab-json" class="hidden bg-ink-900 text-ink-100 text-xs p-3 rounded-lg overflow-x-auto max-h-96">— expand this section to load the preview —</pre>
   </details>
 
   <div id="ph-form-actions" class="flex items-center gap-3 pt-4 border-t border-ink-100">
@@ -3720,19 +3753,33 @@ function setProxyFormMode(mode) {
   refresh();
 })();
 
-// v2.11.13: live route JSON preview. Listens for form changes, debounces
-// 500ms, POSTs the form to /api/proxy-hosts/preview, renders the result
-// in <pre id="ph-preview-json">. Server returns either {route:{...}} on
-// success or {error:"..."} when the form is incomplete.
+// Live Caddyfile + route JSON preview. Listens for form changes, debounces
+// 500ms, and posts the unsaved form to the shared server-side parser.
 (function() {
   var form = document.getElementById('proxy-host-form');
-  var pre = document.getElementById('ph-preview-json');
-  var details = document.getElementById('ph-preview-details');
-  if (!form || !pre) return;
+  var caddyfilePre = document.getElementById('ph-preview-caddyfile');
+  var jsonPre = document.getElementById('ph-preview-json');
+  var details = document.getElementById('ph-preview');
+  var caddyfileTab = document.getElementById('ph-preview-tab-caddyfile');
+  var jsonTab = document.getElementById('ph-preview-tab-json');
+  var copyButton = document.getElementById('ph-preview-copy');
+  if (!form || !caddyfilePre || !jsonPre || !details) return;
   var timer = null;
   var lastSerialized = null;
+  var activeFormat = 'caddyfile';
+  function setFormat(format) {
+    activeFormat = format;
+    var showCaddyfile = format === 'caddyfile';
+    caddyfilePre.classList.toggle('hidden', !showCaddyfile);
+    jsonPre.classList.toggle('hidden', showCaddyfile);
+    caddyfileTab.setAttribute('aria-selected', showCaddyfile ? 'true' : 'false');
+    jsonTab.setAttribute('aria-selected', showCaddyfile ? 'false' : 'true');
+    caddyfileTab.className = 'px-3 py-1.5 rounded-md font-medium ' + (showCaddyfile ? 'bg-white shadow-sm text-ink-800' : 'text-ink-500 hover:text-ink-700');
+    jsonTab.className = 'px-3 py-1.5 rounded-md font-medium ' + (!showCaddyfile ? 'bg-white shadow-sm text-ink-800' : 'text-ink-500 hover:text-ink-700');
+    copyButton.textContent = showCaddyfile ? 'Copy Caddyfile' : 'Copy JSON';
+  }
   function refresh() {
-    if (!details || !details.open) return; // skip when collapsed — avoid background fetches
+    if (!details.open) return; // skip when collapsed — avoid background fetches
     var fd = new FormData(form);
     var serialized = '';
     for (var pair of fd.entries()) { serialized += pair[0] + '=' + pair[1] + '&'; }
@@ -3742,15 +3789,16 @@ function setProxyFormMode(mode) {
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.error) {
-          pre.textContent = '⚠ ' + d.error;
-          pre.className = 'bg-amber-50 text-amber-800 text-xs p-3 rounded-lg overflow-x-auto max-h-96';
+          caddyfilePre.textContent = '⚠ ' + d.error;
+          jsonPre.textContent = '⚠ ' + d.error;
         } else {
-          pre.textContent = JSON.stringify(d.route, null, 2);
-          pre.className = 'bg-ink-900 text-ink-100 text-xs p-3 rounded-lg overflow-x-auto max-h-96';
+          caddyfilePre.textContent = d.caddyfile || '— no Caddyfile excerpt available —';
+          jsonPre.textContent = JSON.stringify(d.route, null, 2);
         }
       })
       .catch(function() {
-        pre.textContent = '— preview unavailable —';
+        caddyfilePre.textContent = '— preview unavailable —';
+        jsonPre.textContent = '— preview unavailable —';
       });
   }
   function schedule() {
@@ -3759,11 +3807,18 @@ function setProxyFormMode(mode) {
   }
   form.addEventListener('input', schedule);
   form.addEventListener('change', schedule);
-  if (details) {
-    details.addEventListener('toggle', function() {
-      if (details.open) refresh();
+  caddyfileTab.addEventListener('click', function() { setFormat('caddyfile'); });
+  jsonTab.addEventListener('click', function() { setFormat('json'); });
+  copyButton.addEventListener('click', function() {
+    var text = activeFormat === 'caddyfile' ? caddyfilePre.textContent : jsonPre.textContent;
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(text).then(function() {
+      copyButton.textContent = 'Copied!';
+      setTimeout(function() { copyButton.textContent = activeFormat === 'caddyfile' ? 'Copy Caddyfile' : 'Copy JSON'; }, 1500);
     });
-  }
+  });
+  details.addEventListener('toggle', function() { if (details.open) refresh(); });
+  setFormat('caddyfile');
 })();
 </script>
 
@@ -3793,17 +3848,9 @@ function setProxyFormMode(mode) {
   io.observe(actions);
 })();
 
-// v2.11.0: section badges — count the configured (non-default) fields in
-// each <details> section and append a small pill to its <summary> so users
-// can see at a glance which sections actually have something set, without
-// expanding them all. Empty/default fields don't count; checkboxes count
-// when checked; selects count when not the first <option>.
+// Section badges and Configured mode share one configured-field count so
+// the filter stays accurate as the unsaved form changes.
 (function() {
-  // Both on create and on edit, every section starts collapsed so the form
-  // stays browsable. The summary badge shows the count of configured fields
-  // so users can see at a glance what each section contains without
-  // expanding it. Managed DNS and TLS Certificate carry data-keep-open and
-  // stay open since users almost always want them visible.
   function isModified(input) {
     if (input.disabled) return false;
     var t = (input.type || '').toLowerCase();
@@ -3814,21 +3861,39 @@ function setProxyFormMode(mode) {
     }
     return (input.value || '').trim() !== '';
   }
+  window.refreshProxyConfiguredSections = function() {
+    document.querySelectorAll('form#proxy-host-form details').forEach(function(det) {
+      var summary = det.querySelector(':scope > summary');
+      if (!summary) return;
+      var oldBadge = summary.querySelector('[data-configured-badge]');
+      if (oldBadge) oldBadge.remove();
+      var n = 0;
+      det.querySelectorAll('input, select, textarea').forEach(function(input) {
+        if (isModified(input)) n++;
+      });
+      det.dataset.configuredCount = String(n);
+      if (n === 0) return;
+      var badge = document.createElement('span');
+      badge.setAttribute('data-configured-badge', '');
+      badge.textContent = n;
+      badge.title = n + ' configured field' + (n === 1 ? '' : 's') + ' in this section';
+      badge.className = 'ml-2 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full text-[10px] font-semibold bg-brand-100 text-brand-700 dark:bg-brand-600/30 dark:text-brand-300';
+      summary.appendChild(badge);
+    });
+  };
   document.querySelectorAll('form#proxy-host-form details').forEach(function(det) {
-    var summary = det.querySelector(':scope > summary');
-    if (!summary) return;
-    var keepOpen = det.hasAttribute('data-keep-open');
-    if (!keepOpen) { det.open = false; }
-    var inputs = det.querySelectorAll('input, select, textarea');
-    var n = 0;
-    inputs.forEach(function(i) { if (isModified(i)) n++; });
-    if (n === 0) return;
-    var badge = document.createElement('span');
-    badge.textContent = n;
-    badge.title = n + ' configured field' + (n === 1 ? '' : 's') + ' in this section';
-    badge.className = 'ml-2 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full text-[10px] font-semibold bg-brand-100 text-brand-700 dark:bg-brand-600/30 dark:text-brand-300';
-    summary.appendChild(badge);
+    if (!det.hasAttribute('data-keep-open')) det.open = false;
   });
+  window.refreshProxyConfiguredSections();
+  var form = document.getElementById('proxy-host-form');
+  if (form) {
+    function updateConfiguredMode() {
+      window.refreshProxyConfiguredSections();
+      if (window.currentProxyFormMode === 'configured') setProxyFormMode('configured');
+    }
+    form.addEventListener('input', updateConfiguredMode);
+    form.addEventListener('change', updateConfiguredMode);
+  }
 })();
 </script>
 


### PR DESCRIPTION
Closes #33

## Summary
- add a live, copyable Caddyfile excerpt to the proxy-host editor beside Route JSON
- generate both previews from unsaved form state through the existing server-side parser
- add a Configured form mode that hides option sections without configured values
- fix the stale DOM ID that prevented the existing JSON preview from loading

## Verification
- `go test ./...`
- `go vet ./...`
- modified inline scripts parsed with Node
- `git diff --check`