### PR TITLE
feat: let proxy hosts and advanced routes opt out of fleet sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.33.0] - 2026-08-21 - Node-local proxy hosts and advanced routes
+
+### Added
+
+- Proxy hosts and advanced routes can be marked **node-local**, which excludes them from full fleet syncs and from **Also deploy to**. Use it when the upstream only means something on the node that owns it — a Docker service name like `immich_server`, a VPN address, a loopback port. Copying such a host to another Caddy produced a route pointing at nothing.
+- Fleet sync reports what it left behind: *"skipped as node-local: 3 proxies, 1 advanced routes"*. Skipped resources are counted rather than silently dropped, so a sync summary can be read at face value.
+- The proxy host form warns when the upstream looks node-local but the host isn't marked as such — a single-label hostname with no dot, matching the rule CaddyUI already uses to decide it can't resolve a backend itself. Marking the host node-local dismisses the warning and hides the deploy picker.
+- Node-local hosts carry a badge in the proxy host list, next to the upstream that pinned them.
+
+### Notes
+
+- Fleet sync copies a host's upstream verbatim, which is correct for **edge replication** — several Caddy nodes fronting the same backends — and wrong for **federated nodes**, where each Caddy fronts its own local stack. `preserveProxyTargetPolicy` already treated certificates, DNS records and keys as node-specific; the upstream address was the field most likely to differ and was still being copied. This closes that gap without introducing per-node upstream overrides.
+- The flag is opt-in and defaults to off, so existing hosts sync exactly as before.
+
 ## [2.32.0] - 2026-08-20 - Fix bulk-action bar covering the last row
 
 ### Fixed

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2194,6 +2194,26 @@ func migrate(db *sql.DB) error {
 	if !columnExists2(db, "proxy_hosts", "monitor_timeout_sec") {
 		migrationStep(db, `ALTER TABLE proxy_hosts ADD COLUMN monitor_timeout_sec INTEGER NOT NULL DEFAULT 0`)
 	}
+	// v2.33.0: node_local — exclude a resource from fleet sync entirely.
+	//
+	// Fleet sync copies a proxy host's upstream (forward_host/port) verbatim to
+	// the target node. That is right for edge replication, where several Caddy
+	// nodes front the same backends, but wrong for federated nodes where each
+	// Caddy fronts its own local stack: a Docker service name like
+	// "immich_server" only resolves inside one node's network, and a WireGuard
+	// address like 10.8.0.1 may route somewhere else entirely.
+	//
+	// preserveProxyTargetPolicy already treats certificates, DNS records and
+	// keys as node-specific; the upstream address was the one field most likely
+	// to differ and was still being copied. Rather than invent per-node
+	// upstream overrides, this lets an operator mark a resource as belonging to
+	// one node, and both full sync and "Also deploy to" skip it.
+	if !columnExists2(db, "proxy_hosts", "node_local") {
+		migrationStep(db, `ALTER TABLE proxy_hosts ADD COLUMN node_local INTEGER NOT NULL DEFAULT 0`)
+	}
+	if !columnExists2(db, "raw_routes", "node_local") {
+		migrationStep(db, `ALTER TABLE raw_routes ADD COLUMN node_local INTEGER NOT NULL DEFAULT 0`)
+	}
 	// v2.9.230: redirect_strip_path_prefix — drop a leading path prefix from
 	// the request URI before composing the Location header. Mirrors the
 	// proxy-host strip_path_prefix option for redirects (e.g. on a partial

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -669,8 +669,15 @@ type ProxyHost struct {
 	MonitorExpectStatus int    // 0 = default classification; >0 = require exactly this code
 	MonitorIntervalSec  int    // 0 = default 60; rounded up to a multiple of the 60s poll tick
 	MonitorTimeoutSec   int    // 0 = default 5
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	// v2.33.0 (node-local hosts): exclude this host from fleet sync and from
+	// "Also deploy to". Set it when the upstream only means something on this
+	// node — a Docker service name, a VPN address, a loopback port — so
+	// copying the host to another Caddy would produce a route pointing at
+	// nothing. Sync reports these as skipped rather than silently ignoring
+	// them.
+	NodeLocal bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // MonitoringDisabled reports whether the operator has switched CaddyUI's own
@@ -1771,14 +1778,15 @@ const proxyHostBaseCols = `ph.id, ph.server_id, ph.domains, ph.forward_scheme, p
     COALESCE(ph.dns_skip_record,0),
     COALESCE(ph.monitor_mode,'auto'), COALESCE(ph.monitor_path,''),
     COALESCE(ph.monitor_method,''), COALESCE(ph.monitor_expect_status,0),
-    COALESCE(ph.monitor_interval_sec,0), COALESCE(ph.monitor_timeout_sec,0)`
+    COALESCE(ph.monitor_interval_sec,0), COALESCE(ph.monitor_timeout_sec,0),
+    COALESCE(ph.node_local,0)`
 
 // scanProxyHost pulls a single row into the struct. Centralises the
 // bool-int unpack so each query site doesn't repeat it.
 func scanProxyHost(s interface {
 	Scan(dest ...any) error
 }, p *ProxyHost, ownerEmail *string) error {
-	var ws, bce, ssl, sslf, h2, en, bae, dnsSkipRecord int
+	var ws, bce, ssl, sslf, h2, en, bae, dnsSkipRecord, nodeLocal int
 	var ownerID int64
 	var compr, sechdrs, maint, sticky, cors, disableAccessLog, addReqID, hstsPreload, forceHTTP1, h2c, flushImm, bufResp, denyDot, corsCredentials, sslVerify, blockUA, hstsSubdomains, hcFollowRedirects, stripPfx, fwdClientIP, stripQS, decompResp, comprPrefGzip, grpcWeb, kaDisabled, corsPrivNet, robotsDisallowAll, canonicalLink, fwdHeader, blockPrivIP, brotli, stripEtag, injectReqTimestamp, stripAcceptEnc, addUpstreamTiming, stripSrvHdr, addNosniff, stripAuthHdr, addXFwdPort, addXFwdHost, addCacheCtrlNoStore, denyRefEmpty, lbCookieHTTPOnly, lbCookieSecure, tlsEarlyData, addVia, addExpectCT, stripXPoweredBy, addCacheCtrlPublic, addXReqStart, addXFwdScheme, addReqIDToResp, addXRealIP, stripIncomingXFwdFor, hcTLSSkipVerify, addCORSVary, addSrvTiming, addXDNSPrefetch, addAcceptRanges, tlsSNIFromHost, addXDlOpts, addPragmaNC, addXReqPath, addAgeZero, addXReqMethod, addXReqQuery, addXRealScheme, addOAC, addXReqReferer, addXReqOrigin, addXFwdURI, addXNoArch, addXReqHost, addXXSSDis, addXReqRemotePort, addXReqProto, addSaveDataVary, addXTraceID, addXSessionID, addXRespTraceID, addXReqLocalAddr, addXReqLocalPort, addXReqPathInfo, addXFwdPath, addXRealSSLProto, addXRealSSLCipher, addXReqUA, addXReqByteCount, addXReqReceivedAt, addXFwdMethod, addXReqOrigHost, addXReqDNT, addXReqSecure, addXReqQueryCount, addXReqIDHdrResp, addXRobotsNoindex, blockBotUA, blockAdminPaths, addXCSPDis, addXMethodOverride, disableUpstreamCompression int
 	dst := []any{
@@ -2094,6 +2102,7 @@ func scanProxyHost(s interface {
 		&p.MonitorMode, &p.MonitorPath,
 		&p.MonitorMethod, &p.MonitorExpectStatus,
 		&p.MonitorIntervalSec, &p.MonitorTimeoutSec,
+		&nodeLocal, // v2.33.0
 	}
 	if ownerEmail != nil {
 		dst = append(dst, ownerEmail)
@@ -2210,6 +2219,7 @@ func scanProxyHost(s interface {
 	p.AddXRequestMethodOverride = addXMethodOverride == 1
 	p.DisableUpstreamCompression = disableUpstreamCompression == 1 // v2.12.52
 	p.DNSSkipRecord = dnsSkipRecord == 1
+	p.NodeLocal = nodeLocal == 1 // v2.33.0
 	if ownerID != 0 {
 		p.OwnerID = sql.NullInt64{Int64: ownerID, Valid: true}
 	}
@@ -2276,7 +2286,7 @@ func ListProxyHostSummaries(db *sql.DB, serverID int64, viewerID int64, isAdmin 
 		COALESCE(ph.dns_provider, ''), COALESCE(ph.dns_record_id, ''),
 		COALESCE(ph.maintenance_mode, 0), COALESCE(ph.tags, ''),
 		COALESCE(ph.notes, ''), COALESCE(ph.color, ''), ph.updated_at,
-		COALESCE(ph.monitor_mode, ''),
+		COALESCE(ph.monitor_mode, ''), COALESCE(ph.node_local, 0),
 		COALESCE(u.email, '')`
 
 	var rows *sql.Rows
@@ -2307,14 +2317,14 @@ func ListProxyHostSummaries(db *sql.DB, serverID int64, viewerID int64, isAdmin 
 	var out []ProxyHost
 	for rows.Next() {
 		var p ProxyHost
-		var sslEnabled, sslForced, enabled, basicAuth, maintenance int
+		var sslEnabled, sslForced, enabled, basicAuth, maintenance, nodeLocal int
 		var ownerID int64
 		if err := rows.Scan(
 			&p.ID, &p.Domains, &p.ForwardScheme, &p.ForwardHost, &p.ForwardPort,
 			&sslEnabled, &sslForced, &enabled, &p.CertificateID,
 			&basicAuth, &ownerID, &p.DNSProvider, &p.DNSRecordID,
 			&maintenance, &p.Tags, &p.Notes, &p.Color, &p.UpdatedAt,
-			&p.MonitorMode,
+			&p.MonitorMode, &nodeLocal,
 			&p.OwnerEmail,
 		); err != nil {
 			return nil, err
@@ -2324,6 +2334,7 @@ func ListProxyHostSummaries(db *sql.DB, serverID int64, viewerID int64, isAdmin 
 		p.Enabled = enabled == 1
 		p.BasicAuthEnabled = basicAuth == 1
 		p.MaintenanceMode = maintenance == 1
+		p.NodeLocal = nodeLocal == 1 // v2.33.0
 		if ownerID != 0 {
 			p.OwnerID = sql.NullInt64{Int64: ownerID, Valid: true}
 		}
@@ -2540,8 +2551,8 @@ func CreateProxyHost(db *sql.DB, serverID int64, ownerID int64, p *ProxyHost) (i
             add_x_csp_disabled, add_x_request_method_override, proxy_redirect_rules,
             additional_upstream_rules, disable_upstream_compression,
             monitor_mode, monitor_path, monitor_method, monitor_expect_status,
-            monitor_interval_sec, monitor_timeout_sec)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            monitor_interval_sec, monitor_timeout_sec, node_local)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		serverID,
 		p.Domains, p.ForwardScheme, p.ForwardHost, p.ForwardPort,
 		boolInt(p.WebsocketSupport), boolInt(p.BlockCommonExploits),
@@ -2666,6 +2677,7 @@ func CreateProxyHost(db *sql.DB, serverID int64, ownerID int64, p *ProxyHost) (i
 		p.MonitorMode, p.MonitorPath,
 		p.MonitorMethod, p.MonitorExpectStatus,
 		p.MonitorIntervalSec, p.MonitorTimeoutSec,
+		boolInt(p.NodeLocal), // v2.33.0
 	)
 	if err != nil {
 		return 0, err
@@ -2999,6 +3011,7 @@ func UpdateProxyHost(db *sql.DB, p *ProxyHost) error {
             disable_upstream_compression=?,
             monitor_mode=?, monitor_path=?, monitor_method=?,
             monitor_expect_status=?, monitor_interval_sec=?, monitor_timeout_sec=?,
+            node_local=?,
             updated_at=CURRENT_TIMESTAMP
         WHERE id = ?`,
 		p.Domains, p.ForwardScheme, p.ForwardHost, p.ForwardPort,
@@ -3305,6 +3318,7 @@ func UpdateProxyHost(db *sql.DB, p *ProxyHost) error {
 		p.MonitorMode, p.MonitorPath,
 		p.MonitorMethod, p.MonitorExpectStatus,
 		p.MonitorIntervalSec, p.MonitorTimeoutSec,
+		boolInt(p.NodeLocal), // v2.33.0
 		p.ID,
 	)
 	if err != nil {
@@ -3719,10 +3733,12 @@ type RawRoute struct {
 	DNSRecordID   string
 	DNSProfileID  string
 	DNSSkipRecord bool // use provider for DNS-01 but do not create public A records
-	OwnerID       sql.NullInt64
-	OwnerEmail    string // populated via JOIN for display
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	// v2.33.0: exclude from fleet sync — see ProxyHost.NodeLocal.
+	NodeLocal  bool
+	OwnerID    sql.NullInt64
+	OwnerEmail string // populated via JOIN for display
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
 }
 
 const rawRouteCols = `id, label, json_data, COALESCE(caddyfile_src, ''), enabled,
@@ -3730,23 +3746,26 @@ const rawRouteCols = `id, label, json_data, COALESCE(caddyfile_src, ''), enabled
     COALESCE(dns_provider,''), COALESCE(dns_zone_id,''),
     COALESCE(dns_zone_name,''), COALESCE(dns_record_id,''),
     COALESCE(dns_profile_id,''), COALESCE(dns_skip_record,0),
+    COALESCE(node_local,0),
     created_at, updated_at, COALESCE(owner_id, 0)`
 
 func scanRawRoute(s interface {
 	Scan(dest ...any) error
 }) (RawRoute, error) {
 	var r RawRoute
-	var en, force, block, dnsSkipRecord int
+	var en, force, block, dnsSkipRecord, nodeLocal int
 	var ownerID int64
 	err := s.Scan(&r.ID, &r.Label, &r.JSONData, &r.CaddyfileSrc, &en,
 		&r.CertificateID, &force, &block,
 		&r.DNSProvider, &r.DNSZoneID, &r.DNSZoneName, &r.DNSRecordID, &r.DNSProfileID, &dnsSkipRecord,
+		&nodeLocal,
 		&r.CreatedAt, &r.UpdatedAt, &ownerID)
 	if err == nil {
 		r.Enabled = en == 1
 		r.ForceSSL = force == 1
 		r.BlockCommonExploits = block == 1
 		r.DNSSkipRecord = dnsSkipRecord == 1
+		r.NodeLocal = nodeLocal == 1 // v2.33.0
 		if ownerID != 0 {
 			r.OwnerID = sql.NullInt64{Int64: ownerID, Valid: true}
 		}
@@ -3768,6 +3787,7 @@ func ListRawRoutes(db *sql.DB, serverID int64, viewerID int64, isAdmin bool, pee
                COALESCE(rr.dns_provider,''), COALESCE(rr.dns_zone_id,''),
                COALESCE(rr.dns_zone_name,''), COALESCE(rr.dns_record_id,''),
                COALESCE(rr.dns_profile_id,''), COALESCE(rr.dns_skip_record,0),
+               COALESCE(rr.node_local,0),
                rr.created_at, rr.updated_at, COALESCE(rr.owner_id, 0), COALESCE(u.email, '')
         FROM raw_routes rr
         LEFT JOIN users u ON u.id = rr.owner_id
@@ -3781,6 +3801,7 @@ func ListRawRoutes(db *sql.DB, serverID int64, viewerID int64, isAdmin bool, pee
                COALESCE(rr.dns_provider,''), COALESCE(rr.dns_zone_id,''),
                COALESCE(rr.dns_zone_name,''), COALESCE(rr.dns_record_id,''),
                COALESCE(rr.dns_profile_id,''), COALESCE(rr.dns_skip_record,0),
+               COALESCE(rr.node_local,0),
                rr.created_at, rr.updated_at, COALESCE(rr.owner_id, 0), COALESCE(u.email, '')
         FROM raw_routes rr
         LEFT JOIN users u ON u.id = rr.owner_id
@@ -3795,11 +3816,12 @@ func ListRawRoutes(db *sql.DB, serverID int64, viewerID int64, isAdmin bool, pee
 	var out []RawRoute
 	for rows.Next() {
 		var r RawRoute
-		var en, force, block, dnsSkipRecord int
+		var en, force, block, dnsSkipRecord, nodeLocal int
 		var ownerID int64
 		if err := rows.Scan(&r.ID, &r.Label, &r.JSONData, &r.CaddyfileSrc, &en,
 			&r.CertificateID, &force, &block,
 			&r.DNSProvider, &r.DNSZoneID, &r.DNSZoneName, &r.DNSRecordID, &r.DNSProfileID, &dnsSkipRecord,
+			&nodeLocal,
 			&r.CreatedAt, &r.UpdatedAt, &ownerID, &r.OwnerEmail); err != nil {
 			return nil, err
 		}
@@ -3807,6 +3829,7 @@ func ListRawRoutes(db *sql.DB, serverID int64, viewerID int64, isAdmin bool, pee
 		r.ForceSSL = force == 1
 		r.BlockCommonExploits = block == 1
 		r.DNSSkipRecord = dnsSkipRecord == 1
+		r.NodeLocal = nodeLocal == 1 // v2.33.0
 		if ownerID != 0 {
 			r.OwnerID = sql.NullInt64{Int64: ownerID, Valid: true}
 		}
@@ -3820,11 +3843,12 @@ func CreateRawRoute(db *sql.DB, serverID int64, ownerID int64, r *RawRoute) (int
 	res, err := db.Exec(`INSERT INTO raw_routes (server_id, label, json_data, caddyfile_src, enabled,
             certificate_id, force_ssl, block_common_exploits,
             dns_provider, dns_zone_id, dns_zone_name, dns_record_id, dns_profile_id, dns_skip_record,
-            owner_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            node_local, owner_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		serverID, r.Label, r.JSONData, r.CaddyfileSrc, boolInt(r.Enabled),
 		nilIfZero(r.CertificateID), boolInt(r.ForceSSL), boolInt(r.BlockCommonExploits),
 		r.DNSProvider, r.DNSZoneID, r.DNSZoneName, r.DNSRecordID, r.DNSProfileID, boolInt(r.DNSSkipRecord),
+		boolInt(r.NodeLocal), // v2.33.0
 		nilIfZero(ownerID))
 	if err != nil {
 		return 0, err
@@ -3844,10 +3868,12 @@ func UpdateRawRoute(db *sql.DB, r *RawRoute) error {
 	_, err := db.Exec(`UPDATE raw_routes SET label=?, json_data=?, caddyfile_src=?, enabled=?,
             certificate_id=?, force_ssl=?, block_common_exploits=?,
             dns_provider=?, dns_zone_id=?, dns_zone_name=?, dns_record_id=?, dns_profile_id=?, dns_skip_record=?,
+            node_local=?,
             updated_at=CURRENT_TIMESTAMP WHERE id=?`,
 		r.Label, r.JSONData, r.CaddyfileSrc, boolInt(r.Enabled),
 		nilIfZero(r.CertificateID), boolInt(r.ForceSSL), boolInt(r.BlockCommonExploits),
 		r.DNSProvider, r.DNSZoneID, r.DNSZoneName, r.DNSRecordID, r.DNSProfileID, boolInt(r.DNSSkipRecord),
+		boolInt(r.NodeLocal), // v2.33.0
 		r.ID)
 	return err
 }

--- a/internal/server/fleet_sync.go
+++ b/internal/server/fleet_sync.go
@@ -26,6 +26,12 @@ type fleetSyncSummary struct {
 	RedirectsUpdated    int
 	RawRoutesCreated    int
 	RawRoutesUpdated    int
+	// v2.33.0: resources deliberately left behind because they are marked
+	// node-local. Counted and reported rather than silently dropped — an
+	// operator seeing "12 proxies added" needs to know three others were
+	// skipped on purpose, not lost to a bug.
+	ProxiesSkipped   int
+	RawRoutesSkipped int
 }
 
 func (s fleetSyncSummary) Changed() int {
@@ -36,13 +42,18 @@ func (s fleetSyncSummary) Changed() int {
 }
 
 func (s fleetSyncSummary) String() string {
-	return fmt.Sprintf(
+	out := fmt.Sprintf(
 		"proxies: %d added, %d updated; redirects: %d added, %d updated; advanced routes: %d added, %d updated; managed certificates: %d added, %d updated",
 		s.ProxiesCreated, s.ProxiesUpdated,
 		s.RedirectsCreated, s.RedirectsUpdated,
 		s.RawRoutesCreated, s.RawRoutesUpdated,
 		s.CertificatesCreated, s.CertificatesUpdated,
 	)
+	if s.ProxiesSkipped > 0 || s.RawRoutesSkipped > 0 {
+		out += fmt.Sprintf("; skipped as node-local: %d proxies, %d advanced routes",
+			s.ProxiesSkipped, s.RawRoutesSkipped)
+	}
+	return out
 }
 
 func fleetOwnerID(owner sql.NullInt64) int64 {
@@ -479,6 +490,13 @@ func (s *Server) syncFleetConfiguration(actor string, sourceServerID, targetServ
 		}
 	}
 	for _, proxy := range proxies {
+		// v2.33.0: node-local hosts never leave their node. Their upstream
+		// (a Docker service name, a VPN address) means nothing on the target,
+		// so copying them would create a route pointing at nothing.
+		if proxy.NodeLocal {
+			summary.ProxiesSkipped++
+			continue
+		}
 		result, err := s.upsertFleetProxyHost(sourceServerID, targetServerID, proxy, fleetOwnerID(proxy.OwnerID))
 		if err != nil {
 			syncErrors = append(syncErrors, fmt.Errorf("proxy %q: %w", proxy.Domains, err))
@@ -503,6 +521,10 @@ func (s *Server) syncFleetConfiguration(actor string, sourceServerID, targetServ
 		}
 	}
 	for _, rawRoute := range rawRoutes {
+		if rawRoute.NodeLocal { // v2.33.0 — see the proxy loop above
+			summary.RawRoutesSkipped++
+			continue
+		}
 		result, err := s.upsertFleetRawRoute(sourceServerID, targetServerID, rawRoute, fleetOwnerID(rawRoute.OwnerID))
 		if err != nil {
 			syncErrors = append(syncErrors, fmt.Errorf("advanced route %q: %w", rawRoute.Label, err))

--- a/internal/server/node_local_test.go
+++ b/internal/server/node_local_test.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// v2.33.0: node-local resources.
+//
+// Fleet sync copies a proxy host's upstream verbatim to the target node. That
+// is correct for edge replication — several Caddy nodes fronting the same
+// backends — and wrong for federated nodes, where each Caddy fronts its own
+// local stack and the upstream is a Docker service name or a VPN address that
+// only resolves on the node that owns it. Marking a resource node-local keeps
+// it on its node.
+
+func TestFleetSyncSkipsNodeLocalResources(t *testing.T) {
+	s, sourceServerID, targetServerID := newFleetSyncTestServer(t)
+
+	// One host that should travel, one pinned to this node.
+	shared := &models.ProxyHost{
+		Domains: "shared.example.com", ForwardScheme: "https",
+		ForwardHost: "origin.example.com", ForwardPort: 443, Enabled: true,
+	}
+	if _, err := models.CreateProxyHost(s.DB, sourceServerID, 0, shared); err != nil {
+		t.Fatal(err)
+	}
+	local := &models.ProxyHost{
+		Domains: "photos.example.com", ForwardScheme: "http",
+		ForwardHost: "immich_server", ForwardPort: 2283, Enabled: true, NodeLocal: true,
+	}
+	if _, err := models.CreateProxyHost(s.DB, sourceServerID, 0, local); err != nil {
+		t.Fatal(err)
+	}
+
+	localRoute := &models.RawRoute{
+		Label: "local-route", JSONData: `{"handle":[]}`, Enabled: true, NodeLocal: true,
+	}
+	if _, err := models.CreateRawRoute(s.DB, sourceServerID, 0, localRoute); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := s.syncFleetConfiguration("tester", sourceServerID, targetServerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if summary.ProxiesCreated != 1 {
+		t.Errorf("ProxiesCreated = %d, want 1 (only the shared host should travel)", summary.ProxiesCreated)
+	}
+	if summary.ProxiesSkipped != 1 {
+		t.Errorf("ProxiesSkipped = %d, want 1", summary.ProxiesSkipped)
+	}
+	if summary.RawRoutesCreated != 0 {
+		t.Errorf("RawRoutesCreated = %d, want 0", summary.RawRoutesCreated)
+	}
+	if summary.RawRoutesSkipped != 1 {
+		t.Errorf("RawRoutesSkipped = %d, want 1", summary.RawRoutesSkipped)
+	}
+
+	// The target must hold the shared host and nothing node-local — the whole
+	// point is that immich_server never appears on a node that can't resolve it.
+	targets, err := models.ListProxyHosts(s.DB, targetServerID, 0, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("target has %d proxy hosts, want 1", len(targets))
+	}
+	if targets[0].Domains != "shared.example.com" {
+		t.Errorf("target host = %q, want shared.example.com", targets[0].Domains)
+	}
+	for _, h := range targets {
+		if h.ForwardHost == "immich_server" {
+			t.Error("a node-local host reached the target node")
+		}
+	}
+
+	targetRoutes, err := models.ListRawRoutes(s.DB, targetServerID, 0, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targetRoutes) != 0 {
+		t.Errorf("target has %d advanced routes, want 0", len(targetRoutes))
+	}
+}
+
+// Skipped resources must be reported. An operator reading "1 added" needs to
+// know another was deliberately left behind, not silently lost.
+func TestFleetSyncSummaryReportsSkips(t *testing.T) {
+	withSkips := fleetSyncSummary{ProxiesCreated: 1, ProxiesSkipped: 3, RawRoutesSkipped: 2}
+	got := withSkips.String()
+	if !strings.Contains(got, "skipped as node-local: 3 proxies, 2 advanced routes") {
+		t.Errorf("summary does not report skips: %s", got)
+	}
+
+	// No skips, no noise.
+	clean := fleetSyncSummary{ProxiesCreated: 1}
+	if strings.Contains(clean.String(), "skipped as node-local") {
+		t.Errorf("summary mentions skips when there were none: %s", clean.String())
+	}
+}
+
+// "Also deploy to" must refuse a node-local resource too, otherwise the
+// per-host form becomes a way around the flag.
+func TestCrossDeployRefusesNodeLocal(t *testing.T) {
+	s, sourceServerID, targetServerID := newFleetSyncTestServer(t)
+
+	local := &models.ProxyHost{
+		Domains: "photos.example.com", ForwardScheme: "http",
+		ForwardHost: "immich_server", ForwardPort: 2283, Enabled: true, NodeLocal: true,
+	}
+	id, err := models.CreateProxyHost(s.DB, sourceServerID, 0, local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	local.ID = id
+	s.crossDeployProxyHost("tester", sourceServerID, local, []int64{targetServerID})
+
+	targets, err := models.ListProxyHosts(s.DB, targetServerID, 0, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 0 {
+		t.Errorf("cross-deploy pushed a node-local host: %d row(s) on target", len(targets))
+	}
+
+	rr := &models.RawRoute{Label: "local", JSONData: `{"handle":[]}`, Enabled: true, NodeLocal: true}
+	rrID, err := models.CreateRawRoute(s.DB, sourceServerID, 0, rr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr.ID = rrID
+	s.crossDeployRawRoute("tester", sourceServerID, rr, []int64{targetServerID})
+
+	targetRoutes, err := models.ListRawRoutes(s.DB, targetServerID, 0, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targetRoutes) != 0 {
+		t.Errorf("cross-deploy pushed a node-local advanced route: %d row(s) on target", len(targetRoutes))
+	}
+}
+
+// A host that isn't marked node-local must still sync — the flag is opt-in and
+// must not change behaviour for anyone who never sets it.
+func TestFleetSyncStillCopiesNormalHosts(t *testing.T) {
+	s, sourceServerID, targetServerID := newFleetSyncTestServer(t)
+
+	normal := &models.ProxyHost{
+		Domains: "app.example.com", ForwardScheme: "https",
+		ForwardHost: "origin.example.com", ForwardPort: 443, Enabled: true,
+	}
+	if _, err := models.CreateProxyHost(s.DB, sourceServerID, 0, normal); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := s.syncFleetConfiguration("tester", sourceServerID, targetServerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.ProxiesCreated != 1 || summary.ProxiesSkipped != 0 {
+		t.Errorf("created=%d skipped=%d, want 1/0", summary.ProxiesCreated, summary.ProxiesSkipped)
+	}
+}

--- a/internal/server/proxy_host_form.go
+++ b/internal/server/proxy_host_form.go
@@ -682,6 +682,8 @@ func parseProxyHostForm(r *http.Request) (*models.ProxyHost, error) {
 	// would promise a cadence the UI can't deliver.
 	ph.MonitorIntervalSec = clampAtoi(r.FormValue("monitor_interval_sec"), 0, 60, 86400)
 	ph.MonitorTimeoutSec = clampAtoi(r.FormValue("monitor_timeout_sec"), 0, 1, 120)
+	// v2.33.0: node-local — never sync this host to another Caddy.
+	ph.NodeLocal = r.FormValue("node_local") == "on"
 	// v2.9.266: proxy_redirect_rules — JSON array of path-based redirects
 	// fired before the reverse_proxy. Same shape as redirection_hosts.
 	ph.ProxyRedirectRules = func() string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3997,6 +3997,16 @@ func (s *Server) crossDeployProxyHost(actor string, sourceServerID int64, p *mod
 	s.fleetDeployMu.Lock()
 	defer s.fleetDeployMu.Unlock()
 
+	// v2.33.0: a node-local host is pinned to the node it was created on — its
+	// upstream only resolves there. Refuse to cross-deploy rather than create a
+	// route on the target that points at nothing. Logged so the operator can
+	// see why nothing happened; the form also hides the picker for these.
+	if p.NodeLocal {
+		_ = models.LogActivity(s.DB, sourceServerID, actor, "proxy_cross_deploy", fmt.Sprintf("proxy:%d", p.ID),
+			"skipped: host is marked node-local", false)
+		return
+	}
+
 	sourceCerts, _ := models.ListCertificates(s.DB, sourceServerID)
 	for _, sid := range serverIDs {
 		if _, _, err := s.validateFleetPair(sourceServerID, sid); err != nil {
@@ -4196,6 +4206,13 @@ func (s *Server) crossDeployRedirectionHost(actor string, sourceServerID int64, 
 func (s *Server) crossDeployRawRoute(actor string, sourceServerID int64, rr *models.RawRoute, serverIDs []int64) {
 	s.fleetDeployMu.Lock()
 	defer s.fleetDeployMu.Unlock()
+
+	// v2.33.0 — see crossDeployProxyHost.
+	if rr.NodeLocal {
+		_ = models.LogActivity(s.DB, sourceServerID, actor, "raw_cross_deploy", fmt.Sprintf("raw:%d", rr.ID),
+			"skipped: route is marked node-local", false)
+		return
+	}
 
 	for _, sid := range serverIDs {
 		if _, _, err := s.validateFleetPair(sourceServerID, sid); err != nil {
@@ -7341,6 +7358,7 @@ func (s *Server) parseRawRouteForm(r *http.Request) (*models.RawRoute, string) {
 		CertificateID:       certID,
 		ForceSSL:            r.FormValue("ssl_forced") == "on",
 		BlockCommonExploits: r.FormValue("block_common_exploits") == "on",
+		NodeLocal:           r.FormValue("node_local") == "on", // v2.33.0
 		DNSProvider:         provider,
 		DNSZoneID:           zoneID,
 		DNSZoneName:         zoneName,

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -3576,19 +3576,39 @@ document.addEventListener('DOMContentLoaded', function() {
         <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Custom security disclosure policy served at <code>GET /.well-known/security.txt</code>. Leave empty to pass the request through to your upstream. See <a href="https://securitytxt.org" target="_blank" class="underline">securitytxt.org</a> for the standard format.</p>
       </div>
 
+  {{/* v2.33.0: node-local. Fleet sync copies the upstream verbatim, which is
+       right when several Caddy nodes front the same backends and wrong when
+       each node fronts its own stack — a Docker service name or VPN address
+       only resolves on the node that owns it. Placed directly above the
+       deploy picker because that is where the decision gets made. */}}
   {{if .OtherServers}}
   <div data-workflow-section="deployment" class="pt-4 border-t border-ink-100">
-    <div class="text-xs uppercase tracking-wider text-ink-500 font-medium mb-2">Also deploy to</div>
-    <p class="text-xs text-ink-400 mb-3">Push a copy of this config to additional servers at the same time. Uploaded PEM/path certificates are not mirrored. If a managed wildcard on this server covers the hostname, CaddyUI automatically copies that definition to each target so Caddy can reuse the wildcard there too.</p>
-    <div class="space-y-2">
-      {{range .OtherServers}}
-      <label class="flex items-center gap-2.5 cursor-pointer select-none">
-        <input type="checkbox" name="deploy_to" value="{{.ID}}" class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
-        <span class="text-sm text-ink-700 font-medium">{{.Name}}</span>
-        {{if eq .Status "online"}}<span class="w-2 h-2 rounded-full bg-green-500 shrink-0"></span>{{else if eq .Status "offline"}}<span class="w-2 h-2 rounded-full bg-red-400 shrink-0"></span>{{else}}<span class="w-2 h-2 rounded-full bg-ink-300 shrink-0"></span>{{end}}
-        <span class="text-xs text-ink-400 font-mono truncate">{{.AdminURL}}</span>
-      </label>
-      {{end}}
+    <label class="flex items-start gap-2.5 cursor-pointer select-none mb-4">
+      <input type="checkbox" name="node_local" id="node-local" {{if .Host.NodeLocal}}checked{{end}}
+        class="mt-0.5 rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
+      <span>
+        <span class="text-sm text-ink-800 font-medium">This host is node-local — never sync it to other servers</span>
+        <span class="block text-xs text-ink-500 mt-0.5">Use when the upstream only means something on this node: a Docker service name, a VPN address, or a loopback port. Full fleet syncs and “Also deploy to” will skip it and report it as skipped rather than creating a route elsewhere that points at nothing.</span>
+      </span>
+    </label>
+
+    <div id="node-local-hint" class="hidden mb-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+      <span class="font-medium">Heads up:</span> <code id="node-local-hint-host" class="font-mono"></code> looks like a Docker service name — it usually only resolves on the node running that container. Deploying this host to another server would create a route there pointing at nothing. Consider marking it node-local.
+    </div>
+
+    <div id="deploy-targets"{{if .Host.NodeLocal}} class="hidden"{{end}}>
+      <div class="text-xs uppercase tracking-wider text-ink-500 font-medium mb-2">Also deploy to</div>
+      <p class="text-xs text-ink-400 mb-3">Push a copy of this config to additional servers at the same time. Uploaded PEM/path certificates are not mirrored. If a managed wildcard on this server covers the hostname, CaddyUI automatically copies that definition to each target so Caddy can reuse the wildcard there too.</p>
+      <div class="space-y-2">
+        {{range .OtherServers}}
+        <label class="flex items-center gap-2.5 cursor-pointer select-none">
+          <input type="checkbox" name="deploy_to" value="{{.ID}}" class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
+          <span class="text-sm text-ink-700 font-medium">{{.Name}}</span>
+          {{if eq .Status "online"}}<span class="w-2 h-2 rounded-full bg-green-500 shrink-0"></span>{{else if eq .Status "offline"}}<span class="w-2 h-2 rounded-full bg-red-400 shrink-0"></span>{{else}}<span class="w-2 h-2 rounded-full bg-ink-300 shrink-0"></span>{{end}}
+          <span class="text-xs text-ink-400 font-mono truncate">{{.AdminURL}}</span>
+        </label>
+        {{end}}
+      </div>
     </div>
   </div>
   {{end}}
@@ -4682,6 +4702,40 @@ document.addEventListener('DOMContentLoaded', function() {
     custom.classList.toggle('hidden', mode.value !== 'custom');
   }
   mode.addEventListener('change', sync);
+  sync();
+})();
+
+// v2.33.0: node-local hosts.
+//
+//  1. Warn when the upstream looks like it only resolves on this node. The
+//     rule mirrors the server's isInternalHostname(): a single-label hostname
+//     with no dot and no colon is a container/Compose service name, which
+//     Caddy on a different node will not resolve.
+//  2. Hide the deploy picker when node-local is ticked, since the server
+//     refuses to cross-deploy those anyway — better to not offer the choice
+//     than to accept it and silently skip.
+(function() {
+  var check = document.getElementById('node-local');
+  var hint = document.getElementById('node-local-hint');
+  var hintHost = document.getElementById('node-local-hint-host');
+  var fwd = document.querySelector('[name="forward_host"]');
+  var picker = document.getElementById('deploy-targets');
+  if (!check || !hint || !fwd) return;
+
+  function looksNodeLocal(host) {
+    host = (host || '').trim();
+    if (!host || host === 'localhost') return false;
+    return host.indexOf('.') === -1 && host.indexOf(':') === -1;
+  }
+  function sync() {
+    var local = looksNodeLocal(fwd.value);
+    // Only nag when they haven't already made the call.
+    hint.classList.toggle('hidden', !local || check.checked);
+    if (local) hintHost.textContent = fwd.value.trim();
+    if (picker) picker.classList.toggle('hidden', check.checked);
+  }
+  fwd.addEventListener('input', sync);
+  check.addEventListener('change', sync);
   sync();
 })();
 </script>

--- a/web/templates/proxy_hosts.html
+++ b/web/templates/proxy_hosts.html
@@ -383,6 +383,15 @@
             <span class="app-dot w-2 h-2 rounded-full bg-ink-300 shrink-0" title="App: checking..."></span>
             {{.ForwardScheme}}://{{.ForwardHost}}:{{.ForwardPort}}
           </span>
+          {{/* v2.33.0: node-local hosts are pinned to this Caddy and skipped by
+               fleet sync. Shown next to the upstream because the upstream is
+               the reason they're pinned. */}}
+          {{if .NodeLocal}}
+          <span class="inline-flex items-center gap-1 ml-1 px-1.5 py-0.5 rounded text-[11px] font-medium bg-ink-100 text-ink-600 align-middle" title="Node-local: never synced to other Caddy servers">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-2.5 h-2.5 shrink-0"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+            node-local
+          </span>
+          {{end}}
         </td>
         <td class="px-5 py-3">
           {{if .CertificateID}}

--- a/web/templates/raw_route_form.html
+++ b/web/templates/raw_route_form.html
@@ -177,21 +177,45 @@
        redirects. Before this, mirroring an advanced route onto a second node
        meant running a full fleet sync against that node, which overwrote
        everything else configured there. */}}
+  {{/* v2.33.0: node-local — see the note on the proxy host form. An advanced
+       route's upstreams live inside its JSON, so there is no single field to
+       inspect for a warning; the opt-out is offered explicitly instead. */}}
   {{if .OtherServers}}
   <div class="pt-4 border-t border-ink-100">
-    <div class="text-xs uppercase tracking-wider text-ink-500 font-medium mb-2">Also deploy to</div>
-    <p class="text-xs text-ink-400 mb-3">Push a copy of this advanced route to additional servers at the same time. Certificates are not mirrored — each server will use its own auto-SSL.</p>
-    <div class="space-y-2">
-      {{range .OtherServers}}
-      <label class="flex items-center gap-2.5 cursor-pointer select-none">
-        <input type="checkbox" name="deploy_to" value="{{.ID}}" class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
-        <span class="text-sm text-ink-700 font-medium">{{.Name}}</span>
-        {{if eq .Status "online"}}<span class="w-2 h-2 rounded-full bg-green-500 shrink-0"></span>{{else if eq .Status "offline"}}<span class="w-2 h-2 rounded-full bg-red-400 shrink-0"></span>{{else}}<span class="w-2 h-2 rounded-full bg-ink-300 shrink-0"></span>{{end}}
-        <span class="text-xs text-ink-400 font-mono truncate">{{.AdminURL}}</span>
-      </label>
-      {{end}}
+    <label class="flex items-start gap-2.5 cursor-pointer select-none mb-4">
+      <input type="checkbox" name="node_local" id="node-local" {{if .Row.NodeLocal}}checked{{end}}
+        class="mt-0.5 rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
+      <span>
+        <span class="text-sm text-ink-800 font-medium">This route is node-local — never sync it to other servers</span>
+        <span class="block text-xs text-ink-500 mt-0.5">Use when the route's upstreams only resolve on this node — Docker service names, VPN addresses, loopback ports. Full fleet syncs and “Also deploy to” will skip it and report it as skipped.</span>
+      </span>
+    </label>
+
+    <div id="deploy-targets"{{if .Row.NodeLocal}} class="hidden"{{end}}>
+      <div class="text-xs uppercase tracking-wider text-ink-500 font-medium mb-2">Also deploy to</div>
+      <p class="text-xs text-ink-400 mb-3">Push a copy of this advanced route to additional servers at the same time. Certificates are not mirrored — each server will use its own auto-SSL.</p>
+      <div class="space-y-2">
+        {{range .OtherServers}}
+        <label class="flex items-center gap-2.5 cursor-pointer select-none">
+          <input type="checkbox" name="deploy_to" value="{{.ID}}" class="rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
+          <span class="text-sm text-ink-700 font-medium">{{.Name}}</span>
+          {{if eq .Status "online"}}<span class="w-2 h-2 rounded-full bg-green-500 shrink-0"></span>{{else if eq .Status "offline"}}<span class="w-2 h-2 rounded-full bg-red-400 shrink-0"></span>{{else}}<span class="w-2 h-2 rounded-full bg-ink-300 shrink-0"></span>{{end}}
+          <span class="text-xs text-ink-400 font-mono truncate">{{.AdminURL}}</span>
+        </label>
+        {{end}}
+      </div>
     </div>
   </div>
+  <script>
+  (function() {
+    var check = document.getElementById('node-local');
+    var picker = document.getElementById('deploy-targets');
+    if (!check || !picker) return;
+    function sync() { picker.classList.toggle('hidden', check.checked); }
+    check.addEventListener('change', sync);
+    sync();
+  })();
+  </script>
   {{end}}
 
   {{if .Users}}


### PR DESCRIPTION
Fleet sync copies a proxy host's upstream **verbatim** to the target node. That's correct for **edge replication** — several Caddy nodes fronting the same backends — and wrong for **federated nodes**, where each Caddy fronts its own local stack.

Concretely: `immich_server:2283` is Docker DNS that only resolves inside one node's network, and `10.8.0.1:9586` is a WireGuard address. Syncing those creates routes on the target that point at nothing.

## The gap this closes

`preserveProxyTargetPolicy` already accepts that some fields must differ per node — it deliberately refuses to overwrite the target's certificates, DNS records, zone IDs and keys. The **upstream address**, the field most likely of all to be node-specific, was still being copied. That inconsistency is the bug.

## What this adds

Proxy hosts and advanced routes can be marked **node-local**:

- Excluded from full fleet syncs **and** from "Also deploy to"
- Enforced server-side in `crossDeployProxyHost` / `crossDeployRawRoute`, so the per-host form can't route around the flag
- Sync **reports** what it skipped rather than silently dropping it — an operator reading "12 proxies added" needs to know three others were left behind on purpose

Real sync summary from a two-node test instance:

```
source_server=1 target_server=2 proxies: 1 added, 0 updated; redirects: 0 added, 0 updated;
advanced routes: 0 added, 0 updated; managed certificates: 0 added, 0 updated;
skipped as node-local: 1 proxies, 0 advanced routes
```

Resulting rows — the Docker-backed host stayed home:

```
server=1  photos.example.com  -> immich_server       node_local=1
server=1  shared.example.com  -> origin.example.com  node_local=0
server=2  shared.example.com  -> origin.example.com  node_local=0
```

## The warning

The proxy host form warns when the upstream looks node-local but the box is unticked, reusing the same single-label-hostname rule as `isInternalHostname()` — the test CaddyUI already applies when deciding it can't resolve a backend itself. Verified in a browser:

```
origin.example.com  -> no warning
immich_server       -> warning, naming the host
tick node-local     -> warning clears, deploy picker hides
```

Advanced routes get the checkbox but no warning: their upstreams live inside arbitrary JSON, so there's no single field to inspect.

## Deliberately *not* per-node upstream overrides

That would make "same hostname, different backend per node" first-class, but needs a new table, form UI, sync logic and config generation. The opt-out solves the actual problem — sync pushing nonsense — without committing to that data model. Worth revisiting if the HA case ever comes up.

## Verification

`go build`, `go vet`, `go test ./...` pass, with four new tests covering sync exclusion, skip reporting, cross-deploy refusal, and that **unmarked hosts still sync normally** (the flag is opt-in and must not change existing behaviour).

One projection trap caught along the way: `ListProxyHostSummaries` has its own narrow column list and returned `NodeLocal=false` until fixed — the same shape of bug as the `monitor_mode` one in v2.28.0. I probed all four read paths explicitly rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)