### PR TITLE
fix: make monitoring Off actually stop every CaddyUI probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.35.0] - 2026-08-21 - Monitoring "Off" now covers all three probes
+
+### Fixed
+
+- The v2.28.0 monitoring section promised that setting a host to **Off** would stop "all outbound probes for this host." It didn't. A third probe — the persisted "Public" health check behind `/proxy-hosts/{id}/health` and the left-most dot on the proxy hosts list, which runs every 5 minutes and keeps 24 hours of history — was never wired to it, and kept probing every enabled host regardless of `MonitorMode`.
+- The same gap meant **Custom** mode's path, method, and expected status only ever applied to the App and Port dots. A host with a non-default health path or an unusual expected status could still show the Public dot red, because that check always requested `/` and only accepted 2xx/3xx/401/403.
+- Both are fixed: the Public checker now reads the same `MonitorSettings` as the other two, is skipped entirely when a host is Off, and paces a custom interval against its own persisted history so pacing survives a restart.
+- The proxy hosts list and the health detail page no longer show a stale "up" or "down" status left over from before a host was switched to Off — both check the current `MonitorMode` first and show a neutral "monitoring off" state instead.
+- The monitoring section's copy on the proxy host form now names all three probes it drives and links to the Public check's history page, instead of only mentioning the App and Port dots.
+
+`NodeLocal` is deliberately not consulted by the Public checker — it describes where a host's *upstream* resolves, not whether its *public domain* should be checked from the internet-facing side, which is what this probe does.
+
 ## [2.34.0] - 2026-08-21 - One place for the update notice
 
 ### Removed

