### PR TITLE
fix: add an always-present button to the Public health history page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.35.1] - 2026-08-21 - An always-present button to the Public health page
+
+### Fixed
+
+- The "Public" health dot on the proxy hosts list was the only way to reach `/proxy-hosts/{id}/health`, and it stops being a clickable link precisely when there's the least data to look at — monitoring off, or no check recorded yet. That was a dead end right where it mattered most. A small, always-present history icon now sits next to the dot regardless of its state, visible to any viewer (it's read-only status, not an edit action).
+
 ## [2.35.0] - 2026-08-21 - Monitoring "Off" now covers all three probes
 
 ### Fixed

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -491,6 +491,13 @@ func TestPublicHealthDotHonorsMonitoringOff(t *testing.T) {
 	if n := strings.Count(list, `{{if eq .MonitorMode "off"}}`); n != 2 {
 		t.Errorf("proxy_hosts.html has %d MonitorMode-off guards on the Public dot, want 2 (card view + table view)", n)
 	}
+	// v2.35.1: a standalone "view health" button next to the dot, since the
+	// dot itself stops being clickable once monitoring is off or there's no
+	// data yet — the exact dead end a user hit when asking where the button
+	// to reach this page was.
+	if n := strings.Count(list, `title="View public health history"`); n != 2 {
+		t.Errorf("proxy_hosts.html has %d always-present health-history buttons, want 2 (card view + table view) — the dot alone is not enough once it stops being a link", n)
+	}
 
 	detailHTML, err := FS.ReadFile("templates/proxy_host_health.html")
 	if err != nil {

--- a/web/templates/proxy_hosts.html
+++ b/web/templates/proxy_hosts.html
@@ -96,6 +96,16 @@
             <span class="inline-block w-2 h-2 rounded-full bg-ink-300 shrink-0" title="Public health: no check yet"></span>
           {{end}}
         {{end}}
+        {{/* v2.35.1 (issue #39 follow-up, round 2): the dot itself used to be
+             the only way to reach the health history, and it stopped being
+             clickable once monitoring is off or there's no data yet — a dead
+             end right where the user most needs the page. This is a
+             standalone, always-present button, visible to any viewer (health
+             status is read-only, not an edit action) regardless of dot state
+             or MonitorMode. */}}
+        <a href="/proxy-hosts/{{$hostID}}/health" class="inline-flex items-center justify-center w-4 h-4 text-ink-300 hover:text-ink-600 transition shrink-0" title="View public health history">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3 h-3"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        </a>
         {{if index $.NeedsSync .ID}}
         <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" title="Modified since last sync — click Sync Caddy to apply"></span>
         {{end}}
@@ -356,6 +366,13 @@
                 <span class="inline-block w-2 h-2 rounded-full bg-ink-300 shrink-0" title="Public health: no check yet"></span>
               {{end}}
             {{end}}
+            {{/* v2.35.1 (issue #39 follow-up, round 2) — see the matching
+                 comment in the card view above. Always-present, unlike the
+                 dot, which stopped being clickable once monitoring is off or
+                 there's no data yet. */}}
+            <a href="/proxy-hosts/{{$hostID}}/health" class="inline-flex items-center justify-center w-4 h-4 text-ink-300 hover:text-ink-600 transition shrink-0" title="View public health history">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3 h-3"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+            </a>
             {{if index $.NeedsSync .ID}}
             <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" title="Modified since last sync — click Sync Caddy to apply"></span>
             {{end}}


### PR DESCRIPTION
Follow-up to #52 / issue #39, prompted by a direct question after that fix shipped: "where button to view health?"

## The dead end I introduced

v2.35.0 correctly stopped the Public dot from being a clickable link when monitoring is off or there's no check recorded yet — showing a live "up"/"down" link over a status that isn't real would be worse than showing nothing. But the dot was the *only* entry point to `/proxy-hosts/{id}/health`, so that fix turned it into a dead end exactly when someone would most want the page: right after switching a host to Off, or before its first check has landed.

## Fix

A small, always-present clock icon next to the dot, in both list renderings (grid card and table row), linking to the health page regardless of dot state. Not gated on edit permission — health status is read-only information any viewer should reach, same as the dot itself always was.

## Verified in a browser

Screenshot attached in chat: a host with monitoring off shows a dead grey dot, and the clock icon next to it is the live link to `/proxy-hosts/{id}/health` — confirmed both by DOM inspection (`href="/proxy-hosts/1/health"`) and a real page load (200).

## Test

The `embed_test.go` guard added in #52 for the MonitorMode dot logic now also asserts this button exists in both list renderings — the same guard shape that caught a missed occurrence in that PR now covers this addition too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)