### PR TITLE
fix: drop the sidebar update pill, keep the dashboard banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.34.0] - 2026-08-21 - One place for the update notice
+
+### Removed
+
+- The **"↑ vX.Y.Z available"** pill in the sidebar footer. The Operations dashboard already announces the same update in context and links straight to the release, so the pill was a second place to notice it and a second place to dismiss it. The running version stays in the sidebar, where it is useful on every page.
+- The `badge-pulse` animation and `#update-badge` rule that existed only for the pill.
+
+The dashboard banner is unchanged.
+
 ## [2.33.0] - 2026-08-21 - Node-local proxy hosts and advanced routes
 
 ### Added

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -378,6 +378,44 @@ func TestCaptchaSecretsNeverRenderIntoTheDOM(t *testing.T) {
 	}
 }
 
+// TestUpdateNoticeLivesOnlyOnTheDashboard pins where the "a new version is
+// available" message appears. v2.34.0 removed the sidebar pill because the
+// Operations dashboard already announces the same update in context and links
+// to the release — two places to notice it meant two places to dismiss it.
+//
+// The dashboard banner is the one that stays; the sidebar keeps the running
+// version but nothing else.
+func TestUpdateNoticeLivesOnlyOnTheDashboard(t *testing.T) {
+	layout, err := FS.ReadFile("templates/layout.html")
+	if err != nil {
+		t.Fatalf("read layout.html: %v", err)
+	}
+	if strings.Contains(string(layout), `id="update-badge"`) {
+		t.Error("the sidebar update pill is back in layout.html — the dashboard banner is the single place for this")
+	}
+	if !strings.Contains(string(layout), "{{.AppVersion}}") {
+		t.Error("layout.html should still show the running version in the sidebar")
+	}
+
+	appJS, err := FS.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatalf("read app.js: %v", err)
+	}
+	if strings.Contains(string(appJS), "update-badge") {
+		t.Error("app.js still populates the removed sidebar pill")
+	}
+
+	dash, err := FS.ReadFile("templates/dashboard.html")
+	if err != nil {
+		t.Fatalf("read dashboard.html: %v", err)
+	}
+	for _, marker := range []string{`id="update-notice"`, "/api/version-check", "has_update"} {
+		if !strings.Contains(string(dash), marker) {
+			t.Errorf("dashboard.html lost its update banner marker %q — removing the pill must not take the banner with it", marker)
+		}
+	}
+}
+
 // TestBulkBarDoesNotOverlapListContent guards the fix for the floating
 // "N selected" bulk-action bar covering the last row of a long list.
 // #bulk-bar is `position: fixed` and never reserved space for itself, so on

--- a/web/static/app.css
+++ b/web/static/app.css
@@ -1393,14 +1393,9 @@ html.dark .text-heading-gradient {
   pointer-events: none;
 }
 
-/* Badge pulse for update dot */
-@keyframes badge-pulse {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.7; }
-}
-#update-badge:not(.hidden) {
-  animation: badge-pulse 2s ease-in-out infinite;
-}
+/* v2.34.0: the badge-pulse keyframes and #update-badge rule were removed with
+   the sidebar update pill they animated. The Operations dashboard banner
+   (#update-notice) carries the update notice now. */
 
 /* Dropdown glass panels */
 [data-server-menu-panel]:not(.hidden),

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -69,30 +69,10 @@ function caddyuiDelayFetch(ms, fn) {
   }
 }
 
-(function() {
-  var badge = document.getElementById('update-badge');
-  if (!badge) return;
-  var DISMISS_KEY = 'caddyui-update-dismissed';
-  // v2.12.42: deferred 3s — version-check is a Docker Hub round-trip
-  // (~300 ms) that has no business blocking initial paint metrics.
-  caddyuiDelayFetch(3000, function() {
-  fetch('/api/version-check')
-    .then(function(r) { return r.ok ? r.json() : null; })
-    .then(function(d) {
-      if (!d || !d.has_update) return;
-      var dismissed = '';
-      try { dismissed = localStorage.getItem(DISMISS_KEY) || ''; } catch(e) {}
-      if (dismissed === d.latest) return; // already dismissed this version
-      badge.textContent = '↑ ' + d.latest + ' available';
-      badge.classList.remove('hidden');
-      badge.addEventListener('click', function() {
-        try { localStorage.setItem(DISMISS_KEY, d.latest); } catch(e) {}
-        badge.classList.add('hidden');
-      });
-    })
-    .catch(function() {});
-  }); // close caddyuiDelayFetch
-})();
+// v2.34.0: the sidebar "available" update pill was removed. The Operations
+// dashboard already surfaces the same information in context, with a link to
+// the release notes, so the pill was a second place to maintain and a second
+// place for the user to dismiss. See #update-notice in dashboard.html.
 
 // v2.11.0: global keyboard shortcuts.
 //   "?" — open the shortcut overlay

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -511,9 +511,13 @@ if ('serviceWorker' in navigator) {
            since v2.6.2 — the sidebar footer is pure project-meta now. */}}
       <div class="app-sidebar__footer border-t border-slate-800 px-4 py-3 space-y-1.5">
         {{if .AppVersion}}
+        {{/* v2.34.0: the "↑ vX.Y.Z available" pill that sat next to the version
+             was removed. The Operations dashboard already announces the same
+             update in context and links to the release, so this was a second
+             place to notice it and a second place to dismiss it. The running
+             version stays — that's useful on every page. */}}
         <div class="text-xs flex items-center gap-1.5">
           <span class="text-[10px] font-mono text-slate-500">{{if .SiteTitle}}{{.SiteTitle}}{{else}}CaddyUI{{end}} {{.AppVersion}}</span>
-          <span id="update-badge" class="hidden inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-amber-100 text-amber-700 cursor-pointer" title="Click to dismiss"></span>
         </div>
         {{end}}
         <div class="text-[10px] text-slate-500 flex items-center gap-1.5 flex-wrap">


### PR DESCRIPTION
The `↑ vX.Y.Z available` pill in the sidebar footer duplicated the Operations dashboard banner, which says the same thing with more context and links to the release:

> ⓘ CaddyUI v2.32.0 is available (running v2.31.0).  **View release**

Two places to notice one update means two places to dismiss it. The dashboard banner wins — it's in context, and it's where you're already looking when you're thinking about the deployment.

## Removed

- The pill markup in `layout.html`
- The IIFE in `app.js` that fetched `/api/version-check` to populate it
- The `badge-pulse` keyframes and `#update-badge` rule in `app.css`, which existed only to animate it

The **running version stays** in the sidebar — useful on every page, and the part that isn't duplicated.

`caddyuiDelayFetch` stays: three other callers still use it.

## Verified

Served HTML and assets after the change:

```
update-badge in page:        0
update-notice banner:        4 refs
app.js  update-badge:        0
app.css #update-badge rule:  False
version line still shown:    True
```

And in a browser, the sidebar footer now reads exactly `CaddyUI dev · © 2026 · GitHub · License` with `#update-badge` absent from the DOM and `#update-notice` still present.

A test pins the asymmetry — no pill in the layout or `app.js`, banner markers still in `dashboard.html` — so a later cleanup can't take the banner along with the pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)