### PR TITLE
fix: correct SSL Verify Upstream docs label and surface its HTTPS-only condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.35.2] - 2026-08-31 - SSL Verify Upstream docs fixed, HTTPS-only condition surfaced
+
+### Fixed
+
+- The Caddyfile → form-field mapping table in the docs referred to the "Verify Upstream TLS Certificate" checkbox by its internal field name, "SSL Verify Upstream", instead of its actual UI label — making the field hard to find (#54).
+- The checkbox only affects the generated config when Forward Scheme is `https`; toggling it under the default `http` scheme was silently a no-op, and that precondition lived only in a small form hint, not the docs table. The docs table now states it, and the form itself shows an inline warning when the toggle is currently inert for the selected scheme.
+
 ## [2.35.1] - 2026-08-21 - An always-present button to the Public health page
 
 ### Fixed

--- a/web/templates/docs.html
+++ b/web/templates/docs.html
@@ -157,7 +157,7 @@
       <tbody class="font-mono">
         <tr class="border-t border-ink-200"><td class="px-3 py-1.5">reverse_proxy https://...</td><td class="px-3 py-1.5">Forward Scheme = https</td><td class="px-3 py-1.5 font-sans text-ink-500">use when upstream serves TLS itself</td></tr>
         <tr class="border-t border-ink-200"><td class="px-3 py-1.5">tls_server_name name</td><td class="px-3 py-1.5">Upstream SNI</td><td class="px-3 py-1.5 font-sans text-ink-500">override SNI for self-signed / shared-cert backends</td></tr>
-        <tr class="border-t border-ink-200"><td class="px-3 py-1.5">tls_insecure_skip_verify</td><td class="px-3 py-1.5">SSL Verify Upstream = off</td><td class="px-3 py-1.5 font-sans text-ink-500">skip cert verification for internal CA / self-signed</td></tr>
+        <tr class="border-t border-ink-200"><td class="px-3 py-1.5">tls_insecure_skip_verify</td><td class="px-3 py-1.5">Verify Upstream TLS Certificate = off</td><td class="px-3 py-1.5 font-sans text-ink-500">in Options &amp; Forwarded Headers; only applies when Forward Scheme = https</td></tr>
         <tr class="border-t border-ink-200"><td class="px-3 py-1.5">header_up Host {host}</td><td class="px-3 py-1.5">(default — no field)</td><td class="px-3 py-1.5 font-sans text-ink-500">Caddy passes the original Host by default</td></tr>
         <tr class="border-t border-ink-200"><td class="px-3 py-1.5">header_up X-Real-IP {remote_host}</td><td class="px-3 py-1.5">Add X-Real-IP Header (checkbox)</td><td class="px-3 py-1.5 font-sans text-ink-500"></td></tr>
         <tr class="border-t border-ink-200"><td class="px-3 py-1.5">header_up X-Forwarded-Host {host}</td><td class="px-3 py-1.5">Add X-Forwarded-Host (checkbox)</td><td class="px-3 py-1.5 font-sans text-ink-500"></td></tr>

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -2440,10 +2440,27 @@ document.addEventListener('DOMContentLoaded', function() {
     <summary class="cursor-pointer select-none text-xs uppercase tracking-wider text-ink-500 hover:text-ink-700 font-medium transition">Options &amp; Forwarded Headers</summary>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
       {{/* v2.11.4: Enabled / Auto SSL / Force SSL hoisted to the always-visible top of the form. */}}
-      <label class="flex items-start gap-2.5 text-sm text-ink-700 cursor-pointer sm:col-span-2">
+      <label id="ssl-verify-upstream-row" class="flex items-start gap-2.5 text-sm text-ink-700 cursor-pointer sm:col-span-2">
         <input type="checkbox" name="ssl_verify_upstream" {{if .Host.SSLVerifyUpstream}}checked{{end}} class="mt-0.5 rounded border-ink-300 text-brand-600 focus:ring-brand-500" />
-        <span>Verify Upstream TLS Certificate<span class="block text-xs text-ink-500 mt-0.5 font-normal">When enabled, validates the upstream TLS certificate against the system trust store (only applies when Forward Scheme is HTTPS)</span></span>
+        <span>Verify Upstream TLS Certificate<span class="block text-xs mt-0.5 font-normal text-ink-500">When enabled, validates the upstream TLS certificate against the system trust store.</span><span id="ssl-verify-upstream-hint" class="block text-xs mt-0.5 font-normal"></span></span>
       </label>
+      <script>
+      (function() {
+        var schemeEl = document.querySelector('[name="forward_scheme"]');
+        var hint = document.getElementById('ssl-verify-upstream-hint');
+        if (!schemeEl || !hint) return;
+        function update() {
+          if (schemeEl.value === 'https') {
+            hint.textContent = '';
+          } else {
+            hint.textContent = 'Inactive: Forward Scheme is currently "' + schemeEl.value + '" — this only applies when Forward Scheme is https.';
+            hint.className = 'block text-xs mt-0.5 font-normal text-amber-600';
+          }
+        }
+        schemeEl.addEventListener('change', update);
+        update();
+      })();
+      </script>
       <!-- v2.9.59: upstream_tls_ca_pem_file -->
 <div class="mb-4">
   <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Upstream TLS CA Bundle File</label>


### PR DESCRIPTION
## Summary
- Fixes #54 — the Caddyfile→form-field docs table referred to the field by its internal name "SSL Verify Upstream" instead of its actual UI label "Verify Upstream TLS Certificate", making it hard to find.
- The field only affects the generated config when Forward Scheme is `https` (it's a no-op under the default `http` scheme). That precondition was only in a small form hint, not in the docs table — now both call it out, and the form shows an inline amber warning when the toggle is currently inert for the selected scheme.

## Test plan
- [x] `go build ./...` passes (validates embedded Go templates)
- [x] Ran the server locally against a scratch SQLite DB, created a proxy host form, and confirmed the rendered HTML/JS matches expectations — the hint text updates live as Forward Scheme changes, following the same `querySelector('[name="forward_scheme"]')` pattern already used elsewhere in the file
- [x] Verified only one `forward_scheme` element exists on the page, so no selector ambiguity

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>