### PR TITLE
feat: require CSRF tokens on cookie-authenticated state changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.29.0] - 2026-08-20 - CSRF protection
+
+### Security
+
+- State-changing requests authenticated by session cookie now require a CSRF token. Session cookies were already `SameSite=Lax`, which blocks the classic cross-site form POST in current browsers, but that was a single layer resting on a browser default; this adds a synchroniser token as defence in depth across all 94 authenticated `POST`/`DELETE` routes.
+- The token is `HMAC-SHA256(secret, sessionToken)`, so it needs no storage of its own and is bound to one session. Logging out or logging in again rotates it, and a token from a closed session is rejected. The secret is generated once and persisted, so tokens survive a restart rather than 403-ing every logged-in user on deploy.
+- Requests authenticated by API bearer token are exempt and unchanged. A browser does not attach an `Authorization` header to a cross-site request on its own, so those calls are not CSRF-reachable.
+
+### Changed
+
+- Pages render into a buffer before being written. This is what lets the hidden token input be stamped into every POST form from a single place, and as a side effect a mid-template error now produces a clean `500` instead of a truncated page followed by an error string.
+- `window.fetch` is wrapped in `app.js` to attach the `X-CSRF-Token` header to same-origin requests using an unsafe method, so scripted callers are protected by default. Cross-origin requests are untouched — the token is never sent to a third-party host.
+
 ## [2.28.0] - 2026-08-20 - Configurable status monitoring
 
 ### Added

