### PR TITLE
perf: index the server-scoped analytics aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.31.0] - 2026-08-20 - Analytics performance at scale
+
+### Fixed
+
+- The Analytics page no longer slows down as proxy hosts are added to a node. Measured on 84,000 access events across 21 hosts, it went from **1.18 s to 0.31 s** end-to-end; the query responsible went from 1068 ms to 109 ms.
+- The cause was the server-scoped "top hosts" aggregation (`WHERE ts >= ? AND server_id = ? GROUP BY host`). No index could supply group order for it, so SQLite built temporary B-trees for the grouping, the distinct-visitor count and the sort, and fetched every matching row from the table to read `host` and `client_ip`. A covering index on `(server_id, host, ts, client_ip)` supplies the group order directly and carries every column the query reads.
+- Only the server-scoped view was affected, which is why this appeared as "it got slow once I had about twenty hosts". The fleet-wide view already had an index giving it group order and was never slow.
+- The index is created automatically on upgrade. Building it takes well under a second on a database of this size, and adds roughly two microseconds per ingested event.
+
+### Added
+
+- Regression tests asserting the query plan still uses the covering index and still avoids a temporary B-tree for `GROUP BY`, so this cannot silently regress.
+
 ## [2.30.0] - 2026-08-20 - Deterministic config, visible migrations, CSP
 
 ### Fixed

--- a/internal/db/analytics_index_test.go
+++ b/internal/db/analytics_index_test.go
@@ -1,0 +1,106 @@
+package db
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// v2.31.0: the Analytics page took ~1.2s once an operator had ~20 hosts on one
+// node. The dominant cost was the server-scoped "top hosts" aggregation —
+// `WHERE ts >= ? AND server_id = ? GROUP BY host` — which had no index able to
+// supply group order, so SQLite built temp B-trees and fetched every matching
+// row from the table.
+//
+// These pin the fix. If the index is dropped, or the query is rewritten in a
+// way that stops using it, the plan assertion fails rather than the page
+// quietly getting slow again.
+
+func TestAnalyticsServerScopedTopHostsUsesCoveringIndex(t *testing.T) {
+	conn, err := Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	const q = `SELECT host, COUNT(*) AS views, COUNT(DISTINCT client_ip) AS visitors, MAX(ts) AS last_ts
+	             FROM access_events
+	            WHERE ts >= ? AND server_id = ?
+	            GROUP BY host
+	            ORDER BY views DESC
+	            LIMIT 50`
+
+	rows, err := conn.Query("EXPLAIN QUERY PLAN "+q, time.Now().Add(-7*24*time.Hour).Unix(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		plan.WriteString(detail)
+		plan.WriteString("\n")
+	}
+	got := plan.String()
+
+	if !strings.Contains(got, "idx_access_events_server_host_ts_ip") {
+		t.Errorf("server-scoped top-hosts query no longer uses the covering index.\nplan:\n%s", got)
+	}
+	// Group order comes from the index; a temp B-tree for GROUP BY means the
+	// index is no longer supplying it, which is what made this slow.
+	if strings.Contains(got, "USE TEMP B-TREE FOR GROUP BY") {
+		t.Errorf("query fell back to a temp B-tree for GROUP BY — the index is not supplying group order.\nplan:\n%s", got)
+	}
+}
+
+// The index must actually exist after a migration, on both a fresh database
+// and one being upgraded.
+func TestAnalyticsCoveringIndexIsCreated(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "caddyui.db")
+
+	assertIndex := func(t *testing.T, stage string) {
+		t.Helper()
+		conn, err := Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer conn.Close()
+		var name string
+		err = conn.QueryRow(
+			`SELECT name FROM sqlite_master WHERE type='index' AND name = ?`,
+			"idx_access_events_server_host_ts_ip",
+		).Scan(&name)
+		if err != nil {
+			t.Errorf("%s: covering index missing: %v", stage, err)
+		}
+	}
+
+	assertIndex(t, "fresh database")
+	assertIndex(t, "reopened database")
+}
+
+// Guard the shape the index depends on: server_id, host, ts and client_ip must
+// all remain columns on access_events.
+func TestAccessEventsRetainsIndexedColumns(t *testing.T) {
+	conn, err := Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	for _, col := range []string{"server_id", "host", "ts", "client_ip"} {
+		ok, err := columnExists(conn, "access_events", col)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Errorf("access_events.%s is gone — idx_access_events_server_host_ts_ip depends on it", col)
+		}
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2245,6 +2245,21 @@ func migrate(db *sql.DB) error {
 			return fmt.Errorf("add server_name to access_events: %w", err)
 		}
 	}
