### PR TITLE
feat: make CaddyUI's own status monitoring configurable per host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.28.0] - 2026-08-20 - Configurable status monitoring
+
+### Added
+
+- Proxy hosts now control how CaddyUI's own status probes behave, via a **CaddyUI status monitoring** section on the host form. Three modes: **Automatic** (unchanged behaviour), **Custom** (probe path, method, expected status, interval and timeout), and **Off**. ([#39](https://github.com/X4Applegate/caddyui/issues/39))
+- Setting a host to **Off** stops CaddyUI issuing any probe for it — both the 60-second public-domain check behind the App dot and the direct upstream check behind the Port dot. Intended for backends that are deliberately unreachable from the CaddyUI container (split-horizon DNS, firewalled networks), where the probes reported a misleading "down" and added recurring noise to firewall logs.
+- Hosts with monitoring off show a neutral grey dot labelled "monitoring off for this host" rather than a red "down" — no probe ran, so no verdict is claimed.
+
+### Changed
+
+- The host form now states which system each health setting belongs to. CaddyUI's own monitoring and Caddy's active upstream health checks are separate mechanisms that were easy to confuse; the existing `health_check_*` options configure Caddy and are unchanged.
+- Custom probe intervals are floored at 60 seconds and round up to a multiple of the poller's 60-second tick. Timeouts are clamped to 1–120 seconds and expected status to 100–599; an out-of-range entry is pulled to the nearest bound rather than failing the save.
+
+### Fixed
+
+- `ListProxyHostSummaries` now projects `monitor_mode`, which `/api/upstream-health` reads. Without it the Port dot would have resolved every host to "automatic" and ignored the off switch.
+
 ## [2.27.0] - 2026-08-20 - Self-contained assets and advanced-route cross-deploy
 
 ### Fixed

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2123,6 +2123,39 @@ func migrate(db *sql.DB) error {
 	if !columnExists2(db, "proxy_hosts", "disable_upstream_compression") {
 		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN disable_upstream_compression INTEGER NOT NULL DEFAULT 0`)
 	}
+	// v2.28.0 (issue #39): per-host control over CaddyUI's *own* monitoring
+	// probes — the 60s app-health poller against the public domain and the
+	// direct upstream fallback probe. Distinct from the health_check_* columns,
+	// which configure Caddy's active upstream health checking.
+	//
+	// monitor_mode defaults to 'auto' so every existing row keeps the exact
+	// behaviour it had before this migration. 'custom' honours the four
+	// override columns; 'off' suppresses both probes entirely for hosts that
+	// are deliberately unreachable from the CaddyUI container (split DNS,
+	// firewalled backends) and were showing a misleading "down" plus
+	// generating recurring firewall noise.
+	// Stored as '' rather than 'auto' on existing rows: MariaDB is fussier
+	// about non-empty DEFAULTs on TEXT columns than SQLite, and every other
+	// TEXT migration here uses DEFAULT ''. Readers treat '' and 'auto'
+	// identically (see models.normalizeMonitorMode).
+	if !columnExists2(db, "proxy_hosts", "monitor_mode") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN monitor_mode TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "monitor_path") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN monitor_path TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "monitor_method") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN monitor_method TEXT NOT NULL DEFAULT ''`)
+	}
+	if !columnExists2(db, "proxy_hosts", "monitor_expect_status") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN monitor_expect_status INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "proxy_hosts", "monitor_interval_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN monitor_interval_sec INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "proxy_hosts", "monitor_timeout_sec") {
+		_, _ = db.Exec(`ALTER TABLE proxy_hosts ADD COLUMN monitor_timeout_sec INTEGER NOT NULL DEFAULT 0`)
+	}
 	// v2.9.230: redirect_strip_path_prefix — drop a leading path prefix from
 	// the request URI before composing the Location header. Mirrors the
 	// proxy-host strip_path_prefix option for redirects (e.g. on a partial

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -644,8 +644,71 @@ type ProxyHost struct {
 	// in the reverse_proxy block. Useful when the upstream double-compresses
 	// already-compressed responses.
 	DisableUpstreamCompression bool
-	CreatedAt                  time.Time
-	UpdatedAt                  time.Time
+	// v2.28.0 (issue #39): per-host control over CaddyUI's *own* monitoring
+	// probes. These are distinct from the HealthCheck* fields above, which
+	// configure Caddy's active upstream health checking. CaddyUI additionally
+	// runs two probes of its own that were previously unconditional:
+	//
+	//   1. the app-health poller (app_health.go) — an HTTPS GET of "/" against
+	//      the host's public domain every 60s, driving the "App" dot
+	//   2. the upstream fallback probe (apiUpstreamHealth) — a direct
+	//      HEAD/GET against forward_host:forward_port for hosts Caddy's
+	//      admin API doesn't report on, driving the "Port" dot
+	//
+	// Split-DNS installs, hosts that only answer on a specific path, and
+	// backends that are deliberately unreachable from the CaddyUI container
+	// showed a misleading "down" and generated recurring firewall noise.
+	//
+	// MonitorMode: "" / "auto" (default, previous behaviour), "custom", "off".
+	MonitorMode string
+	// The remaining fields apply only when MonitorMode == "custom". Zero
+	// values mean "use the built-in default", so a custom-mode host that only
+	// overrides the path keeps the standard method, interval and timeout.
+	MonitorPath         string // default "/"
+	MonitorMethod       string // "GET" (default) or "HEAD"
+	MonitorExpectStatus int    // 0 = default classification; >0 = require exactly this code
+	MonitorIntervalSec  int    // 0 = default 60; rounded up to a multiple of the 60s poll tick
+	MonitorTimeoutSec   int    // 0 = default 5
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+// MonitoringDisabled reports whether the operator has switched CaddyUI's own
+// probes off for this host. Callers should treat it as "don't emit any
+// outbound request on this host's behalf", not merely "hide the dot".
+func (p *ProxyHost) MonitoringDisabled() bool {
+	return NormalizeMonitorMode(p.MonitorMode) == "off"
+}
+
+// MonitorSettings resolves the effective probe parameters for this host,
+// applying the built-in defaults for anything left at its zero value. The
+// defaults match the hardcoded behaviour that predated issue #39, so an
+// "auto" host probes exactly as it always did.
+func (p *ProxyHost) MonitorSettings(defaultInterval, defaultTimeout time.Duration) (path, method string, expectStatus int, interval, timeout time.Duration) {
+	path, method, expectStatus = "/", "GET", 0
+	interval, timeout = defaultInterval, defaultTimeout
+	if NormalizeMonitorMode(p.MonitorMode) != "custom" {
+		return
+	}
+	if v := strings.TrimSpace(p.MonitorPath); v != "" {
+		if !strings.HasPrefix(v, "/") {
+			v = "/" + v
+		}
+		path = v
+	}
+	if strings.EqualFold(strings.TrimSpace(p.MonitorMethod), "HEAD") {
+		method = "HEAD"
+	}
+	if p.MonitorExpectStatus > 0 {
+		expectStatus = p.MonitorExpectStatus
+	}
+	if p.MonitorIntervalSec > 0 {
+		interval = time.Duration(p.MonitorIntervalSec) * time.Second
+	}
+	if p.MonitorTimeoutSec > 0 {
+		timeout = time.Duration(p.MonitorTimeoutSec) * time.Second
+	}
+	return
 }
 
 // InScheduledMaintenanceWindow returns true when the current wall-clock time
@@ -1705,7 +1768,10 @@ const proxyHostBaseCols = `ph.id, ph.server_id, ph.domains, ph.forward_scheme, p
     COALESCE(ph.proxy_redirect_rules,''),
     COALESCE(ph.additional_upstream_rules,''),
     COALESCE(ph.disable_upstream_compression,0),
-    COALESCE(ph.dns_skip_record,0)`
+    COALESCE(ph.dns_skip_record,0),
+    COALESCE(ph.monitor_mode,'auto'), COALESCE(ph.monitor_path,''),
+    COALESCE(ph.monitor_method,''), COALESCE(ph.monitor_expect_status,0),
+    COALESCE(ph.monitor_interval_sec,0), COALESCE(ph.monitor_timeout_sec,0)`
 
 // scanProxyHost pulls a single row into the struct. Centralises the
 // bool-int unpack so each query site doesn't repeat it.
@@ -2024,6 +2090,10 @@ func scanProxyHost(s interface {
 		&p.AdditionalUpstreamRules,
 		&disableUpstreamCompression, // v2.12.52
 		&dnsSkipRecord,
+		// v2.28.0 (issue #39): CaddyUI's own monitoring controls.
+		&p.MonitorMode, &p.MonitorPath,
+		&p.MonitorMethod, &p.MonitorExpectStatus,
+		&p.MonitorIntervalSec, &p.MonitorTimeoutSec,
 	}
 	if ownerEmail != nil {
 		dst = append(dst, ownerEmail)
@@ -2196,12 +2266,17 @@ func ListProxyHosts(db *sql.DB, serverID int64, viewerID int64, isAdmin bool, pe
 // many containing large JSON/HTML blobs; selecting and scanning all of them
 // made /proxy-hosts increasingly expensive as the host count grew.
 func ListProxyHostSummaries(db *sql.DB, serverID int64, viewerID int64, isAdmin bool, peerIDs []int64) ([]ProxyHost, error) {
+	// v2.28.0 (issue #39): monitor_mode is part of the summary projection
+	// because /api/upstream-health decides whether to probe a host from these
+	// rows. Leaving it out would silently resolve every host to "auto" and
+	// defeat the per-host off switch.
 	const cols = `ph.id, ph.domains, ph.forward_scheme, ph.forward_host, ph.forward_port,
 		ph.ssl_enabled, ph.ssl_forced, ph.enabled, COALESCE(ph.certificate_id, 0),
 		ph.basicauth_enabled, COALESCE(ph.owner_id, 0),
 		COALESCE(ph.dns_provider, ''), COALESCE(ph.dns_record_id, ''),
 		COALESCE(ph.maintenance_mode, 0), COALESCE(ph.tags, ''),
 		COALESCE(ph.notes, ''), COALESCE(ph.color, ''), ph.updated_at,
+		COALESCE(ph.monitor_mode, ''),
 		COALESCE(u.email, '')`
 
 	var rows *sql.Rows
@@ -2239,6 +2314,7 @@ func ListProxyHostSummaries(db *sql.DB, serverID int64, viewerID int64, isAdmin 
 			&sslEnabled, &sslForced, &enabled, &p.CertificateID,
 			&basicAuth, &ownerID, &p.DNSProvider, &p.DNSRecordID,
 			&maintenance, &p.Tags, &p.Notes, &p.Color, &p.UpdatedAt,
+			&p.MonitorMode,
 			&p.OwnerEmail,
 		); err != nil {
 			return nil, err
@@ -2305,6 +2381,29 @@ func boolInt(b bool) int {
 		return 1
 	}
 	return 0
+}
+
+// NormalizeMonitorMode coerces a monitor_mode value to one of the three the
+// rest of the code branches on. Anything unrecognised — including "" on rows
+// created before v2.28.0 — becomes "auto", the behaviour that predated issue
+// #39.
+//
+// Deliberately applied at the form boundary rather than inside
+// CreateProxyHost/UpdateProxyHost. Normalising on write would rewrite ""
+// to "auto" in the database while leaving the caller's in-memory struct at
+// "", so the fleet sync's reflect.DeepEqual of source against the re-read
+// target row would report a difference on every pass and re-push an
+// unchanged host forever. Readers treat "" and "auto" identically, so
+// storing either is safe.
+func NormalizeMonitorMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "off":
+		return "off"
+	case "custom":
+		return "custom"
+	default:
+		return "auto"
+	}
 }
 
 // CreateProxyHost inserts a new proxy host. ownerID 0 means global/admin-owned (NULL in DB).
@@ -2439,8 +2538,10 @@ func CreateProxyHost(db *sql.DB, serverID int64, ownerID int64, p *ProxyHost) (i
             force_canonical_host, add_x_robots_noindex_quick, block_bot_user_agents,
             block_admin_paths, add_link_dns_prefetch, add_link_preconnect,
             add_x_csp_disabled, add_x_request_method_override, proxy_redirect_rules,
-            additional_upstream_rules, disable_upstream_compression)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            additional_upstream_rules, disable_upstream_compression,
+            monitor_mode, monitor_path, monitor_method, monitor_expect_status,
+            monitor_interval_sec, monitor_timeout_sec)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		serverID,
 		p.Domains, p.ForwardScheme, p.ForwardHost, p.ForwardPort,
 		boolInt(p.WebsocketSupport), boolInt(p.BlockCommonExploits),
@@ -2559,6 +2660,12 @@ func CreateProxyHost(db *sql.DB, serverID int64, ownerID int64, p *ProxyHost) (i
 		p.ProxyRedirectRules,
 		p.AdditionalUpstreamRules,
 		boolInt(p.DisableUpstreamCompression), // v2.12.52
+		// v2.28.0 (issue #39): CaddyUI's own monitoring controls. Stored
+		// verbatim — see NormalizeMonitorMode for why normalising here would
+		// break fleet-sync idempotency.
+		p.MonitorMode, p.MonitorPath,
+		p.MonitorMethod, p.MonitorExpectStatus,
+		p.MonitorIntervalSec, p.MonitorTimeoutSec,
 	)
 	if err != nil {
 		return 0, err
@@ -2890,6 +2997,8 @@ func UpdateProxyHost(db *sql.DB, p *ProxyHost) error {
             proxy_redirect_rules=?,
             additional_upstream_rules=?,
             disable_upstream_compression=?,
+            monitor_mode=?, monitor_path=?, monitor_method=?,
+            monitor_expect_status=?, monitor_interval_sec=?, monitor_timeout_sec=?,
             updated_at=CURRENT_TIMESTAMP
         WHERE id = ?`,
 		p.Domains, p.ForwardScheme, p.ForwardHost, p.ForwardPort,
@@ -3190,6 +3299,12 @@ func UpdateProxyHost(db *sql.DB, p *ProxyHost) error {
 		p.ProxyRedirectRules,
 		p.AdditionalUpstreamRules,
 		boolInt(p.DisableUpstreamCompression), // v2.12.52
+		// v2.28.0 (issue #39): CaddyUI's own monitoring controls. Stored
+		// verbatim — see NormalizeMonitorMode for why normalising here would
+		// break fleet-sync idempotency.
+		p.MonitorMode, p.MonitorPath,
+		p.MonitorMethod, p.MonitorExpectStatus,
+		p.MonitorIntervalSec, p.MonitorTimeoutSec,
 		p.ID,
 	)
 	if err != nil {

--- a/internal/models/proxy_monitor_test.go
+++ b/internal/models/proxy_monitor_test.go
@@ -1,0 +1,133 @@
+package models_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	appdb "github.com/X4Applegate/caddyui/internal/db"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// v2.28.0 (issue #39): the monitoring columns must survive a full
+// create → read → update → read round trip, and must reach the summary
+// projection that /api/upstream-health reads.
+
+func newMonitorTestHost() *models.ProxyHost {
+	return &models.ProxyHost{
+		Domains:       "app.example.com",
+		ForwardScheme: "http",
+		ForwardHost:   "app",
+		ForwardPort:   8080,
+		Enabled:       true,
+	}
+}
+
+func TestProxyHostMonitorFieldsRoundTrip(t *testing.T) {
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	host := newMonitorTestHost()
+	host.MonitorMode = "custom"
+	host.MonitorPath = "/healthz"
+	host.MonitorMethod = "HEAD"
+	host.MonitorExpectStatus = 204
+	host.MonitorIntervalSec = 300
+	host.MonitorTimeoutSec = 12
+
+	id, err := models.CreateProxyHost(conn, 1, 0, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := models.GetProxyHost(conn, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MonitorMode != "custom" || got.MonitorPath != "/healthz" || got.MonitorMethod != "HEAD" {
+		t.Errorf("after create: mode=%q path=%q method=%q", got.MonitorMode, got.MonitorPath, got.MonitorMethod)
+	}
+	if got.MonitorExpectStatus != 204 || got.MonitorIntervalSec != 300 || got.MonitorTimeoutSec != 12 {
+		t.Errorf("after create: expect=%d interval=%d timeout=%d",
+			got.MonitorExpectStatus, got.MonitorIntervalSec, got.MonitorTimeoutSec)
+	}
+
+	got.MonitorMode = "off"
+	got.MonitorExpectStatus = 0
+	if err := models.UpdateProxyHost(conn, got); err != nil {
+		t.Fatal(err)
+	}
+	got2, err := models.GetProxyHost(conn, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got2.MonitorMode != "off" {
+		t.Errorf("after update: mode = %q, want off", got2.MonitorMode)
+	}
+	if !got2.MonitoringDisabled() {
+		t.Error("MonitoringDisabled() should be true after switching to off")
+	}
+	if got2.MonitorExpectStatus != 0 {
+		t.Errorf("after update: expect = %d, want 0 (cleared)", got2.MonitorExpectStatus)
+	}
+	// Overrides the user typed earlier survive a switch away from custom, so
+	// flipping back does not lose them.
+	if got2.MonitorPath != "/healthz" {
+		t.Errorf("after update: path = %q, want /healthz preserved", got2.MonitorPath)
+	}
+}
+
+// A host created without touching the monitoring fields must read back as
+// "auto" behaviour — this is what keeps every pre-v2.28.0 row unchanged.
+func TestProxyHostMonitorDefaultsToAuto(t *testing.T) {
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	id, err := models.CreateProxyHost(conn, 1, 0, newMonitorTestHost())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := models.GetProxyHost(conn, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MonitoringDisabled() {
+		t.Error("a host that never set a monitor mode must not be disabled")
+	}
+	if models.NormalizeMonitorMode(got.MonitorMode) != "auto" {
+		t.Errorf("normalized mode = %q, want auto", models.NormalizeMonitorMode(got.MonitorMode))
+	}
+}
+
+// /api/upstream-health decides whether to probe from the summary rows, so
+// monitor_mode has to be part of that projection. Without it every host
+// silently resolves to "auto" and the off switch does nothing.
+func TestListProxyHostSummariesIncludesMonitorMode(t *testing.T) {
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	host := newMonitorTestHost()
+	host.MonitorMode = "off"
+	if _, err := models.CreateProxyHost(conn, 1, 0, host); err != nil {
+		t.Fatal(err)
+	}
+
+	summaries, err := models.ListProxyHostSummaries(conn, 1, 0, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("summaries = %d, want 1", len(summaries))
+	}
+	if !summaries[0].MonitoringDisabled() {
+		t.Errorf("summary MonitorMode = %q; the off switch would be ignored by /api/upstream-health",
+			summaries[0].MonitorMode)
+	}
+}

--- a/internal/server/app_health.go
+++ b/internal/server/app_health.go
@@ -94,6 +94,17 @@ func (s *Server) pollAllApps(ctx context.Context) {
 	for _, h := range allHosts {
 		wg.Add(1)
 		sem <- struct{}{}
+		// v2.28.0 (issue #39): skip hosts whose custom interval hasn't elapsed
+		// yet. The ticker still fires every appHealthInterval; a host asking
+		// for a longer gap simply sits out the intervening cycles, so the
+		// effective interval rounds up to a multiple of the tick. Checked
+		// before spawning the goroutine so a mostly-idle fleet doesn't
+		// allocate workers it will immediately discard.
+		if !s.appProbeDue(h) {
+			wg.Done()
+			<-sem
+			continue
+		}
 		go func(h models.ProxyHost) {
 			defer wg.Done()
 			defer func() { <-sem }()
@@ -137,10 +148,38 @@ func (s *Server) pollAllApps(ctx context.Context) {
 // ends up as ok (200) rather than showing the 302. Cert validation is
 // skipped — an expired or self-signed cert shouldn't mask the fact that the
 // upstream *is* responding; the cert-expiry notifier handles that concern.
+// appProbeDue reports whether enough time has passed since this host's last
+// cached probe to warrant another one. Hosts on the default interval are
+// always due, because the poller tick already paces them.
+//
+// v2.28.0 (issue #39).
+func (s *Server) appProbeDue(h models.ProxyHost) bool {
+	_, _, _, interval, _ := h.MonitorSettings(appHealthInterval, appHealthProbeTO)
+	if interval <= appHealthInterval {
+		return true
+	}
+	s.appHealthMu.Lock()
+	prev, ok := s.appHealth[h.ID]
+	s.appHealthMu.Unlock()
+	if !ok || prev.CheckedAt.IsZero() {
+		return true
+	}
+	// Subtract half a tick so a host configured at exactly 2× the interval
+	// isn't pushed out to 3× by scheduling jitter.
+	return time.Since(prev.CheckedAt) >= interval-(appHealthInterval/2)
+}
+
 func (s *Server) probeApp(ctx context.Context, h models.ProxyHost) appHealthEntry {
 	now := time.Now()
 	if !h.Enabled {
 		return appHealthEntry{Status: "disabled", CheckedAt: now}
+	}
+	// v2.28.0 (issue #39): the operator has switched CaddyUI's own probes off
+	// for this host. Emit no outbound request at all — the whole point is to
+	// stop generating traffic toward a backend that is deliberately
+	// unreachable from here, not merely to hide the dot.
+	if h.MonitoringDisabled() {
+		return appHealthEntry{Status: "off", Error: "monitoring disabled for this host", CheckedAt: now}
 	}
 
 	domains := h.DomainList()
@@ -179,10 +218,14 @@ func (s *Server) probeApp(ctx context.Context, h models.ProxyHost) appHealthEntr
 	if !h.SSLEnabled && h.CertificateID == 0 {
 		scheme = "http"
 	}
-	probeURL := (&url.URL{Scheme: scheme, Host: primary, Path: "/"}).String()
+	// v2.28.0 (issue #39): resolve the per-host probe overrides. An "auto"
+	// host yields exactly the values that were hardcoded before this change,
+	// so its behaviour is unchanged.
+	probePath, probeMethod, expectStatus, _, probeTimeout := h.MonitorSettings(appHealthInterval, appHealthProbeTO)
+	probeURL := (&url.URL{Scheme: scheme, Host: primary, Path: probePath}).String()
 
 	client := &http.Client{
-		Timeout: appHealthProbeTO,
+		Timeout: probeTimeout,
 		Transport: &http.Transport{
 			// Skip TLS verification: we care whether the app responds, not
 			// about cert validity (that's tracked separately by the cert
@@ -200,9 +243,9 @@ func (s *Server) probeApp(ctx context.Context, h models.ProxyHost) appHealthEntr
 		},
 	}
 
-	probeCtx, cancel := context.WithTimeout(ctx, appHealthProbeTO)
+	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
+	req, err := http.NewRequestWithContext(probeCtx, probeMethod, probeURL, nil)
 	if err != nil {
 		return appHealthEntry{Status: "down", Error: err.Error(), CheckedAt: now}
 	}
@@ -238,6 +281,20 @@ func (s *Server) probeApp(ctx context.Context, h models.ProxyHost) appHealthEntr
 
 	code := resp.StatusCode
 	entry := appHealthEntry{Code: code, LatencyMS: latency, CheckedAt: now}
+	// v2.28.0 (issue #39): when the host declares an exact expected status,
+	// that verdict replaces the heuristic below entirely. This is what makes
+	// deliberately-unusual endpoints reportable — a health path that answers
+	// 204, or an app that correctly returns 418 on its probe route, is "ok"
+	// only if the operator said so, and anything else is unambiguously down.
+	if expectStatus > 0 {
+		if code == expectStatus {
+			entry.Status = "ok"
+		} else {
+			entry.Status = "down"
+			entry.Error = fmt.Sprintf("HTTP %d (expected %d)", code, expectStatus)
+		}
+		return entry
+	}
 	switch {
 	case code >= 500:
 		entry.Status = "degraded"

--- a/internal/server/app_health_monitor_test.go
+++ b/internal/server/app_health_monitor_test.go
@@ -1,0 +1,195 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// hostportOf extracts "127.0.0.1:port" from an httptest server URL so it can
+// be used as a ProxyHost domain. probeApp builds its own scheme, so the
+// domain must not carry one.
+func hostportOf(t *testing.T, rawURL string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse test server URL %q: %v", rawURL, err)
+	}
+	return u.Host
+}
+
+// v2.28.0 (issue #39): per-host control over CaddyUI's own monitoring probes.
+
+func TestMonitorSettingsDefaultsMatchPreIssue39Behaviour(t *testing.T) {
+	for _, mode := range []string{"", "auto", "AUTO", "nonsense"} {
+		p := models.ProxyHost{MonitorMode: mode, MonitorPath: "/ignored", MonitorMethod: "HEAD", MonitorIntervalSec: 900}
+		path, method, expect, interval, timeout := p.MonitorSettings(60*time.Second, 5*time.Second)
+		if path != "/" || method != "GET" || expect != 0 {
+			t.Errorf("mode %q: got %s %s expect=%d, want GET / expect=0", mode, method, path, expect)
+		}
+		if interval != 60*time.Second || timeout != 5*time.Second {
+			t.Errorf("mode %q: got interval=%v timeout=%v, want 60s/5s", mode, interval, timeout)
+		}
+	}
+}
+
+func TestMonitorSettingsCustomOverrides(t *testing.T) {
+	p := models.ProxyHost{
+		MonitorMode:         "custom",
+		MonitorPath:         "healthz", // no leading slash on purpose
+		MonitorMethod:       "head",
+		MonitorExpectStatus: 204,
+		MonitorIntervalSec:  300,
+		MonitorTimeoutSec:   12,
+	}
+	path, method, expect, interval, timeout := p.MonitorSettings(60*time.Second, 5*time.Second)
+	if path != "/healthz" {
+		t.Errorf("path = %q, want /healthz (leading slash added)", path)
+	}
+	if method != "HEAD" {
+		t.Errorf("method = %q, want HEAD", method)
+	}
+	if expect != 204 || interval != 300*time.Second || timeout != 12*time.Second {
+		t.Errorf("expect=%d interval=%v timeout=%v, want 204/300s/12s", expect, interval, timeout)
+	}
+}
+
+func TestMonitorSettingsCustomFallsBackPerField(t *testing.T) {
+	// A custom-mode host that overrides only the path keeps every other default.
+	p := models.ProxyHost{MonitorMode: "custom", MonitorPath: "/up"}
+	path, method, expect, interval, timeout := p.MonitorSettings(60*time.Second, 5*time.Second)
+	if path != "/up" || method != "GET" || expect != 0 || interval != 60*time.Second || timeout != 5*time.Second {
+		t.Errorf("got %s %s expect=%d interval=%v timeout=%v; only the path should change",
+			method, path, expect, interval, timeout)
+	}
+}
+
+func TestMonitoringDisabledOnlyForOff(t *testing.T) {
+	for mode, want := range map[string]bool{"": false, "auto": false, "custom": false, "off": true, "OFF": true, " off ": true} {
+		if got := (&models.ProxyHost{MonitorMode: mode}).MonitoringDisabled(); got != want {
+			t.Errorf("MonitoringDisabled(%q) = %v, want %v", mode, got, want)
+		}
+	}
+}
+
+// probeApp must emit no outbound request at all when monitoring is off. The
+// whole point of the off switch is to stop traffic toward a backend that is
+// deliberately unreachable, not merely to hide the dot.
+func TestProbeAppMakesNoRequestWhenMonitoringOff(t *testing.T) {
+	var hits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := &Server{appHealth: map[int64]appHealthEntry{}}
+	host := models.ProxyHost{
+		ID:          1,
+		Enabled:     true,
+		Domains:     hostportOf(t, srv.URL),
+		SSLEnabled:  false,
+		MonitorMode: "off",
+	}
+	entry := s.probeApp(context.Background(), host)
+	if entry.Status != "off" {
+		t.Errorf("status = %q, want off", entry.Status)
+	}
+	if n := atomic.LoadInt64(&hits); n != 0 {
+		t.Errorf("probe made %d request(s) with monitoring off, want 0", n)
+	}
+}
+
+// A custom probe must actually use the configured path and method.
+func TestProbeAppUsesCustomPathAndMethod(t *testing.T) {
+	gotPath := make(chan string, 4)
+	gotMethod := make(chan string, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath <- r.URL.Path
+		gotMethod <- r.Method
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	s := &Server{appHealth: map[int64]appHealthEntry{}}
+	host := models.ProxyHost{
+		ID:                  1,
+		Enabled:             true,
+		Domains:             hostportOf(t, srv.URL),
+		SSLEnabled:          false,
+		MonitorMode:         "custom",
+		MonitorPath:         "/healthz",
+		MonitorMethod:       "HEAD",
+		MonitorExpectStatus: 204,
+	}
+	entry := s.probeApp(context.Background(), host)
+	if p := <-gotPath; p != "/healthz" {
+		t.Errorf("probed path = %q, want /healthz", p)
+	}
+	if m := <-gotMethod; m != "HEAD" {
+		t.Errorf("probed method = %q, want HEAD", m)
+	}
+	// 204 is neither 2xx-with-body nor an error; without the expect-status
+	// override the default classifier calls it ok too, so assert the code
+	// round-tripped and the verdict is ok.
+	if entry.Status != "ok" || entry.Code != 204 {
+		t.Errorf("entry = %+v, want ok/204", entry)
+	}
+}
+
+// An unexpected status under an explicit expectation is unambiguously down.
+func TestProbeAppExpectStatusMismatchIsDown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK) // 200, but the host demands 204
+	}))
+	defer srv.Close()
+
+	s := &Server{appHealth: map[int64]appHealthEntry{}}
+	host := models.ProxyHost{
+		ID:                  1,
+		Enabled:             true,
+		Domains:             hostportOf(t, srv.URL),
+		SSLEnabled:          false,
+		MonitorMode:         "custom",
+		MonitorExpectStatus: 204,
+	}
+	entry := s.probeApp(context.Background(), host)
+	if entry.Status != "down" {
+		t.Errorf("status = %q, want down (200 received, 204 expected)", entry.Status)
+	}
+	if entry.Code != 200 {
+		t.Errorf("code = %d, want 200", entry.Code)
+	}
+}
+
+// appProbeDue paces hosts that asked for a longer interval, and never delays
+// hosts on the default.
+func TestAppProbeDueRespectsCustomInterval(t *testing.T) {
+	s := &Server{appHealth: map[int64]appHealthEntry{}}
+
+	def := models.ProxyHost{ID: 1}
+	if !s.appProbeDue(def) {
+		t.Error("default-interval host should always be due")
+	}
+
+	slow := models.ProxyHost{ID: 2, MonitorMode: "custom", MonitorIntervalSec: 600}
+	if !s.appProbeDue(slow) {
+		t.Error("never-probed host should be due")
+	}
+
+	s.appHealth[2] = appHealthEntry{Status: "ok", CheckedAt: time.Now()}
+	if s.appProbeDue(slow) {
+		t.Error("host probed just now with a 600s interval should not be due")
+	}
+
+	s.appHealth[2] = appHealthEntry{Status: "ok", CheckedAt: time.Now().Add(-11 * time.Minute)}
+	if !s.appProbeDue(slow) {
+		t.Error("host last probed 11m ago with a 600s interval should be due")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4330,6 +4330,28 @@ func (s *Server) newProxyHost(w http.ResponseWriter, r *http.Request) {
 	}))
 }
 
+// clampAtoi parses a form value as an int and constrains it to [min, max].
+// Blank, unparseable, or non-positive input yields zeroValue, which callers
+// use as their "unset — fall back to the built-in default" sentinel. A value
+// that parses but falls outside the range is pulled to the nearest bound
+// rather than rejected, so a typo in one numeric field can't fail the whole
+// form save.
+//
+// v2.28.0 (issue #39).
+func clampAtoi(raw string, zeroValue, min, max int) int {
+	v, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || v <= 0 {
+		return zeroValue
+	}
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
+}
+
 func parseProxyHostForm(r *http.Request) (*models.ProxyHost, error) {
 	_ = r.ParseForm()
 	port, err := strconv.Atoi(r.FormValue("forward_port"))
@@ -4961,6 +4983,19 @@ func parseProxyHostForm(r *http.Request) (*models.ProxyHost, error) {
 	ph.AddXRequestMethodOverride = r.FormValue("add_x_request_method_override") == "on"
 	// v2.12.52: disable upstream compression toggle.
 	ph.DisableUpstreamCompression = r.FormValue("disable_upstream_compression") == "on"
+	// v2.28.0 (issue #39): CaddyUI's own monitoring controls. The override
+	// fields are parsed regardless of mode so switching custom → auto → custom
+	// doesn't discard what the user typed; the mode alone decides whether they
+	// take effect (see models.ProxyHost.MonitorSettings).
+	ph.MonitorMode = models.NormalizeMonitorMode(r.FormValue("monitor_mode"))
+	ph.MonitorPath = strings.TrimSpace(r.FormValue("monitor_path"))
+	ph.MonitorMethod = strings.ToUpper(strings.TrimSpace(r.FormValue("monitor_method")))
+	ph.MonitorExpectStatus = clampAtoi(r.FormValue("monitor_expect_status"), 0, 100, 599)
+	// Floor the interval at the poller's own tick: a smaller value can't be
+	// honoured (the poller only wakes every appHealthInterval) and storing it
+	// would promise a cadence the UI can't deliver.
+	ph.MonitorIntervalSec = clampAtoi(r.FormValue("monitor_interval_sec"), 0, 60, 86400)
+	ph.MonitorTimeoutSec = clampAtoi(r.FormValue("monitor_timeout_sec"), 0, 1, 120)
 	// v2.9.266: proxy_redirect_rules — JSON array of path-based redirects
 	// fired before the reverse_proxy. Same shape as redirection_hosts.
 	ph.ProxyRedirectRules = func() string {
@@ -11371,6 +11406,16 @@ func (s *Server) apiUpstreamHealth(w http.ResponseWriter, r *http.Request) {
 		results[i] = upstreamHealthResult{ID: h.ID, Domains: h.Domains}
 		if !h.Enabled {
 			results[i].Status = "disabled"
+			continue
+		}
+		// v2.28.0 (issue #39): monitoring switched off for this host. Reading
+		// Caddy's own upstream map would be harmless, but reporting a verdict
+		// from it would contradict the UI's "monitoring off" state, and the
+		// fallback branch below would emit exactly the probe traffic the
+		// operator asked us to stop. Skip the host entirely.
+		if h.MonitoringDisabled() {
+			results[i].Status = "off"
+			results[i].Error = "monitoring disabled for this host"
 			continue
 		}
 

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -270,6 +270,48 @@ func TestAdvancedRouteFormOffersCrossDeploy(t *testing.T) {
 	}
 }
 
+// TestMonitoringControlsAndOffStateAreWired covers issue #39. Two halves have
+// to stay in sync: the form must offer the mode selector, and every status-dot
+// painter must special-case "off". If a painter loses its "off" branch the
+// status falls through to the red "down" dot — the precise opposite of what
+// switching monitoring off is supposed to convey.
+func TestMonitoringControlsAndOffStateAreWired(t *testing.T) {
+	form, err := FS.ReadFile("templates/proxy_host_form.html")
+	if err != nil {
+		t.Fatalf("read proxy_host_form.html: %v", err)
+	}
+	formHTML := string(form)
+	for _, marker := range []string{
+		`name="monitor_mode"`,
+		`name="monitor_path"`,
+		`name="monitor_method"`,
+		`name="monitor_expect_status"`,
+		`name="monitor_interval_sec"`,
+		`name="monitor_timeout_sec"`,
+		`id="monitor-custom"`,
+		"CaddyUI status monitoring",
+	} {
+		if !strings.Contains(formHTML, marker) {
+			t.Errorf("proxy host form missing monitoring control %q", marker)
+		}
+	}
+
+	for _, name := range []string{"templates/proxy_hosts.html", "templates/dashboard.html"} {
+		body, err := FS.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		html := string(body)
+		// Both painters live in each file: the Port dot keys off h.status and
+		// the App dot off a local `s`, so require both spellings.
+		for _, branch := range []string{`h.status === 'off'`, `s === 'off'`} {
+			if !strings.Contains(html, branch) {
+				t.Errorf("%s missing status-dot branch %q — an off host would paint red", name, branch)
+			}
+		}
+	}
+}
+
 // TestCaptchaSecretsNeverRenderIntoTheDOM covers the settings-page leak where
 // turnstile_secret_key / recaptcha_secret_key were emitted as input values.
 // type="password" masks them visually, but the plaintext is readable via

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -498,6 +498,11 @@
     } else if (h.status === 'disabled') {
       dot.classList.add('bg-ink-300');
       dot.title = 'Port: disabled';
+    } else if (h.status === 'off') {
+      // v2.28.0 (issue #39): monitoring switched off for this host. Neutral
+      // dot, never red — nothing was probed, so "down" would be unfounded.
+      dot.classList.add('bg-ink-300');
+      dot.title = 'Port: monitoring off for this host';
     } else if (h.status === 'unknown') {
       dot.classList.add('bg-amber-400');
       dot.title = 'Port: unknown (' + (h.error || 'not probeable from caddyui') + ')';
@@ -522,6 +527,10 @@
     } else if (s === 'disabled') {
       dot.classList.add('bg-ink-300');
       dot.title = 'App: disabled';
+    } else if (s === 'off') {
+      // v2.28.0 (issue #39): see paintPort — no probe ran, so no verdict.
+      dot.classList.add('bg-ink-300');
+      dot.title = 'App: monitoring off for this host';
     } else if (s === 'unknown') {
       dot.classList.add('bg-amber-400');
       dot.title = 'App: unknown (' + (h.app_error || 'not probeable from caddyui') + ')';

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -1321,9 +1321,72 @@ document.addEventListener('DOMContentLoaded', function() {
         <p class="text-xs text-ink-500 sm:pt-7">Sets a per-SNI TLS connection policy in Caddy. TLS 1.2+ is the modern standard. TLS 1.3 offers improved security and performance but drops support for some older clients.</p>
       </div>
 
+      {{/* v2.28.0 (issue #39): CaddyUI's own monitoring probes. Deliberately
+           placed immediately above the Caddy health-check block, and labelled
+           to say who is doing the probing — the two were easy to confuse, and
+           the settings below this point do not affect these dots at all. */}}
+      <div class="border-t border-gray-100 dark:border-gray-800 pt-3 mt-3 space-y-3">
+        <p class="text-xs font-medium text-ink-700">CaddyUI status monitoring <span class="font-normal text-ink-400">(drives the App and Port dots — not Caddy's own health checking)</span></p>
+        <p class="text-xs text-ink-500">CaddyUI probes this host from its own container to show status in the dashboard: an HTTPS request to the public domain, and a direct check of the upstream. Turn it off for hosts that are deliberately unreachable from here — split-horizon DNS, firewalled backends — where the probe would report a misleading “down” and add noise to your firewall logs.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 items-start">
+          <div>
+            <label class="block text-sm font-medium text-ink-800 mb-1.5">Monitoring</label>
+            <select name="monitor_mode" id="monitor-mode"
+              class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+              <option value="auto" {{if or (eq .Host.MonitorMode "") (eq .Host.MonitorMode "auto")}}selected{{end}}>Automatic (default)</option>
+              <option value="custom" {{if eq .Host.MonitorMode "custom"}}selected{{end}}>Custom path, method and timing</option>
+              <option value="off" {{if eq .Host.MonitorMode "off"}}selected{{end}}>Off — never probe this host</option>
+            </select>
+          </div>
+          <p class="text-xs text-ink-500 sm:pt-7">Automatic probes <code>GET /</code> every 60&nbsp;seconds with a 5&nbsp;second timeout. Off stops all outbound probes for this host and shows a neutral dot.</p>
+        </div>
+
+        <div id="monitor-custom" class="space-y-3 {{if ne .Host.MonitorMode "custom"}}hidden{{end}}">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label class="block text-sm font-medium text-ink-800 mb-1.5">Probe path</label>
+              <input type="text" name="monitor_path" value="{{.Host.MonitorPath}}" placeholder="/"
+                class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+              <p class="text-xs text-ink-500 mt-1">Blank uses <code>/</code>. Point this at a lightweight endpoint to keep probe traffic cheap.</p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-ink-800 mb-1.5">Method</label>
+              <select name="monitor_method"
+                class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+                <option value="GET" {{if ne .Host.MonitorMethod "HEAD"}}selected{{end}}>GET (default)</option>
+                <option value="HEAD" {{if eq .Host.MonitorMethod "HEAD"}}selected{{end}}>HEAD (no response body)</option>
+              </select>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label class="block text-sm font-medium text-ink-800 mb-1.5">Expected status</label>
+              <input type="number" name="monitor_expect_status" value="{{if .Host.MonitorExpectStatus}}{{.Host.MonitorExpectStatus}}{{end}}"
+                min="100" max="599" placeholder="any"
+                class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+              <p class="text-xs text-ink-500 mt-1">Blank accepts 2xx/3xx/401/403.</p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-ink-800 mb-1.5">Interval (seconds)</label>
+              <input type="number" name="monitor_interval_sec" value="{{if .Host.MonitorIntervalSec}}{{.Host.MonitorIntervalSec}}{{end}}"
+                min="60" max="86400" placeholder="60"
+                class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+              <p class="text-xs text-ink-500 mt-1">Minimum 60, rounded up to a multiple of 60.</p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-ink-800 mb-1.5">Timeout (seconds)</label>
+              <input type="number" name="monitor_timeout_sec" value="{{if .Host.MonitorTimeoutSec}}{{.Host.MonitorTimeoutSec}}{{end}}"
+                min="1" max="120" placeholder="5"
+                class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
+              <p class="text-xs text-ink-500 mt-1">Blank uses 5.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
       {{/* v2.9.4: Active upstream health check */}}
       <div class="border-t border-gray-100 dark:border-gray-800 pt-3 mt-3 space-y-3">
-        <p class="text-xs font-medium text-ink-700">Active upstream health check <span class="font-normal text-ink-400">(Caddy polls each upstream on this URI)</span></p>
+        <p class="text-xs font-medium text-ink-700">Active upstream health check <span class="font-normal text-ink-400">(Caddy polls each upstream on this URI — separate from CaddyUI's dots above)</span></p>
         <div class="flex items-center gap-3">
           <label class="text-sm text-gray-700 dark:text-gray-300 w-48 shrink-0">Health check URI</label>
           <input type="text" name="health_check_uri" value="{{.Host.HealthCheckURI}}"
@@ -4605,6 +4668,21 @@ document.addEventListener('DOMContentLoaded', function() {
   form.addEventListener('input', refreshReview);
   form.addEventListener('change', refreshReview);
   showStep(current, false);
+})();
+
+// v2.28.0 (issue #39): reveal the CaddyUI monitoring overrides only in custom
+// mode. The inputs stay in the DOM (and keep submitting) in every mode so a
+// user who flips to Off and back doesn't silently lose what they typed —
+// the server decides what to honour based on the mode alone.
+(function() {
+  var mode = document.getElementById('monitor-mode');
+  var custom = document.getElementById('monitor-custom');
+  if (!mode || !custom) return;
+  function sync() {
+    custom.classList.toggle('hidden', mode.value !== 'custom');
+  }
+  mode.addEventListener('change', sync);
+  sync();
 })();
 </script>
 {{end}}

--- a/web/templates/proxy_hosts.html
+++ b/web/templates/proxy_hosts.html
@@ -655,6 +655,12 @@ function fetchUpstreams() {
     } else if (h.status === 'disabled') {
       dot.classList.add('bg-ink-300');
       dot.title = 'Port: disabled';
+    } else if (h.status === 'off') {
+      // v2.28.0 (issue #39): monitoring switched off for this host. Neutral
+      // dot, never red — nothing was probed, so "down" would be a claim we
+      // have no evidence for.
+      dot.classList.add('bg-ink-300');
+      dot.title = 'Port: monitoring off for this host';
     } else if (h.status === 'unknown') {
       dot.classList.add('bg-amber-400');
       dot.title = 'Port: unknown (' + (h.error || 'not probeable from caddyui') + ')';
@@ -680,6 +686,10 @@ function fetchUpstreams() {
     } else if (s === 'disabled') {
       dot.classList.add('bg-ink-300');
       dot.title = 'App: disabled';
+    } else if (s === 'off') {
+      // v2.28.0 (issue #39): see paintPort — no probe ran, so no verdict.
+      dot.classList.add('bg-ink-300');
+      dot.title = 'App: monitoring off for this host';
     } else if (s === 'unknown') {
       dot.classList.add('bg-amber-400');
       dot.title = 'App: unknown (' + (h.app_error || 'not probeable from caddyui') + ')';


### PR DESCRIPTION
Closes #39.

## What was actually unconfigurable

Worth separating two things the issue understandably conflates. Caddy's **active upstream health checks** are already extensively configurable — 18 form fields (`health_check_uri`, `_method`, `_interval_sec`, `_expect_status`, `_port`, `_host_override`, TLS, basic auth, …). Those are unchanged here.

What had no controls at all were the two probes **CaddyUI itself** issues:

| Probe | Where | Cadence | Drives |
|---|---|---|---|
| Public-domain HTTPS `GET /` | `app_health.go` | every 60s, hardcoded | the **App** dot |
| Direct `HEAD`/`GET` to `forward_host:forward_port` | `apiUpstreamHealth` | on page load | the **Port** dot |

Both ran unconditionally against every enabled host. For a backend deliberately unreachable from the CaddyUI container — split-horizon DNS, a firewalled network — those probes could only ever report a misleading "down", while generating exactly the recurring firewall noise the issue describes.

## What this adds

A **CaddyUI status monitoring** section on the proxy host form, placed directly above the Caddy health-check block and labelled to say which system it drives.

- **Automatic** — unchanged behaviour (`GET /`, 60s, 5s timeout)
- **Custom** — probe path, method, expected status, interval, timeout
- **Off** — no probe is issued for this host at all

"Off" suppresses both probes rather than hiding the dot; the point is to stop the traffic. Such a host paints a **neutral** dot ("monitoring off for this host"), never red — no probe ran, so "down" would be a verdict without evidence. This needed a new branch in all four dot painters; without it "off" fell through to the red `else`, the exact opposite of the intent.

Custom fields fall back independently, so overriding only the path leaves method, interval and timeout at their defaults. An explicit expected status replaces the classification heuristic entirely, which is what makes an endpoint answering 204 reportable as healthy.

## Two things worth reviewing

**`monitor_mode` is normalized at the form boundary, not on write.** Normalizing inside `CreateProxyHost`/`UpdateProxyHost` stored `"auto"` while leaving the caller's in-memory struct at `""`, so the fleet sync's `reflect.DeepEqual` of source against the re-read target row reported a difference on every pass and would have re-pushed unchanged hosts forever. The existing `TestFleetProxyUpsertTracksSourceAndPreservesTargetPolicy` caught this.

**`monitor_mode` had to be added to the `ListProxyHostSummaries` projection**, which `/api/upstream-health` reads. Without it every host resolved to "auto" and the off switch would have been silently ignored on the Port dot — a bug that would have looked like the feature half-working. There's now a regression test for exactly that.

## Not applicable to advanced routes

The issue asks about advanced routes too. The app-health poller only iterates proxy hosts — advanced routes are never probed, so there is nothing there to disable or tune. Adding monitoring to them would mean building the probing first, which is a separate piece of work rather than part of this fix.

## Verification

`go build`, `go vet`, `go test ./...` all pass, plus 11 new tests. Beyond that, the built binary was exercised against a database created by the **published v2.27.0 release binary**, so the `ALTER TABLE` upgrade path ran for real: clean, no errors, existing session and data intact.

With one host set to Off and another to Custom (`/healthz`, HEAD, expect 204):

```
custom.example.com   port=unknown   app=unknown   Head "http://custom.example.com/healthz": di…
off.example.com      port=off       app=off       monitoring disabled for this host
```

The poller's own error string shows `Head` and `/healthz` — both custom overrides took effect. The Off host was never probed by either system. Clamping verified through the form: interval `5` → `60` (floored), timeout `999` → `120` (ceiling), and all values round-trip through the edit form.

Existing rows migrate to `''` and read as automatic, so nothing changes for hosts that don't opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)