--- a/internal/server/csrf.go
+++ b/internal/server/csrf.go
@@ -1,0 +1,279 @@
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"html/template"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/X4Applegate/caddyui/internal/auth"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// CSRF protection for cookie-authenticated, state-changing requests.
+//
+// v2.29.0. Session cookies are SameSite=Lax, which already blocks the classic
+// cross-site form POST in current browsers, but that is a single layer resting
+// on a browser default. This adds a synchroniser token as defence in depth.
+//
+// The token is HMAC-SHA256(secret, sessionToken), so it needs no storage of
+// its own and is automatically bound to one session: logging out or logging in
+// again produces a new session token and therefore a new CSRF token. An
+// attacker cannot compute it without reading the victim's session cookie,
+// which is HttpOnly.
+//
+// Requests authenticated by bearer token are exempt. A browser never attaches
+// an Authorization header to a cross-site request on its own, so those calls
+// are not CSRF-reachable, and requiring a token would break API clients.
+
+const (
+	csrfFieldName  = "csrf_token"
+	csrfHeaderName = "X-CSRF-Token"
+	settingCSRFKey = "csrf_secret"
+)
+
+// csrfSecret returns the process-wide HMAC key, generating and persisting one
+// on first use. Kept in the settings table rather than derived from something
+// like the DB path so tokens stay valid across restarts — regenerating on boot
+// would invalidate every live session's token and 403 users mid-flow.
+func (s *Server) csrfSecret() []byte {
+	s.csrfSecretOnce.Do(func() {
+		if existing, err := models.GetSetting(s.DB, settingCSRFKey); err == nil {
+			if raw, err := hex.DecodeString(strings.TrimSpace(existing)); err == nil && len(raw) == 32 {
+				s.csrfSecretCache = raw
+				return
+			}
+		}
+		buf := make([]byte, 32)
+		if _, err := rand.Read(buf); err != nil {
+			// crypto/rand failing is not recoverable in any useful way here.
+			// Panicking beats silently falling back to a predictable key that
+			// would make every token forgeable.
+			panic("csrf: generate secret: " + err.Error())
+		}
+		if err := models.SetSetting(s.DB, settingCSRFKey, hex.EncodeToString(buf)); err != nil {
+			// Persisting failed — keep the in-memory key so this process still
+			// works. Tokens simply won't survive a restart.
+			log.Printf("csrf: persist secret: %v", err)
+		}
+		s.csrfSecretCache = buf
+	})
+	return s.csrfSecretCache
+}
+
+// csrfTokenFor derives the token for a session token. Returns "" for an empty
+// session so anonymous pages render no token rather than a constant one.
+func (s *Server) csrfTokenFor(sessionToken string) string {
+	if sessionToken == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, s.csrfSecret())
+	mac.Write([]byte(sessionToken))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// csrfTokenForRequest reads the session cookie and derives its token.
+func (s *Server) csrfTokenForRequest(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	cookie, err := r.Cookie(auth.SessionCookie)
+	if err != nil || cookie.Value == "" {
+		return ""
+	}
+	return s.csrfTokenFor(cookie.Value)
+}
+
+// csrfField renders the hidden input that templates embed in every POST form.
+// Returns empty HTML when there is no session, so the login and setup pages
+// (which have no session to protect) render unchanged.
+func (s *Server) csrfField(r *http.Request) template.HTML {
+	token := s.csrfTokenForRequest(r)
+	if token == "" {
+		return ""
+	}
+	// token is hex from HMAC output — no user input reaches it, so it cannot
+	// break out of the attribute.
+	return template.HTML(`<input type="hidden" name="` + csrfFieldName + `" value="` + token + `">`)
+}
+
+// csrfInjectForms inserts the hidden token input immediately after the opening
+// tag of every POST form in a rendered page.
+//
+// Done here, on the rendered output, rather than by adding {{$.CSRFField}} to
+// each of the ~75 forms in web/templates. One choke point means a form added
+// later is protected automatically instead of silently 403-ing the first time
+// someone submits it, and it avoids the template-scoping trap where `.` inside
+// a {{range}} is not the root data.
+//
+// The scan is quote-aware so a '>' inside an attribute value (an inline
+// onclick, say) doesn't terminate the tag early. Template actions are already
+// evaluated by this point, so only quoting has to be handled.
+func csrfInjectForms(page, field []byte) []byte {
+	if len(field) == 0 || len(page) == 0 {
+		return page
+	}
+	var out []byte
+	pos := 0
+	for {
+		idx := indexFoldASCII(page[pos:], "<form")
+		if idx < 0 {
+			break
+		}
+		start := pos + idx
+		end := csrfTagEnd(page, start)
+		if end < 0 {
+			break // malformed tag; leave the remainder untouched
+		}
+		tag := page[start:end]
+		if !bytesContainsFold(tag, `method="post"`) && !bytesContainsFold(tag, "method='post'") {
+			out = append(out, page[pos:end]...)
+			pos = end
+			continue
+		}
+		out = append(out, page[pos:end]...)
+		out = append(out, field...)
+		pos = end
+	}
+	if out == nil {
+		return page
+	}
+	return append(out, page[pos:]...)
+}
+
+// csrfTagEnd returns the index just past the '>' closing the tag that starts at
+// `start`, skipping quoted attribute values. Returns -1 if unterminated.
+func csrfTagEnd(page []byte, start int) int {
+	var quote byte
+	for i := start; i < len(page); i++ {
+		c := page[i]
+		if quote != 0 {
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'':
+			quote = c
+		case '>':
+			return i + 1
+		}
+	}
+	return -1
+}
+
+// indexFoldASCII is a case-insensitive bytes.Index for an ASCII needle.
+func indexFoldASCII(haystack []byte, needle string) int {
+	n := len(needle)
+	if n == 0 || len(haystack) < n {
+		return -1
+	}
+	for i := 0; i+n <= len(haystack); i++ {
+		if equalFoldASCII(haystack[i:i+n], needle) {
+			return i
+		}
+	}
+	return -1
+}
+
+func bytesContainsFold(haystack []byte, needle string) bool {
+	return indexFoldASCII(haystack, needle) >= 0
+}
+
+func equalFoldASCII(b []byte, s string) bool {
+	if len(b) != len(s) {
+		return false
+	}
+	for i := range b {
+		x, y := b[i], s[i]
+		if 'A' <= x && x <= 'Z' {
+			x += 'a' - 'A'
+		}
+		if 'A' <= y && y <= 'Z' {
+			y += 'a' - 'A'
+		}
+		if x != y {
+			return false
+		}
+	}
+	return true
+}
+
+// csrfSafeMethod reports whether a method is defined as safe and so needs no
+// token. HEAD and OPTIONS are included alongside GET per RFC 9110.
+func csrfSafeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+		return true
+	}
+	return false
+}
+
+// requireCSRF rejects state-changing requests that do not carry a token
+// matching the caller's session.
+//
+// Ordering matters: this must run *inside* requireAuth, because it relies on
+// requireAuth having already established how the request is authenticated.
+func (s *Server) requireCSRF(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if csrfSafeMethod(r.Method) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Bearer-token clients are not CSRF-reachable — see the package note.
+		if currentAPITokenScope(r) != "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		expected := s.csrfTokenForRequest(r)
+		if expected == "" {
+			// No session cookie: nothing to protect, and requireAuth has
+			// already decided whether this request may proceed at all.
+			next.ServeHTTP(w, r)
+			return
+		}
+		if !csrfTokenMatches(expected, csrfTokenFromRequest(r)) {
+			log.Printf("csrf: rejected %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+			http.Error(w, "CSRF token missing or invalid — reload the page and try again.", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// csrfTokenFromRequest pulls the token from the form field or the header. The
+// header path is what the JSON/fetch callers use; see the fetch wrapper in
+// web/static/app.js.
+//
+// Reading the form value would normally consume the body, so this only parses
+// form-encoded content types. JSON handlers keep an intact body and are
+// expected to send the header instead.
+func csrfTokenFromRequest(r *http.Request) string {
+	if v := strings.TrimSpace(r.Header.Get(csrfHeaderName)); v != "" {
+		return v
+	}
+	ct := r.Header.Get("Content-Type")
+	if strings.HasPrefix(ct, "application/x-www-form-urlencoded") ||
+		strings.HasPrefix(ct, "multipart/form-data") {
+		// ParseForm caches its result on the request, so the downstream
+		// handler's own ParseForm call is a no-op rather than a second read of
+		// an already-drained body.
+		if err := r.ParseForm(); err == nil {
+			return strings.TrimSpace(r.PostFormValue(csrfFieldName))
+		}
+	}
+	return ""
+}
+
+// csrfTokenMatches compares in constant time.
+func csrfTokenMatches(expected, got string) bool {
+	if expected == "" || got == "" {
+		return false
+	}
+	return hmac.Equal([]byte(expected), []byte(got))
+}

--- a/internal/server/csrf_test.go
+++ b/internal/server/csrf_test.go
@@ -1,0 +1,268 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/X4Applegate/caddyui/internal/auth"
+	appdb "github.com/X4Applegate/caddyui/internal/db"
+)
+
+// v2.29.0: CSRF protection.
+
+func newCSRFTestServer(t *testing.T) *Server {
+	t.Helper()
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return &Server{DB: conn}
+}
+
+func TestCSRFTokenIsSessionBoundAndStable(t *testing.T) {
+	s := newCSRFTestServer(t)
+
+	a1 := s.csrfTokenFor("session-alpha")
+	a2 := s.csrfTokenFor("session-alpha")
+	b := s.csrfTokenFor("session-beta")
+
+	if a1 == "" {
+		t.Fatal("token for a real session must not be empty")
+	}
+	if a1 != a2 {
+		t.Error("token must be stable for the same session")
+	}
+	if a1 == b {
+		t.Error("different sessions must produce different tokens")
+	}
+	if s.csrfTokenFor("") != "" {
+		t.Error("empty session must yield an empty token, not a constant")
+	}
+	if strings.Contains(a1, "session-alpha") {
+		t.Error("token must not leak the session value it derives from")
+	}
+}
+
+// The secret must survive a restart, otherwise every live session's token is
+// invalidated on deploy and users get a 403 on their next save.
+func TestCSRFSecretPersistsAcrossServerInstances(t *testing.T) {
+	dir := t.TempDir()
+	conn, err := appdb.Open(filepath.Join(dir, "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	first := (&Server{DB: conn}).csrfTokenFor("session-alpha")
+	second := (&Server{DB: conn}).csrfTokenFor("session-alpha")
+	if first != second {
+		t.Errorf("token changed across Server instances (%s vs %s) — secret was not persisted", first, second)
+	}
+}
+
+func TestCSRFTokenMatchesRejectsEmptyAndMismatch(t *testing.T) {
+	cases := []struct {
+		expected, got string
+		want          bool
+	}{
+		{"abc", "abc", true},
+		{"abc", "abd", false},
+		{"", "", false},
+		{"abc", "", false},
+		{"", "abc", false},
+		{"abc", "ab", false},
+	}
+	for _, c := range cases {
+		if got := csrfTokenMatches(c.expected, c.got); got != c.want {
+			t.Errorf("csrfTokenMatches(%q,%q) = %v, want %v", c.expected, c.got, got, c.want)
+		}
+	}
+}
+
+func TestCSRFInjectForms(t *testing.T) {
+	field := []byte(`<input type="hidden" name="csrf_token" value="TOK">`)
+
+	tests := []struct {
+		name  string
+		page  string
+		count int
+	}{
+		{"simple post form", `<form method="post" action="/x">a</form>`, 1},
+		{"uppercase tag and method", `<FORM METHOD="POST" action="/x">a</FORM>`, 1},
+		{"single quoted method", `<form method='post'>a</form>`, 1},
+		{"get form untouched", `<form method="get" action="/s">a</form>`, 0},
+		{"method-less form untouched", `<form action="/s">a</form>`, 0},
+		{"two post forms", `<form method="post">a</form><form method="post">b</form>`, 2},
+		{"mixed", `<form method="get">a</form><form method="post">b</form>`, 1},
+		{
+			// A '>' inside an attribute value must not be mistaken for the end
+			// of the tag — otherwise the field lands in the middle of markup.
+			"angle bracket inside attribute",
+			`<form method="post" onsubmit="return a>b" class="x">a</form>`,
+			1,
+		},
+		{
+			"multi-line opening tag",
+			"<form method=\"post\" action=\"/bulk\"\n      id=\"bulk-form\"\n      class=\"inline\">a</form>",
+			1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(csrfInjectForms([]byte(tc.page), field))
+			if n := strings.Count(got, `name="csrf_token"`); n != tc.count {
+				t.Fatalf("injected %d times, want %d\ngot: %s", n, tc.count, got)
+			}
+			if tc.count > 0 {
+				// The field must land immediately after the opening tag, i.e.
+				// inside the form element where it will actually be submitted.
+				if !strings.Contains(got, `>`+string(field)) {
+					t.Errorf("field not placed directly after the opening tag: %s", got)
+				}
+			}
+		})
+	}
+}
+
+func TestCSRFInjectFormsNoTokenLeavesPageUntouched(t *testing.T) {
+	page := `<form method="post">a</form>`
+	if got := string(csrfInjectForms([]byte(page), nil)); got != page {
+		t.Errorf("page altered with an empty field: %s", got)
+	}
+}
+
+func TestCSRFSafeMethods(t *testing.T) {
+	for _, m := range []string{http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace} {
+		if !csrfSafeMethod(m) {
+			t.Errorf("%s should be safe", m)
+		}
+	}
+	for _, m := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		if csrfSafeMethod(m) {
+			t.Errorf("%s must not be treated as safe", m)
+		}
+	}
+}
+
+// The middleware is the actual control. These exercise it end to end.
+func TestRequireCSRFMiddleware(t *testing.T) {
+	s := newCSRFTestServer(t)
+	const session = "session-alpha"
+	token := s.csrfTokenFor(session)
+
+	reached := false
+	h := s.requireCSRF(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	withSession := func(r *http.Request) *http.Request {
+		r.AddCookie(&http.Cookie{Name: auth.SessionCookie, Value: session})
+		return r
+	}
+	formPost := func(body string) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/proxy-hosts", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		return withSession(r)
+	}
+
+	t.Run("GET passes without a token", func(t *testing.T) {
+		reached = false
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, withSession(httptest.NewRequest(http.MethodGet, "/", nil)))
+		if !reached || w.Code != http.StatusOK {
+			t.Fatalf("safe method blocked: code=%d reached=%v", w.Code, reached)
+		}
+	})
+
+	t.Run("POST without a token is rejected", func(t *testing.T) {
+		reached = false
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, formPost("domains=evil.example.com"))
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("code = %d, want 403", w.Code)
+		}
+		if reached {
+			t.Fatal("handler ran despite a missing token")
+		}
+	})
+
+	t.Run("POST with a wrong token is rejected", func(t *testing.T) {
+		reached = false
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, formPost("csrf_token=deadbeef&domains=evil.example.com"))
+		if w.Code != http.StatusForbidden || reached {
+			t.Fatalf("forged token accepted: code=%d reached=%v", w.Code, reached)
+		}
+	})
+
+	t.Run("POST with another session's token is rejected", func(t *testing.T) {
+		reached = false
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, formPost("csrf_token="+s.csrfTokenFor("session-beta")))
+		if w.Code != http.StatusForbidden || reached {
+			t.Fatalf("cross-session token accepted: code=%d reached=%v", w.Code, reached)
+		}
+	})
+
+	t.Run("POST with the form field passes", func(t *testing.T) {
+		reached = false
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, formPost("csrf_token="+token+"&domains=ok.example.com"))
+		if w.Code != http.StatusOK || !reached {
+			t.Fatalf("valid form token rejected: code=%d reached=%v", w.Code, reached)
+		}
+	})
+
+	t.Run("POST with the header passes", func(t *testing.T) {
+		reached = false
+		r := withSession(httptest.NewRequest(http.MethodPost, "/api/x", strings.NewReader(`{"a":1}`)))
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set(csrfHeaderName, token)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusOK || !reached {
+			t.Fatalf("valid header token rejected: code=%d reached=%v", w.Code, reached)
+		}
+	})
+
+	t.Run("no session cookie falls through to requireAuth", func(t *testing.T) {
+		reached = false
+		r := httptest.NewRequest(http.MethodPost, "/proxy-hosts", strings.NewReader(""))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusOK || !reached {
+			t.Fatalf("anonymous request should be left to requireAuth: code=%d", w.Code)
+		}
+	})
+}
+
+// A JSON handler must still see its body after the middleware has looked for a
+// token. Reading the form off a JSON request would drain the body and leave the
+// handler with nothing.
+func TestRequireCSRFLeavesJSONBodyIntact(t *testing.T) {
+	s := newCSRFTestServer(t)
+	const session = "session-alpha"
+
+	var seen string
+	h := s.requireCSRF(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 64)
+		n, _ := r.Body.Read(buf)
+		seen = string(buf[:n])
+	}))
+
+	r := httptest.NewRequest(http.MethodPost, "/api/ai/chat", strings.NewReader(`{"msg":"hi"}`))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set(csrfHeaderName, s.csrfTokenFor(session))
+	r.AddCookie(&http.Cookie{Name: auth.SessionCookie, Value: session})
+
+	h.ServeHTTP(httptest.NewRecorder(), r)
+	if seen != `{"msg":"hi"}` {
+		t.Errorf("handler saw body %q, want the original JSON", seen)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,6 +64,12 @@ type Server struct {
 	DBPath      string
 	pendingTOTP sync.Map // token → userID (int64), auto-deleted after 5 min
 
+	// CSRF HMAC key, loaded from (or generated into) the settings table on
+	// first use. Per-Server rather than package-level so two Servers in the
+	// same test binary don't share one another's key. v2.29.0.
+	csrfSecretOnce  sync.Once
+	csrfSecretCache []byte
+
 	// version-check cache (Docker Hub, 1h TTL)
 	versionMu        sync.Mutex
 	latestVersion    string
@@ -517,6 +523,10 @@ func (s *Server) Routes() http.Handler {
 
 	r.Group(func(r chi.Router) {
 		r.Use(s.requireAuth)
+		// v2.29.0: CSRF must sit *inside* requireAuth — it reads the API-token
+		// scope that requireAuth puts on the context to decide whether a
+		// request is bearer-authenticated (and so not CSRF-reachable).
+		r.Use(s.requireCSRF)
 		r.Get("/", s.dashboard)
 		r.Get("/onboarding", s.getOnboarding)
 
@@ -1084,6 +1094,17 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, dat
 	}
 	// Always inject app version.
 	data["AppVersion"] = s.Version
+	// v2.29.0: CSRF token for every rendered page. CSRFField is the ready-made
+	// hidden input each POST form embeds; CSRFToken is the raw value, surfaced
+	// as a <meta> tag so the fetch wrapper in app.js can pick it up for JSON
+	// calls. Both are empty for anonymous pages, which have no session to
+	// protect. Injected here so no page can forget it.
+	if _, ok := data["CSRFField"]; !ok {
+		data["CSRFField"] = s.csrfField(r)
+	}
+	if _, ok := data["CSRFToken"]; !ok {
+		data["CSRFToken"] = s.csrfTokenForRequest(r)
+	}
 	// Inject site title for every page so layout.html can use it.
 	if _, ok := data["SiteTitle"]; !ok {
 		data["SiteTitle"] = mustGetSetting(s.DB, settingSiteTitle)
@@ -1111,10 +1132,24 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, dat
 		http.Error(w, "template not found: "+name, http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := tpl.ExecuteTemplate(w, "layout", data); err != nil {
+	// v2.29.0: render into a buffer so the CSRF hidden input can be stamped
+	// into every POST form before anything reaches the client. Buffering also
+	// means a mid-template error produces a clean 500 instead of a truncated
+	// page followed by an error string, which is what happened when this wrote
+	// to the ResponseWriter directly.
+	var buf bytes.Buffer
+	if err := tpl.ExecuteTemplate(&buf, "layout", data); err != nil {
 		log.Printf("template %s: %v", name, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	page := buf.Bytes()
+	if field, _ := data["CSRFField"].(template.HTML); field != "" {
+		page = csrfInjectForms(page, []byte(field))
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if _, err := w.Write(page); err != nil {
+		log.Printf("template %s: write: %v", name, err)
 	}
 }
 

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -312,6 +312,41 @@ func TestMonitoringControlsAndOffStateAreWired(t *testing.T) {
 	}
 }
 
+// TestCSRFClientPlumbing guards the two client-side halves of CSRF protection.
+// The hidden form input is stamped into rendered HTML server-side (see
+// csrfInjectForms), but scripted callers depend on these two pieces: the meta
+// tag carrying the token, and the fetch wrapper that turns it into a header.
+// Lose either and every fetch()-based mutation starts returning 403.
+func TestCSRFClientPlumbing(t *testing.T) {
+	layout, err := FS.ReadFile("templates/layout.html")
+	if err != nil {
+		t.Fatalf("read layout.html: %v", err)
+	}
+	if !strings.Contains(string(layout), `name="csrf-token"`) {
+		t.Error("layout.html must emit the csrf-token meta tag for app.js to read")
+	}
+
+	appJS, err := FS.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatalf("read app.js: %v", err)
+	}
+	js := string(appJS)
+	for _, marker := range []string{
+		`meta[name="csrf-token"]`,
+		"X-CSRF-Token",
+		"window.fetch =",
+	} {
+		if !strings.Contains(js, marker) {
+			t.Errorf("app.js missing CSRF fetch-wrapper marker %q", marker)
+		}
+	}
+	// The wrapper must not attach the token to cross-origin requests, or it
+	// leaks the token to whatever third-party host a future call talks to.
+	if !strings.Contains(js, "sameOrigin") {
+		t.Error("app.js fetch wrapper must gate the token on a same-origin check")
+	}
+}
+
 // TestCaptchaSecretsNeverRenderIntoTheDOM covers the settings-page leak where
 // turnstile_secret_key / recaptcha_secret_key were emitted as input values.
 // type="password" masks them visually, but the plaintext is readable via

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -9,6 +9,54 @@
 // Cached via the v2.12.38 Cache-Control: public, max-age=86400 wrapper
 // on /static/* — repeat navigations skip the network entirely.
 
+// v2.29.0: CSRF header for fetch()-based mutations.
+//
+// HTML forms carry a hidden csrf_token input injected server-side. Scripted
+// calls can't, so this wraps window.fetch and attaches the X-CSRF-Token header
+// to every same-origin request using an unsafe method. Doing it centrally
+// means a new fetch() call site is protected by default rather than 403-ing
+// until someone remembers the header.
+//
+// Deliberately runs before any other IIFE in this file so that anything below
+// which fetches during startup is already wrapped. Cross-origin requests are
+// left untouched — we must never leak the token to a third-party host.
+(function() {
+  var meta = document.querySelector('meta[name="csrf-token"]');
+  var token = meta ? meta.getAttribute('content') : '';
+  if (!token || typeof window.fetch !== 'function') return;
+
+  var SAFE = { GET: 1, HEAD: 1, OPTIONS: 1, TRACE: 1 };
+  var nativeFetch = window.fetch.bind(window);
+
+  function sameOrigin(url) {
+    try {
+      return new URL(url, window.location.href).origin === window.location.origin;
+    } catch (e) {
+      // Relative paths that URL() can't parse are same-origin by definition.
+      return true;
+    }
+  }
+
+  window.fetch = function(input, init) {
+    init = init || {};
+    var method = (init.method || (input && input.method) || 'GET').toUpperCase();
+    var url = (typeof input === 'string') ? input : (input && input.url) || '';
+    if (SAFE[method] || !sameOrigin(url)) {
+      return nativeFetch(input, init);
+    }
+    // Headers may arrive as a Headers instance, an array of pairs, or a plain
+    // object. Normalising to Headers handles all three without clobbering
+    // whatever the caller already set.
+    var headers = new Headers(init.headers || (input && input.headers) || {});
+    if (!headers.has('X-CSRF-Token')) headers.set('X-CSRF-Token', token);
+    var next = {};
+    for (var k in init) { if (Object.prototype.hasOwnProperty.call(init, k)) next[k] = init[k]; }
+    next.headers = headers;
+    if (!next.method) next.method = method;
+    return nativeFetch(input, next);
+  };
+})();
+
 // v2.12.42: small helper used below to delay non-critical /api/* fetches
 // until after Lighthouse's TBT/LCP measurement window closes. The page
 // renders fine without these calls — they just populate a badge and

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -36,6 +36,11 @@
   }catch(e){}})();</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  {{/* v2.29.0: CSRF token for fetch()-based callers. Forms carry their own
+       hidden input; the wrapper in app.js reads this tag to set the
+       X-CSRF-Token header on same-origin mutating requests. Empty on
+       anonymous pages, which have no session to protect. */}}
+  {{if .CSRFToken}}<meta name="csrf-token" content="{{.CSRFToken}}" />{{end}}
   <title>{{block "title" .}}{{if .SiteTitle}}{{.SiteTitle}}{{else}}CaddyUI{{end}}{{end}}</title>
   {{/* v2.12.48: meta description for SEO. Defaults to a generic
        CaddyUI summary; individual pages override via the "description"


### PR DESCRIPTION
Closes the CSRF gap flagged in the earlier security review: zero occurrences of `csrf` across the Go source, against 94 authenticated `POST`/`DELETE` routes.

Session cookies are already `SameSite=Lax`, which blocks the classic cross-site form POST in current browsers — so this was never wide open. But that's a single layer resting on a browser default, and it doesn't cover a same-site subdomain or a browser with relaxed behaviour. This adds a synchroniser token.

## Design

**Token = `HMAC-SHA256(secret, sessionToken)`.** No storage of its own, no schema change, and inherently bound to one session — logging out or back in rotates the session token and therefore the CSRF token. The secret is generated once and **persisted**; regenerating it per boot would invalidate every live session's token and 403 every logged-in user on deploy.

**Injection happens in `s.render`, not in the templates.** Adding `{{$.CSRFField}}` to each of the ~75 forms across 31 templates would work, but a form added later would silently 403 the first time someone submitted it. `s.render` is the only path in the codebase that executes a template (verified — one `ExecuteTemplate` call exists), so stamping the hidden input into the rendered HTML there means no form can miss it. It also sidesteps the scoping trap where `.` inside a `{{range}}` isn't the root data.

The tag scan is quote-aware, so a `>` inside an inline `onclick` doesn't terminate the tag early — there's a test for exactly that, plus uppercase tags, single-quoted attributes and multi-line opening tags.

Rendering now goes through a buffer to make this possible. That incidentally fixes a smaller wart: `ExecuteTemplate` wrote straight to the `ResponseWriter`, so a mid-template failure emitted a truncated page *followed by* an error string. It now produces a clean 500.

**Scripted callers** can't carry a hidden input, so `app.js` wraps `window.fetch` to attach `X-CSRF-Token` on same-origin unsafe-method requests. Central wrapping protects the nine existing call sites and any added later. It deliberately skips cross-origin requests so the token is never leaked to a third-party host.

**Bearer-token requests are exempt.** A browser never attaches an `Authorization` header to a cross-site request on its own, so they aren't CSRF-reachable, and demanding a token would break every API client.

The middleware only parses a body for form content types, so JSON handlers still receive an intact body — there's a test for that too.

## Verification

`go build`, `go vet`, `go test ./...` pass, with 20 new test cases. Beyond unit tests, the built binary was driven through real flows:

| Case | Result |
|---|---|
| Create host **without** token | **403**, nothing created |
| Create host with **forged** token | **403**, nothing created |
| Create host with **valid** token | 303, host created |
| Token from a **logged-out** session | **403** |
| `fetch` endpoints **with** `X-CSRF-Token` | 200 |
| `fetch` endpoints **without** header | **403** |
| **Bearer** POST, no CSRF token | **201** — API clients unaffected |
| Settings save / edit / delete / profile / server create+delete | all pass, changes persisted |
| Login, logout, re-login | pass; token rotates on new session |
| **Restart** with live session | token unchanged — no mass 403 on deploy |

Every POST form on all 21 reachable pages was counted against its token count:

```
/proxy-hosts     13 forms  13 tokens
/snapshots        4 forms   4 tokens
/redirection-hosts 4 forms  4 tokens
…21 pages, zero mismatches
```

## Not covered

The pre-session routes (`/login`, `/setup`, `/forgot-password`, `/reset-password`, `/accept-invite`) and `/logout` sit outside the authenticated group and are not token-checked. Login CSRF is a real but much lower-value attack against a self-hosted admin panel, and `SameSite=Lax` still applies there. Worth doing later; I didn't want to fold a second auth-flow change into this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)