--- a/internal/server/public_health_monitor_test.go
+++ b/internal/server/public_health_monitor_test.go
@@ -1,0 +1,244 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	appdb "github.com/X4Applegate/caddyui/internal/db"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// v2.35.0 (issue #39 follow-up): the "Public" health checker — the persisted,
+// 24h-history probe behind /proxy-hosts/{id}/health and the left-most dot on
+// the proxy hosts list — was a *third* CaddyUI-run probe alongside the App and
+// Port dots v2.28.0 made configurable. It was never wired to MonitorMode: a
+// host set to "Off" (promised to stop "all outbound probes for this host")
+// kept getting hit here every 5 minutes regardless, and a host in "Custom"
+// mode with a non-default path or expected status still showed this dot red
+// because the check always requested "/" with the default classification.
+// These tests pin the fix.
+
+// newPublicHealthTestServer builds a Server plus a registered CaddyServer
+// (serverID 1). checkAllProxyHosts walks models.ListCaddyServers before it
+// ever looks at a host, so a test that skips this and creates hosts under a
+// bare serverID with no matching caddy_servers row silently checks nothing —
+// the loop body never runs. That previously hung a test outright: it blocked
+// forever reading from an httptest handler's channel that was never fed
+// because checkAllProxyHosts had zero servers to iterate.
+func newPublicHealthTestServer(t *testing.T) *Server {
+	t.Helper()
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if _, err := models.CreateCaddyServer(conn, &models.CaddyServer{
+		Name: "Primary", AdminURL: "http://primary:2019", Type: models.CaddyServerTypeManaged,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return &Server{DB: conn}
+}
+
+func hostportOfURL(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse test server URL %q: %v", raw, err)
+	}
+	return u.Host
+}
+
+func TestCheckAllProxyHostsSkipsMonitoringOff(t *testing.T) {
+	s := newPublicHealthTestServer(t)
+
+	var hits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	host := &models.ProxyHost{
+		Domains: hostportOfURL(t, srv.URL), ForwardScheme: "http", ForwardHost: "backend",
+		ForwardPort: 80, Enabled: true, SSLEnabled: false, MonitorMode: "off",
+	}
+	id, err := models.CreateProxyHost(s.DB, 1, 0, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s.checkAllProxyHosts()
+
+	if n := atomic.LoadInt64(&hits); n != 0 {
+		t.Errorf("probe made %d request(s) to a monitoring-off host, want 0", n)
+	}
+	history, err := models.GetProxyHealthHistory(s.DB, id, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 0 {
+		t.Errorf("monitoring-off host has %d persisted health row(s), want 0", len(history))
+	}
+}
+
+func TestCheckAllProxyHostsUsesCustomPathMethodAndExpectStatus(t *testing.T) {
+	s := newPublicHealthTestServer(t)
+
+	gotPath := make(chan string, 1)
+	gotMethod := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath <- r.URL.Path
+		gotMethod <- r.Method
+		w.WriteHeader(http.StatusNoContent) // 204: "up" only because expectStatus says so
+	}))
+	defer srv.Close()
+
+	host := &models.ProxyHost{
+		Domains: hostportOfURL(t, srv.URL), ForwardScheme: "http", ForwardHost: "backend",
+		ForwardPort: 80, Enabled: true, SSLEnabled: false,
+		MonitorMode: "custom", MonitorPath: "/healthz", MonitorMethod: "HEAD", MonitorExpectStatus: 204,
+	}
+	id, err := models.CreateProxyHost(s.DB, 1, 0, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s.checkAllProxyHosts()
+
+	if p := <-gotPath; p != "/healthz" {
+		t.Errorf("probed path = %q, want /healthz", p)
+	}
+	if m := <-gotMethod; m != "HEAD" {
+		t.Errorf("probed method = %q, want HEAD", m)
+	}
+	history, err := models.GetProxyHealthHistory(s.DB, id, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("history rows = %d, want 1", len(history))
+	}
+	if !history[0].OK {
+		t.Error("204 with expectStatus=204 should record OK, got not-OK")
+	}
+	if history[0].StatusCode != 204 {
+		t.Errorf("recorded status = %d, want 204", history[0].StatusCode)
+	}
+}
+
+// The pre-existing failure mode: a custom health path answering something
+// other than the default-accepted codes (2xx/3xx/401/403) must show as down
+// when no expectStatus is set, matching the App-dot semantics exactly.
+func TestCheckAllProxyHostsWithoutExpectStatusUsesDefaultHeuristic(t *testing.T) {
+	s := newPublicHealthTestServer(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot) // 418: outside the default-accepted set
+	}))
+	defer srv.Close()
+
+	host := &models.ProxyHost{
+		Domains: hostportOfURL(t, srv.URL), ForwardScheme: "http", ForwardHost: "backend",
+		ForwardPort: 80, Enabled: true, SSLEnabled: false,
+	}
+	id, err := models.CreateProxyHost(s.DB, 1, 0, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s.checkAllProxyHosts()
+
+	history, err := models.GetProxyHealthHistory(s.DB, id, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("history rows = %d, want 1", len(history))
+	}
+	if history[0].OK {
+		t.Error("418 with no expectStatus should record not-OK")
+	}
+}
+
+func TestCheckAllProxyHostsStillChecksAutomaticHosts(t *testing.T) {
+	s := newPublicHealthTestServer(t)
+
+	var hits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	host := &models.ProxyHost{
+		Domains: hostportOfURL(t, srv.URL), ForwardScheme: "http", ForwardHost: "backend",
+		ForwardPort: 80, Enabled: true, SSLEnabled: false, // MonitorMode left unset — must behave as before this fix
+	}
+	if _, err := models.CreateProxyHost(s.DB, 1, 0, host); err != nil {
+		t.Fatal(err)
+	}
+
+	s.checkAllProxyHosts()
+
+	if n := atomic.LoadInt64(&hits); n != 1 {
+		t.Errorf("automatic-mode host got %d probe(s), want 1 — the flag is opt-in and must not change default behaviour", n)
+	}
+}
+
+func TestPublicHealthDueRespectsCustomInterval(t *testing.T) {
+	s := newPublicHealthTestServer(t)
+
+	host := &models.ProxyHost{
+		Domains: "app.example.com", ForwardScheme: "http", ForwardHost: "backend",
+		ForwardPort: 80, Enabled: true,
+	}
+	id, err := models.CreateProxyHost(s.DB, 1, 0, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No history yet: always due, regardless of interval.
+	if !s.publicHealthDue(id, 30*time.Minute) {
+		t.Error("never-checked host should be due")
+	}
+	// At or below the native 5-minute tick: always due (can't run faster than
+	// the ticker itself).
+	if !s.publicHealthDue(id, publicHealthCheckerInterval) {
+		t.Error("a host at the native interval should always be due")
+	}
+
+	if err := models.InsertProxyHealth(s.DB, id, true, 200, 10, ""); err != nil {
+		t.Fatal(err)
+	}
+	if s.publicHealthDue(id, 30*time.Minute) {
+		t.Error("a host just checked with a 30-minute interval should not be due yet")
+	}
+}
+
+func TestPublicHealthCadenceLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		h    models.ProxyHost
+		want string
+	}{
+		{"auto", models.ProxyHost{MonitorMode: "auto"}, "every 5 min"},
+		{"blank", models.ProxyHost{}, "every 5 min"},
+		{"off", models.ProxyHost{MonitorMode: "off"}, "every 5 min"},
+		{"custom no interval", models.ProxyHost{MonitorMode: "custom"}, "every 5 min"},
+		{"custom below native tick", models.ProxyHost{MonitorMode: "custom", MonitorIntervalSec: 60}, "every 5 min"},
+		{"custom 30 min", models.ProxyHost{MonitorMode: "custom", MonitorIntervalSec: 1800}, "roughly every 30 min (custom)"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := publicHealthCadenceLabel(c.h); got != c.want {
+				t.Errorf("publicHealthCadenceLabel(%+v) = %q, want %q", c.h, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -107,9 +107,6 @@ type Server struct {
 	runtimeLogMu       sync.Mutex
 	runtimeLogTimers   map[int64]*time.Timer
 	certificateProbeFn func(models.CaddyServer, models.Certificate) managedCertificateServerStatus
-
-	// v2.9.2: HTTP client used by the background per-proxy-host health checker.
-	healthClient *http.Client
 }
 
 type apiTokenScopeContextKey struct{}
@@ -148,16 +145,6 @@ func New(db *sql.DB, caddyClient *caddy.Client, templates fs.FS, static fs.FS, c
 		healthFailures:   map[int64]int{},
 		appHealth:        map[int64]appHealthEntry{},
 		runtimeLogTimers: map[int64]*time.Timer{},
-	}
-	// Initialize health check HTTP client (short timeouts, no redirect following).
-	s.healthClient = &http.Client{
-		Timeout: 10 * time.Second,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse // don't follow redirects
-		},
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // check reachability, not cert validity
-		},
 	}
 	go s.runHealthChecker()
 	go s.runAutoSyncLoop()
@@ -2862,12 +2849,13 @@ func (s *Server) getProxyHostHealth(w http.ResponseWriter, r *http.Request) {
 		uptime = float64(okCount) / float64(total) * 100
 	}
 	s.render(w, r, "proxy_host_health.html", map[string]any{
-		"User":    s.currentUser(r),
-		"Host":    host,
-		"Checks":  checks,
-		"Uptime":  uptime,
-		"Total":   total,
-		"Section": "proxy",
+		"User":         s.currentUser(r),
+		"Host":         host,
+		"Checks":       checks,
+		"Uptime":       uptime,
+		"CadenceLabel": publicHealthCadenceLabel(*host),
+		"Total":        total,
+		"Section":      "proxy",
 	})
 }
 
@@ -11870,8 +11858,26 @@ var upstreamNotifyState struct {
 }
 
 // runHealthChecker polls each enabled proxy host every 5 minutes and records
-// the result in proxy_health. It checks the first domain of each host via HTTPS
-// (falling back to HTTP if ssl_enabled is false). Runs until the process exits.
+// the result in proxy_health — the persisted "Public" health history behind
+// /proxy-hosts/{id}/health and the left-most dot on the proxy hosts list. It
+// checks the first domain of each host via HTTPS (falling back to HTTP if
+// ssl_enabled is false). Runs until the process exits.
+//
+// v2.35.0 (issue #39 follow-up): this is a *third* probe CaddyUI runs on a
+// host's behalf, alongside the App and Port dots that v2.28.0 made
+// configurable. It was never wired to MonitorMode, so a host set to "Off" —
+// explicitly promised to stop "all outbound probes for this host" — kept
+// getting hit here every 5 minutes regardless, and a host in "Custom" mode
+// with a non-default path or expected status still showed this dot red
+// because the check always requested "/" and only accepted <400/401/403.
+// That's the exact failure mode the issue described. Now it honors the same
+// MonitorSettings as the other two probes.
+//
+// NodeLocal is deliberately NOT consulted here. It says the *upstream*
+// (forward_host/port) only resolves on this node — it says nothing about
+// whether the host's public domain should be checked from the internet-facing
+// side, which is what this probe does. Only an explicit MonitorMode of "off"
+// suppresses it.
 func (s *Server) runHealthChecker() {
 	// Stagger the first check by 30 seconds so startup load doesn't spike.
 	time.Sleep(30 * time.Second)
@@ -11882,6 +11888,18 @@ func (s *Server) runHealthChecker() {
 		s.checkAllProxyHosts()
 	}
 }
+
+// publicHealthCheckerInterval is this poller's native cadence, and therefore
+// the "Automatic" default fed to MonitorSettings — distinct from the App
+// dot's 60s default, since this checker has always run every 5 minutes.
+//
+// publicHealthCheckerTimeout matches the client this poller has always used
+// (short timeout, no redirect following) — the historical "Automatic"
+// default for MonitorSettings, same as the interval above.
+const (
+	publicHealthCheckerInterval = 5 * time.Minute
+	publicHealthCheckerTimeout  = 10 * time.Second
+)
 
 func (s *Server) checkAllProxyHosts() {
 	servers, err := models.ListCaddyServers(s.DB)
@@ -11899,6 +11917,11 @@ func (s *Server) checkAllProxyHosts() {
 			if !h.Enabled {
 				continue
 			}
+			// v2.35.0: "Off" means no outbound probe of any kind — see the
+			// package comment on runHealthChecker.
+			if h.MonitoringDisabled() {
+				continue
+			}
 			domains := h.DomainList()
 			if len(domains) == 0 {
 				continue
@@ -11908,15 +11931,68 @@ func (s *Server) checkAllProxyHosts() {
 			if !h.SSLEnabled {
 				scheme = "http"
 			}
-			targetURL := scheme + "://" + domain + "/"
-			s.checkProxyHost(h.ID, targetURL)
+			path, method, expectStatus, interval, timeout := h.MonitorSettings(publicHealthCheckerInterval, publicHealthCheckerTimeout)
+			if !s.publicHealthDue(h.ID, interval) {
+				continue
+			}
+			targetURL := scheme + "://" + domain + path
+			s.checkProxyHost(h.ID, targetURL, method, expectStatus, timeout)
 		}
 	}
 }
 
-func (s *Server) checkProxyHost(hostID int64, targetURL string) {
+// publicHealthCadenceLabel describes the effective cadence of the Public
+// health checker for the /proxy-hosts/{id}/health page, since it's no longer
+// unconditionally "every 5 min" once Custom mode can set a longer interval.
+func publicHealthCadenceLabel(h models.ProxyHost) string {
+	if !strings.EqualFold(strings.TrimSpace(h.MonitorMode), "custom") || h.MonitorIntervalSec <= 0 {
+		return "every 5 min"
+	}
+	interval := time.Duration(h.MonitorIntervalSec) * time.Second
+	if interval <= publicHealthCheckerInterval {
+		return "every 5 min" // custom value floors to the native tick anyway
+	}
+	minutes := int(interval / time.Minute)
+	return fmt.Sprintf("roughly every %d min (custom)", minutes)
+}
+
+// publicHealthDue reports whether hostID's persisted public health check is
+// due for a new probe, honoring a custom interval longer than the poller's
+// native 5-minute tick (a shorter one can't be honoured — the ticker itself
+// only fires every 5 minutes). Paced off the most recently persisted check
+// rather than separate in-memory state, so — unlike the App dot's pacing —
+// this survives a process restart instead of probing immediately on boot
+// regardless of how recently it last ran.
+func (s *Server) publicHealthDue(hostID int64, interval time.Duration) bool {
+	if interval <= publicHealthCheckerInterval {
+		return true
+	}
+	history, err := models.GetProxyHealthHistory(s.DB, hostID, 1)
+	if err != nil || len(history) == 0 {
+		return true
+	}
+	// Subtract half a tick so a host configured at exactly 2x the interval
+	// isn't pushed out to 3x by scheduling jitter, matching appProbeDue.
+	return time.Since(history[0].CheckedAt) >= interval-(publicHealthCheckerInterval/2)
+}
+
+func (s *Server) checkProxyHost(hostID int64, targetURL, method string, expectStatus int, timeout time.Duration) {
+	client := &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse // don't follow redirects
+		},
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // check reachability, not cert validity
+		},
+	}
+	req, err := http.NewRequest(method, targetURL, nil)
+	if err != nil {
+		_ = models.InsertProxyHealth(s.DB, hostID, false, 0, 0, err.Error())
+		return
+	}
 	start := time.Now()
-	resp, err := s.healthClient.Get(targetURL)
+	resp, err := client.Do(req)
 	latencyMs := time.Since(start).Milliseconds()
 	if err != nil {
 		errMsg := err.Error()
@@ -11929,7 +12005,16 @@ func (s *Server) checkProxyHost(hostID int64, targetURL string) {
 	defer resp.Body.Close()
 	// Drain body to free connection.
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
-	ok := resp.StatusCode < 400 || resp.StatusCode == 401 || resp.StatusCode == 403
+	// v2.35.0: an explicit expected status replaces the heuristic entirely —
+	// same rule as the App dot probe, and for the same reason: a host whose
+	// health path deliberately answers something other than 2xx/401/403 is
+	// "up" only if the operator said so.
+	var ok bool
+	if expectStatus > 0 {
+		ok = resp.StatusCode == expectStatus
+	} else {
+		ok = resp.StatusCode < 400 || resp.StatusCode == 401 || resp.StatusCode == 403
+	}
 	_ = models.InsertProxyHealth(s.DB, hostID, ok, resp.StatusCode, latencyMs, "")
 }
 

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -473,3 +473,48 @@ func TestBulkBarDoesNotOverlapListContent(t *testing.T) {
 		}
 	}
 }
