### PR TITLE
fix: render each Advanced route once between the md and lg breakpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.35.4] - 2026-09-04 - One rendering per Advanced route
+
+### Fixed
+
+- `/raw-routes` drew every Advanced route twice at tablet-to-laptop widths (768–1024 CSS px — which is also where a zoomed desktop browser lands): the desktop table became visible at the `md` breakpoint, but the mobile card list only hid from `lg`. Both now switch at `lg`, matching `/certificates` and `/snapshots`. The second copy was the same database row rendered again, not a duplicate route — which is why deleting "one" of them removed "both".
+- A template guard test now asserts the table and card-list breakpoints on `/raw-routes` stay paired, so the mismatch can't silently come back.
+
 ## [2.35.3] - 2026-09-02 - Go 1.27 build toolchain
 
 ### Changed

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -270,6 +270,31 @@ func TestAdvancedRouteFormOffersCrossDeploy(t *testing.T) {
 	}
 }
 
+// TestRawRoutesTableAndCardListShareABreakpoint guards v2.35.4. /raw-routes
+// renders every route twice on purpose — once as a desktop table row and once
+// as a mobile card — and relies on the two containers flipping visibility at
+// the SAME Tailwind breakpoint so only one is ever on screen. Before v2.35.4
+// the table was `hidden md:table` while the card list was `lg:hidden`, so at
+// 768–1024 CSS px (tablets, or a zoomed desktop browser) both rendered and each
+// route appeared twice. The two copies are the same database row, so deleting
+// "one" removed "both". Keep the pair on `lg`, matching /certificates and
+// /snapshots.
+func TestRawRoutesTableAndCardListShareABreakpoint(t *testing.T) {
+	body, err := FS.ReadFile("templates/raw_routes.html")
+	if err != nil {
+		t.Fatalf("read raw_routes.html: %v", err)
+	}
+	html := string(body)
+	// Both assertions are needed: if either container is moved to a different
+	// breakpoint on its own, exactly one of them fails and names the culprit.
+	if !strings.Contains(html, `class="hidden lg:table`) {
+		t.Errorf("raw_routes.html: desktop table must be `hidden lg:table` so it only shows from the lg breakpoint (the card list hides at lg)")
+	}
+	if !strings.Contains(html, `class="lg:hidden`) {
+		t.Errorf("raw_routes.html: mobile card list must be `lg:hidden` so it hides from the lg breakpoint (the table shows at lg)")
+	}
+}
+
 // TestMonitoringControlsAndOffStateAreWired covers issue #39. Two halves have
 // to stay in sync: the form must offer the mode selector, and every status-dot
 // painter must special-case "off". If a painter loses its "off" branch the

--- a/web/templates/raw_routes.html
+++ b/web/templates/raw_routes.html
@@ -73,7 +73,11 @@
 </div>
 
 <div class="bg-ink-50 border border-ink-200 rounded-xl shadow-card overflow-hidden overflow-x-auto">
-  <table class="hidden md:table w-full text-sm">
+  {{/* v2.35.4: switch at lg, matching the card list below (lg:hidden) and
+       the /certificates + /snapshots pages. This used to be md:table, so at
+       768–1024 CSS px (tablet, or a zoomed desktop browser) the table AND
+       the card list both rendered, showing every route twice. */}}
+  <table class="hidden lg:table w-full text-sm">
     <thead class="bg-ink-100 text-left border-b border-ink-200">
       <tr class="text-xs uppercase tracking-wider text-ink-500">
         {{/* v2.11.9: select-all for bulk operations. */}}


### PR DESCRIPTION
## Summary
`/raw-routes` showed every Advanced route **twice** at tablet-to-laptop widths (768–1024 CSS px — also where a zoomed desktop browser lands). The page intentionally renders each route as both a desktop table row and a mobile card, and relies on the two containers flipping at the same breakpoint. They didn't: the table was `hidden md:table` while the card list was `lg:hidden`, so in that band both were visible. Both copies are the same DB row, which is why deleting "one" deleted "both".

- Move the table to `hidden lg:table` so the pair switches at `lg`, matching `/certificates` and `/snapshots`. (Below 1024px the five-column table with an inline config block is cramped anyway; the card is the right layout there.)
- Add `TestRawRoutesTableAndCardListShareABreakpoint` in `web/embed_test.go` — if either container drifts off `lg`, exactly one assertion fails and names it.
- CHANGELOG entry for v2.35.4.

## Test plan
- [x] `go test ./web/` — all 17 pass, including the new guard (it correctly failed against an over-broad first draft, then passed once scoped to the two containers).
- [x] Ran the app on a scratch SQLite DB with one seeded Advanced route and rendered `/raw-routes` in headless Chrome: **900px** shows only the card (one entry), **1200px** shows only the table row (one entry). Before the fix, 900px showed both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)