+	// v2.31.0: covering index for the server-scoped "top hosts" aggregation
+	// behind the Analytics page.
+	//
+	// That query is `WHERE ts >= ? AND server_id = ? GROUP BY host`. With only
+	// (server_id, ts) available, SQLite scanned in timestamp order and then
+	// built a temp B-tree to group by host, plus another for the DISTINCT —
+	// and had to fetch every matching row from the table for `host` and
+	// `client_ip`. Ordering by host *inside* the server lets the GROUP BY read
+	// straight off the index, and carrying ts and client_ip makes it covering.
+	//
+	// Measured on 84k events across 21 hosts: 1068 ms → 109 ms. The unscoped
+	// variant was always fast because (host, ts) already gave it group order —
+	// which is why this only became visible to operators running several
+	// hosts on one node.
+	migrationStep(db, `CREATE INDEX IF NOT EXISTS idx_access_events_server_host_ts_ip ON access_events(server_id, host, ts, client_ip)`)
 	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_access_events_server_ts ON access_events(server_id, ts)`); err != nil {
 		return fmt.Errorf("create access_events server index: %w", err)
 	}


### PR DESCRIPTION
Reported: Analytics and Operations slow down at ~20-21 proxy hosts.

## Reproduced and measured

Seeded 21 hosts and 84,000 access events, then timed each page:

| Page | Before |
|---|---|
| `/analytics` | **1.18 s** |
| `/` (Operations) | 0.020 s |
| `/proxy-hosts` | 0.004 s |

So this is Analytics specifically. CPU profiling attributed **84% of the page to one call** — `TopHostsSince(7 days, limit 50, serverScopeID)`:

```
.  6.39s  476:  hostRows, err2 = models.TopHostsSince(s.DB, sevenDaysAgo, 50, serverScopeID)
.  540ms  449:  sevenTotals, err2 = models.AccessTotalsSince(...)
.  370ms  556:  statusBuckets, err2 = models.StatusBucketsSince(...)
```

## Root cause

The query is `WHERE ts >= ? AND server_id = ? GROUP BY host`. No index could supply group order for it:

```
SEARCH access_events USING INDEX idx_access_events_server_ts (server_id=? AND ts>?)
USE TEMP B-TREE FOR GROUP BY
USE TEMP B-TREE FOR count(DISTINCT)
USE TEMP B-TREE FOR ORDER BY
```

Three temp B-trees, plus a table fetch for every matching row to read `host` and `client_ip` — the profile was almost entirely `_sqlite3BtreeTableMoveto`.

The **fleet-wide** variant of the same query was always fast (137 ms vs 1068 ms) because `(host, ts)` already gave it group order. That asymmetry is exactly why this surfaced only for operators running many hosts on a single node.

## Fix

A covering index on `(server_id, host, ts, client_ip)` — group order from the index, and every column the query reads carried in it.

| | |
|---|---|
| `TopHostsSince` scoped | **1068 ms → 109 ms** |
| `/analytics` end-to-end | **1.18 s → 0.31 s** |

I tested the obvious alternative first, `(server_id, ts, host, client_ip)`, and it only reached 957 ms — it makes the scan covering but still can't supply group order. The column order is the whole fix, so the test asserts specifically that no `TEMP B-TREE FOR GROUP BY` appears.

## Cost, measured not assumed

- Index build: ~60 ms on 84k rows, at startup, once.
- Ingest: ~2 µs extra per event (5000 inserts: 28.7 ms → 38.8 ms).

That is a good trade for 10× on the read. I stopped there deliberately: two further covering indexes for `AccessTotalsSince` and `StatusBucketsSince` get the page to 0.24 s, but that is 87 ms for triple the write amplification on the highest-write table in the schema. Happy to add them if wanted — the measurements are in the commit message.

## On Operations

Profiled with the same dataset: **13.6 ms** server-side. The page itself is not the problem, so if it still feels slow in practice the cause is downstream of the HTML — most likely `/api/upstream-health`, which probes upstreams Caddy doesn't report on with a 3 s timeout. That needs the reporter's environment to reproduce; I have not guessed at a change.

Its per-host loop is a genuine N+1 (42 queries at 21 hosts) but measured only ~40 ms here, so I left it alone rather than rewrite it speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)