+
+// TestPublicHealthDotHonorsMonitoringOff guards the fix for issue #39's
+// follow-up: a third CaddyUI-run probe (the persisted "Public" health check
+// behind /proxy-hosts/{id}/health) was never wired to MonitorMode, so a host
+// set to "Off" kept showing a stale or misleading status there indefinitely.
+// Both the list page and the detail page must check MonitorMode before
+// trusting any persisted HealthMap/Checks data — see the matching Go-side
+// tests in internal/server/public_health_monitor_test.go for the poller
+// itself.
+func TestPublicHealthDotHonorsMonitoringOff(t *testing.T) {
+	listHTML, err := FS.ReadFile("templates/proxy_hosts.html")
+	if err != nil {
+		t.Fatalf("read proxy_hosts.html: %v", err)
+	}
+	list := string(listHTML)
+	if n := strings.Count(list, `{{if eq .MonitorMode "off"}}`); n != 2 {
+		t.Errorf("proxy_hosts.html has %d MonitorMode-off guards on the Public dot, want 2 (card view + table view)", n)
+	}
+
+	detailHTML, err := FS.ReadFile("templates/proxy_host_health.html")
+	if err != nil {
+		t.Fatalf("read proxy_host_health.html: %v", err)
+	}
+	detail := string(detailHTML)
+	for _, marker := range []string{
+		`{{if eq .Host.MonitorMode "off"}}`,
+		"Monitoring off",
+		"CadenceLabel",
+	} {
+		if !strings.Contains(detail, marker) {
+			t.Errorf("proxy_host_health.html missing marker %q", marker)
+		}
+	}
+
+	formHTML, err := FS.ReadFile("templates/proxy_host_form.html")
+	if err != nil {
+		t.Fatalf("read proxy_host_form.html: %v", err)
+	}
+	// The monitoring section's copy must name all three probes it drives, not
+	// just the App and Port dots — that omission is what left the reporter
+	// unable to find where the Public check was managed.
+	if !strings.Contains(string(formHTML), "Public") {
+		t.Error("proxy_host_form.html's monitoring section no longer mentions the Public dot/check")
+	}
+}

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -1326,8 +1326,8 @@ document.addEventListener('DOMContentLoaded', function() {
            to say who is doing the probing — the two were easy to confuse, and
            the settings below this point do not affect these dots at all. */}}
       <div class="border-t border-gray-100 dark:border-gray-800 pt-3 mt-3 space-y-3">
