### PR TITLE
fix: stop the bulk-action bar from covering the last row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.32.0] - 2026-08-20 - Fix bulk-action bar covering the last row
+
+### Fixed
+
+- The floating "N selected" bulk-action bar no longer covers the last row of a long list. It is `position: fixed` to the bottom of the viewport and never reserved space for itself, so once a list needed scrolling — a shorter window, or simply enough proxy hosts / redirections / advanced routes / certificates — the last row's Edit and Delete buttons sat directly under it, overlapping into an unreadable jumble as soon as any rows were selected and you scrolled to the bottom.
+- The scroll container now reserves exactly the bar's own rendered height (which can grow if it wraps to two lines on a narrow window) as bottom padding whenever the bar is visible, and releases it when the selection is cleared. Fixed centrally, so it applies to every page using this bar without per-page changes.
+
 ## [2.31.0] - 2026-08-20 - Analytics performance at scale
 
 ### Fixed

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -377,3 +377,61 @@ func TestCaptchaSecretsNeverRenderIntoTheDOM(t *testing.T) {
 		}
 	}
 }
+
+// TestBulkBarDoesNotOverlapListContent guards the fix for the floating
+// "N selected" bulk-action bar covering the last row of a long list.
+// #bulk-bar is `position: fixed` and never reserved space for itself, so on
+// a short viewport (or just a list long enough to scroll) the last row's
+// Edit/Delete buttons sat directly under it once rows were selected — an
+// unreadable overlap once you scrolled to the bottom.
+//
+// The fix has two halves that must both stay in place: layout.html's scroll
+// container needs the id the JS targets, and app.js needs the observer that
+// reserves space for the bar's actual (possibly wrapped) height. Losing
+// either silently brings the overlap back with no compile-time signal.
+func TestBulkBarDoesNotOverlapListContent(t *testing.T) {
+	layout, err := FS.ReadFile("templates/layout.html")
+	if err != nil {
+		t.Fatalf("read layout.html: %v", err)
+	}
+	if !strings.Contains(string(layout), `id="app-scroll"`) {
+		t.Error(`layout.html must give its scroll container id="app-scroll" — app.js's bulk-bar spacer targets it by that id`)
+	}
+
+	appJS, err := FS.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatalf("read app.js: %v", err)
+	}
+	js := string(appJS)
+	for _, marker := range []string{
+		`getElementById('bulk-bar')`,
+		`getElementById('app-scroll')`,
+		"paddingBottom",
+		"MutationObserver",
+	} {
+		if !strings.Contains(js, marker) {
+			t.Errorf("app.js missing bulk-bar spacer marker %q", marker)
+		}
+	}
+
+	// Every page with a bulk-action bar must render inside the shared layout
+	// that defines #app-scroll — a page with its own layout would silently
+	// fall outside the fix.
+	entries, err := fs.ReadDir(FS, "templates")
+	if err != nil {
+		t.Fatalf("read templates dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		body, err := FS.ReadFile("templates/" + entry.Name())
+		if err != nil {
+			t.Fatalf("read %s: %v", entry.Name(), err)
+		}
+		html := string(body)
+		if strings.Contains(html, `id="bulk-bar"`) && !strings.Contains(html, `{{define "content"}}`) {
+			t.Errorf("%s has a bulk-bar but does not render inside the shared layout's content block — it will not get the overlap fix", entry.Name())
+		}
+	}
+}

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -807,3 +807,25 @@ function caddyuiDelayFetch(ms, fn) {
       '</svg>';
   }
 })();
+
+// The floating "N selected" bulk-action bar (#bulk-bar) is fixed to the
+// viewport bottom on proxy hosts / redirections / advanced routes /
+// certificates. Its container never reserved space for it, so on a short
+// viewport — or just a list long enough to need scrolling — the last row's
+// Edit/Delete buttons sat directly under the bar, overlapping into an
+// unreadable jumble once you scrolled to the bottom with rows selected.
+// Reserve exactly the bar's rendered height (it can wrap to two lines on a
+// narrow window) as scroll-container padding whenever it's visible, so the
+// last row always clears it.
+(function() {
+  var bar = document.getElementById('bulk-bar');
+  var scroller = document.getElementById('app-scroll');
+  if (!bar || !scroller) return;
+  function sync() {
+    scroller.style.paddingBottom = bar.classList.contains('hidden') ? '' : (bar.offsetHeight + 24) + 'px';
+  }
+  new MutationObserver(sync).observe(bar, { attributes: true, attributeFilter: ['class'] });
+  if ('ResizeObserver' in window) new ResizeObserver(sync).observe(bar);
+  window.addEventListener('resize', sync);
+  sync();
+})();

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -529,7 +529,7 @@ if ('serviceWorker' in navigator) {
       </div>
     </aside>
 
-    <div class="flex-1 min-w-0 flex flex-col lg:overflow-y-auto">
+    <div id="app-scroll" class="flex-1 min-w-0 flex flex-col lg:overflow-y-auto">
       {{/* Top bar always renders when a user is signed in. When a
            CurrentServer exists we show the server status/name/URL on the
            left; otherwise just the profile cluster on the right, so the


### PR DESCRIPTION
Found it — reproduced in headless Chrome to confirm before writing the fix.

## Root cause

`#bulk-bar` (the floating "N selected" toolbar) is `position: fixed` to the viewport bottom on the proxy hosts, redirections, advanced routes, and certificates pages. Nothing ever reserved space for it in the scrolling content, so once a list needed scrolling — a shorter browser window, or simply enough rows — the last row's Edit/Delete buttons sat directly under it as soon as any selection was made. Scrolling to the bottom put two unrelated button rows on top of each other.

Not narrow-screen-specific despite how it presented — any window short enough, or any list long enough to scroll, triggers it once rows are selected.

## Reproduction

Selected all checkboxes and scrolled to the bottom at 1280×720 with 8 proxy hosts + 2 multi-domain advanced routes:

**Before** — the last row (an Advanced route) is fully obscured by the bar, its Edit/Delete buttons merging with the bar's own buttons.
**After** — full clearance, plus the panel below the table is visible too.

(Screenshots attached in the chat.)

## Fix

Central, not per-page: `layout.html`'s scroll container gets `id="app-scroll"`, and `app.js` watches `#bulk-bar`'s class via `MutationObserver` and its own size via `ResizeObserver` (it can wrap to two lines on a narrow window, changing its height) to keep the container's bottom padding matched to the bar's actual rendered height + 24px clearance.

`id="bulk-bar"` is duplicated verbatim across `proxy_hosts.html`, `redirection_hosts.html`, `raw_routes.html`, and `certificates.html`, and all four render inside the same shared layout — so this one fix covers all of them, and any future page using the same pattern, without four separate template edits.

## Verification

`go build`, `go vet`, `go test ./...` pass, plus a new regression test asserting both halves of the fix stay in place (`#app-scroll` exists in the layout, the observer markers exist in `app.js`) and that no template with a `#bulk-bar` renders outside the shared layout.

Confirmed the fix applies on the redirections page too (not just proxy hosts), and holds at a narrower 1030×720 viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)