-        <p class="text-xs font-medium text-ink-700">CaddyUI status monitoring <span class="font-normal text-ink-400">(drives the App and Port dots — not Caddy's own health checking)</span></p>
-        <p class="text-xs text-ink-500">CaddyUI probes this host from its own container to show status in the dashboard: an HTTPS request to the public domain, and a direct check of the upstream. Turn it off for hosts that are deliberately unreachable from here — split-horizon DNS, firewalled backends — where the probe would report a misleading “down” and add noise to your firewall logs.</p>
+        <p class="text-xs font-medium text-ink-700">CaddyUI status monitoring <span class="font-normal text-ink-400">(drives the App, Port, and Public dots — not Caddy's own health checking)</span></p>
+        <p class="text-xs text-ink-500">CaddyUI runs three probes of its own from this section: an HTTPS request to the public domain every 60&nbsp;seconds (the <strong>App</strong> dot), a direct check of the upstream (the <strong>Port</strong> dot), and a separate public check every 5&nbsp;minutes whose history is kept for 24&nbsp;hours at <a href="/proxy-hosts/{{.Host.ID}}/health" class="text-brand-600 hover:underline">/proxy-hosts/{{.Host.ID}}/health</a> (the <strong>Public</strong> dot, left-most on the list). All three read the settings below. Turn monitoring off for hosts that are deliberately unreachable from here — split-horizon DNS, firewalled backends — where a probe would report a misleading “down” and add noise to your firewall logs.</p>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 items-start">
           <div>
             <label class="block text-sm font-medium text-ink-800 mb-1.5">Monitoring</label>
@@ -1338,7 +1338,7 @@ document.addEventListener('DOMContentLoaded', function() {
               <option value="off" {{if eq .Host.MonitorMode "off"}}selected{{end}}>Off — never probe this host</option>
             </select>
           </div>
-          <p class="text-xs text-ink-500 sm:pt-7">Automatic probes <code>GET /</code> every 60&nbsp;seconds with a 5&nbsp;second timeout. Off stops all outbound probes for this host and shows a neutral dot.</p>
+          <p class="text-xs text-ink-500 sm:pt-7">Automatic keeps each probe's own default cadence — the App/Port checks run every 60&nbsp;seconds, the Public check every 5&nbsp;minutes — with a 5&nbsp;second timeout. Off stops all three and shows a neutral dot everywhere.</p>
         </div>
 
         <div id="monitor-custom" class="space-y-3 {{if ne .Host.MonitorMode "custom"}}hidden{{end}}">
@@ -1371,7 +1371,7 @@ document.addEventListener('DOMContentLoaded', function() {
               <input type="number" name="monitor_interval_sec" value="{{if .Host.MonitorIntervalSec}}{{.Host.MonitorIntervalSec}}{{end}}"
                 min="60" max="86400" placeholder="60"
                 class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
-              <p class="text-xs text-ink-500 mt-1">Minimum 60, rounded up to a multiple of 60.</p>
+              <p class="text-xs text-ink-500 mt-1">Floored at each probe's own tick: 60 for the App/Port checks, 300 for the Public check — a smaller value just means that probe runs every tick instead.</p>
             </div>
             <div>
               <label class="block text-sm font-medium text-ink-800 mb-1.5">Timeout (seconds)</label>

--- a/web/templates/proxy_host_health.html
+++ b/web/templates/proxy_host_health.html
@@ -12,8 +12,16 @@
     <h1 class="text-2xl font-semibold tracking-tight text-ink-900 font-mono">{{index (.Host.DomainList) 0}}</h1>
     <p class="text-sm text-ink-500 mt-1">Public health check history — last 50 checks, up to 24 h of data.</p>
   </div>
-  {{/* Current status badge — use most recent check if available */}}
-  {{if .Checks}}
+  {{/* Current status badge — use most recent check if available.
+       v2.35.0 (issue #39 follow-up): MonitorMode "off" takes priority over
+       .Checks so an old status from before monitoring was disabled doesn't
+       keep reading as the current one. */}}
+  {{if eq .Host.MonitorMode "off"}}
+    <span class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium bg-ink-100 border border-ink-200 text-ink-600 shrink-0">
+      <span class="w-2 h-2 rounded-full bg-ink-400"></span>
+      Monitoring off
+    </span>
+  {{else if .Checks}}
     {{$latest := index .Checks 0}}
     {{if $latest.OK}}
       <span class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium bg-green-50 border border-green-200 text-green-800 shrink-0">
@@ -34,6 +42,19 @@
   {{end}}
 </div>
 
+{{/* v2.35.0 (issue #39 follow-up): this page used to keep checking a host
+     every 5 minutes and show its last real status even after "Off" was set
+     on the Monitoring section — the exact behaviour that setting promised to
+     stop. Say so plainly rather than leaving the badge above to speak for
+     itself, since the uptime/history below is now frozen history, not a
+     live signal. */}}
+{{if eq .Host.MonitorMode "off"}}
+<div class="mb-6 rounded-lg border border-ink-200 bg-ink-50 px-4 py-3 text-sm text-ink-700 flex items-start gap-2">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mt-0.5 shrink-0 text-ink-400"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+  <span>Monitoring is off for this host — no new checks are being recorded. The history below is frozen from before it was turned off. <a href="/proxy-hosts/{{.Host.ID}}/edit" class="text-brand-600 hover:underline">Change this in the host's settings.</a></span>
+</div>
+{{end}}
+
 {{/* Uptime summary card */}}
 <div class="bg-white border border-ink-200 rounded-xl shadow-card px-5 py-4 mb-6 flex items-center gap-6 flex-wrap">
   <div>
@@ -49,7 +70,11 @@
   </div>
   <div class="text-ink-300 text-lg">|</div>
   <div>
-    <div class="text-sm text-ink-600">Checked every 5 min &middot; up to 288 results stored</div>
+    {{/* v2.35.0: "every 5 min" was unconditional even though Custom mode can
+         set a longer interval (floored to a multiple of this checker's own
+         5-minute tick — see the Monitoring section on the edit form).
+         CadenceLabel is computed server-side in getProxyHostHealth. */}}
+    <div class="text-sm text-ink-600">Checked {{.CadenceLabel}} &middot; up to 288 results stored</div>
     <div class="text-xs text-ink-400 mt-0.5">401 and 403 count as up (upstream is responding)</div>
   </div>
 </div>

--- a/web/templates/proxy_hosts.html
+++ b/web/templates/proxy_hosts.html
@@ -79,14 +79,22 @@
   <div class="bg-white border border-ink-200 rounded-xl shadow-card card-lift p-4{{if $canEdit}} cursor-pointer hover:border-brand-300 transition{{end}}" data-search="{{.Domains}} {{.ForwardHost}}" data-host-id="{{.ID}}" data-tags="{{.Tags}}" data-notes="{{.Notes}}"{{if $canEdit}} data-edit-href="/proxy-hosts/{{.ID}}/edit"{{end}}>
     <div class="flex items-start justify-between gap-2 mb-2">
       <div class="flex flex-wrap items-center gap-1 min-w-0">
-        {{with index $.HealthMap $hostID}}
-          {{if .OK}}
-            <a href="/proxy-hosts/{{$hostID}}/health" class="inline-block w-2 h-2 rounded-full bg-green-500 shrink-0" title="Public: up — {{.StatusCode}} in {{.LatencyMs}}ms ({{fmtRel .CheckedAt}})"></a>
-          {{else}}
-            <a href="/proxy-hosts/{{$hostID}}/health" class="inline-block w-2 h-2 rounded-full bg-red-500 shrink-0" title="Public: down — {{.ErrorMsg}} ({{fmtRel .CheckedAt}})"></a>
-          {{end}}
+        {{/* v2.35.0 (issue #39 follow-up): check MonitorMode before HealthMap
+             — see the matching comment on the table-view Public dot below.
+             Without this, an "off" host with older history kept showing
+             stale green/red status forever. */}}
+        {{if eq .MonitorMode "off"}}
+          <span class="inline-block w-2 h-2 rounded-full bg-ink-300 shrink-0" title="Public: monitoring off for this host"></span>
         {{else}}
-          <span class="inline-block w-2 h-2 rounded-full bg-ink-300 shrink-0" title="Public health: no check yet"></span>
+          {{with index $.HealthMap $hostID}}
+            {{if .OK}}
+              <a href="/proxy-hosts/{{$hostID}}/health" class="inline-block w-2 h-2 rounded-full bg-green-500 shrink-0" title="Public: up — {{.StatusCode}} in {{.LatencyMs}}ms ({{fmtRel .CheckedAt}})"></a>
+            {{else}}
+              <a href="/proxy-hosts/{{$hostID}}/health" class="inline-block w-2 h-2 rounded-full bg-red-500 shrink-0" title="Public: down — {{.ErrorMsg}} ({{fmtRel .CheckedAt}})"></a>
+            {{end}}
+          {{else}}
+            <span class="inline-block w-2 h-2 rounded-full bg-ink-300 shrink-0" title="Public health: no check yet"></span>
+          {{end}}
         {{end}}
         {{if index $.NeedsSync .ID}}
         <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" title="Modified since last sync — click Sync Caddy to apply"></span>
@@ -331,14 +339,22 @@
         <td class="px-5 py-3">
           <div class="flex flex-wrap items-center gap-1">
             {{$hostID := .ID}}
-            {{with index $.HealthMap $hostID}}
-              {{if .OK}}
-                <a href="/proxy-hosts/{{$hostID}}/health" class="inline-block w-2 h-2 rounded-full bg-green-500 shrink-0" title="Public: up — {{.StatusCode}} in {{.LatencyMs}}ms ({{fmtRel .CheckedAt}})"></a>
-              {{else}}
-                <a href="/proxy-hosts/{{$hostID}}/health" class="inline-block w-2 h-2 rounded-full bg-red-500 shrink-0" title="Public: down — {{.ErrorMsg}} ({{fmtRel .CheckedAt}})"></a>
-              {{end}}
+            {{/* v2.35.0 (issue #39 follow-up): check MonitorMode before
+                 HealthMap — see the matching comment in the card view above.
+                 Without this, an "off" host with older history kept showing
+                 stale green/red status forever. */}}
+            {{if eq .MonitorMode "off"}}
+              <span class="inline-block w-2 h-2 rounded-full bg-ink-300 shrink-0" title="Public: monitoring off for this host"></span>
             {{else}}
-              <span class="inline-block w-2 h-2 rounded-full bg-ink-300 shrink-0" title="Public health: no check yet"></span>
+              {{with index $.HealthMap $hostID}}
+                {{if .OK}}
+                  <a href="/proxy-hosts/{{$hostID}}/health" class="inline-block w-2 h-2 rounded-full bg-green-500 shrink-0" title="Public: up — {{.StatusCode}} in {{.LatencyMs}}ms ({{fmtRel .CheckedAt}})"></a>
+                {{else}}
+                  <a href="/proxy-hosts/{{$hostID}}/health" class="inline-block w-2 h-2 rounded-full bg-red-500 shrink-0" title="Public: down — {{.ErrorMsg}} ({{fmtRel .CheckedAt}})"></a>
+                {{end}}
+              {{else}}
+                <span class="inline-block w-2 h-2 rounded-full bg-ink-300 shrink-0" title="Public health: no check yet"></span>
+              {{end}}
             {{end}}
             {{if index $.NeedsSync .ID}}
             <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" title="Modified since last sync — click Sync Caddy to apply"></span>


### PR DESCRIPTION
Closes the real gap behind [issue #39](https://github.com/X4Applegate/caddyui/issues/39)'s follow-up comment.

## What was reported

> maybe I'm just confused but I can't seem to find where the external health checks are taking place? So this would be the info that drives the far left dot and is published when viewing the health of a proxy host: /proxy-hosts/18/health. Where is this managed?

It genuinely wasn't managed anywhere. That's the bug.

## Root cause

v2.28.0 made two of CaddyUI's own probes configurable — the App and Port dots — and its comment promised Off would stop "all outbound probes for this host." There is a **third** probe: a persisted "Public" health check (`runHealthChecker` → `checkAllProxyHosts` → `checkProxyHost`), running every 5 minutes, keeping 24h of history at `/proxy-hosts/{id}/health`, surfaced as the left-most dot on the list. It was never wired to `MonitorMode` at all — it probed every enabled host on its own fixed schedule no matter what the Monitoring section said.

The same gap meant **Custom** mode's path/method/expected-status only ever reached the App and Port dots. A host with a non-default health path, or one that legitimately answers something other than 2xx/3xx/401/403, could still show the Public dot red — which is the *exact* complaint the original issue described, just coming from a checker the v2.28.0 fix never touched.

## Fix

- `checkAllProxyHosts` skips a host entirely when `MonitoringDisabled()` — no request, no DB row, matching what "Off" already promised.
- `checkProxyHost` resolves path/method/expectStatus/timeout through the same `MonitorSettings()` call the App dot uses.
- A custom interval longer than this checker's native 5-minute tick is paced against the host's own **persisted history** (`publicHealthDue`) rather than new in-memory state — unlike the App dot, this survives a restart instead of probing immediately on boot regardless of how recently it last ran.
- `NodeLocal` is deliberately **not** consulted here — it says the *upstream* only resolves on this node, not whether the *public domain* should be probed from the internet-facing side, which is what this checker does.

## Stale-state fix

Both list-page renderings of the Public dot (grid card and table row) and the detail page now check `MonitorMode` before trusting persisted history — a host switched to Off used to keep showing whatever "up"/"down" it last recorded, indefinitely.

**One of the two list renderings was missed on my first editing pass.** A template-guard test in `embed_test.go` asserting both exist caught it before I noticed by eye — worth calling out since it's exactly the kind of silent gap this whole PR is about.

## Copy fix

The monitoring section on the proxy host form named only the App and Port dots. It now names all three and links to the Public check's history page — directly answering "where is this managed."

## Verification

`go build`, `go vet`, `go test ./...` pass, with 11 new test cases covering: Off suppresses the probe entirely (no request made, no DB row), Custom mode's path/method/expectStatus are honored, the pre-existing default-heuristic behavior is preserved when no expectStatus is set, unmarked hosts still probe exactly as before (opt-in, no behavior change), and interval pacing.

One test caught a real bug in my own test setup: a channel-read hang when `checkAllProxyHosts` had no registered `CaddyServer` row to iterate, so the httptest handler backing the assertion never fired and the test blocked forever. Fixed the test helper; noted in a comment so it isn't repeated.

Beyond unit tests, verified against the real running app end to end:

```
BEFORE off:  title="Public: up — 200 in 42ms (1h ago)"      (stale data from before)
AFTER off:   title="Public: monitoring off for this host"    (both list renderings)
detail page: "Monitoring off" badge + explanatory banner
custom 30m:  "Checked roughly every 30 min (custom) · up to 288 results stored"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)