### PR TITLE
fix: show full dates on Server Logs and make Clear actually clear the buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.35.5] - 2026-09-04 - Server logs show the date, and Clear now clears
+
+### Fixed
+
+- The Server Logs page stamped every entry with the time only. CaddyUI's runtime-log buffer keeps the last 1000 entries for as long as the process runs, so on a quiet node it spans days and the times read out of order. Entries now show `YYYY-MM-DD HH:MM:SS` in CaddyUI's configured timezone — the same layout the Activity log already uses. (#60)
+- **Clear screen** only emptied the table; every entry came straight back on the next page load because the buffer behind it was untouched. The button is now **Clear logs**: it discards the buffered entries for the selected server as well (nothing on disk is involved — runtime logs are never persisted) and records the purge in the Activity log. New endpoint `POST /api/server-logs/clear`. (#60)
+
 ## [2.35.4] - 2026-09-04 - One rendering per Advanced route
 
 ### Fixed

--- a/internal/caddylogs/hub.go
+++ b/internal/caddylogs/hub.go
@@ -132,6 +132,39 @@ func (h *Hub) Since(cursor uint64, serverID int64, limit int) []Entry {
 	return out
 }
 
+// Clear (v2.35.5, issue #60) drops every buffered entry for serverID — or
+// every entry when serverID <= 0 — and reports how many were removed. The
+// ring holds up to maxEntries for as long as the process runs, so on a quiet
+// node it spans days; the Server Logs page's "Clear" used to empty only the
+// table, and everything came straight back on the next load. IDs keep
+// counting from where they were, so a page that reconnects with its last
+// cursor neither replays the purged entries nor misses the next new one.
+func (h *Hub) Clear(serverID int64) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if serverID <= 0 {
+		removed := len(h.entries)
+		h.entries = nil
+		return removed
+	}
+	kept := h.entries[:0]
+	removed := 0
+	for _, entry := range h.entries {
+		if entry.ServerID == serverID {
+			removed++
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	// Zero the vacated tail so purged entries (and their field maps) don't
+	// linger in the backing array.
+	for i := len(kept); i < len(h.entries); i++ {
+		h.entries[i] = Entry{}
+	}
+	h.entries = kept
+	return removed
+}
+
 func (h *Hub) SetCapture(state CaptureState) {
 	h.mu.Lock()
 	h.active[state.ServerID] = state

--- a/internal/caddylogs/hub_clear_test.go
+++ b/internal/caddylogs/hub_clear_test.go
@@ -1,0 +1,48 @@
+package caddylogs
+
+import "testing"
+
+// v2.35.5 (issue #60): Clear must drop only the selected server's entries,
+// keep IDs monotonic so a reconnecting page's cursor stays valid, and leave
+// the buffer usable afterwards. Lines use logger=admin so they stay clear of
+// the certificate-projection path, which is not what's under test.
+func TestHubClearDropsOnlyThatServer(t *testing.T) {
+	h := New(nil)
+	h.AcceptLine([]byte(`{"ts":1.0,"level":"info","logger":"admin","msg":"one","caddyui_server_id":1}`))
+	h.AcceptLine([]byte(`{"ts":2.0,"level":"info","logger":"admin","msg":"two","caddyui_server_id":2}`))
+	h.AcceptLine([]byte(`{"ts":3.0,"level":"info","logger":"admin","msg":"three","caddyui_server_id":1}`))
+	if got := len(h.Since(0, 0, 0)); got != 3 {
+		t.Fatalf("seeded %d entries, want 3", got)
+	}
+
+	if n := h.Clear(1); n != 2 {
+		t.Errorf("Clear(1) removed %d entries, want 2", n)
+	}
+	rest := h.Since(0, 0, 0)
+	if len(rest) != 1 || rest[0].ServerID != 2 || rest[0].Message != "two" {
+		t.Fatalf("after Clear(1) the buffer holds %+v, want only server 2's entry", rest)
+	}
+	if got := h.Since(0, 1, 0); len(got) != 0 {
+		t.Errorf("server 1 still has %d entries after Clear(1)", len(got))
+	}
+
+	// IDs keep counting up: a page that reconnects with its old cursor (3)
+	// must neither replay purged rows nor miss the next new one.
+	h.AcceptLine([]byte(`{"ts":4.0,"level":"info","logger":"admin","msg":"four","caddyui_server_id":1}`))
+	fresh := h.Since(3, 1, 0)
+	if len(fresh) != 1 || fresh[0].ID != 4 || fresh[0].Message != "four" {
+		t.Fatalf("after Clear(1) + one new line, Since(3, server 1) = %+v; want just the new entry with ID 4", fresh)
+	}
+
+	if n := h.Clear(0); n != 2 {
+		t.Errorf("Clear(0) removed %d entries, want 2 (everything left)", n)
+	}
+	if got := len(h.Since(0, 0, 0)); got != 0 {
+		t.Errorf("Clear(0) left %d entries behind", got)
+	}
+	// And the buffer still accepts lines afterwards.
+	h.AcceptLine([]byte(`{"ts":5.0,"level":"info","logger":"admin","msg":"five","caddyui_server_id":2}`))
+	if got := h.Since(0, 2, 0); len(got) != 1 || got[0].ID != 5 {
+		t.Errorf("buffer unusable after Clear(0): Since(0, server 2) = %+v", got)
+	}
+}

--- a/internal/server/caddy_logs.go
+++ b/internal/server/caddy_logs.go
@@ -363,6 +363,36 @@ func (s *Server) disableServerLogs(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"enabled": false})
 }
 
+// clearServerLogs (v2.35.5, issue #60) discards CaddyUI's in-memory runtime
+// log buffer for one Caddy server. The buffer keeps up to 1000 entries for the
+// life of the process, so on a quiet node it spans days; the page's "Clear
+// screen" used to empty only the table and every entry returned on the next
+// load. Nothing on disk is involved — runtime logs are never persisted — so
+// this needs no confirmation, but it is recorded in the Activity log.
+//
+// Unlike enable/disable this doesn't go through runtimeLogServerFromRequest:
+// that helper rejects external servers as "cannot be reconfigured", which is
+// beside the point for emptying a buffer.
+func (s *Server) clearServerLogs(w http.ResponseWriter, r *http.Request) {
+	if s.caddyLogHub == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "Caddy log ingest is unavailable")
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid form")
+		return
+	}
+	id, err := strconv.ParseInt(strings.TrimSpace(r.FormValue("server_id")), 10, 64)
+	if err != nil || id <= 0 {
+		writeJSONError(w, http.StatusBadRequest, "select a Caddy server")
+		return
+	}
+	cleared := s.caddyLogHub.Clear(id)
+	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r), "server_logs_clear",
+		"server:"+strconv.FormatInt(id, 10), strconv.Itoa(cleared)+" buffered runtime log entries discarded", true)
+	writeJSON(w, http.StatusOK, map[string]any{"cleared": cleared})
+}
+
 func (s *Server) runtimeLogServerFromRequest(w http.ResponseWriter, r *http.Request) (*models.CaddyServer, bool) {
 	if err := r.ParseForm(); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid form")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -800,6 +800,7 @@ func (s *Server) Routes() http.Handler {
 			r.Get("/api/server-logs/stream", s.serverLogStream)
 			r.Post("/api/server-logs/enable", s.enableServerLogs)
 			r.Post("/api/server-logs/disable", s.disableServerLogs)
+			r.Post("/api/server-logs/clear", s.clearServerLogs) // v2.35.5 (issue #60)
 			r.Post("/dashboard/recommendations/unused-certificates/dismiss", s.dismissUnusedCertificateRecommendation)
 
 			// v2.7.2: create/edit moved up to the requireWrite group so

--- a/web/templates/server_logs.html
+++ b/web/templates/server_logs.html
@@ -11,7 +11,7 @@
     <span id="capture-status" class="ui-status ui-status--neutral">Checking…</span>
     <span id="stream-status" class="ui-status ui-status--neutral">Stream connecting…</span>
     <button id="refresh-logs" type="button" class="ui-button ui-button--quiet">Refresh / reconnect</button>
-    <button id="clear-logs" type="button" class="ui-button ui-button--quiet">Clear screen</button>
+    <button id="clear-logs" type="button" class="ui-button ui-button--quiet" title="Empties the table and discards CaddyUI's buffered runtime log entries for this server, so they don't come back on the next load. Nothing on disk is affected.">Clear logs</button>
   </div>
 </div>
 
@@ -184,6 +184,30 @@
     row.style.display = show ? '' : 'none';
   }
 
+  // v2.35.5 (issue #60): show the full date, not just the time. The buffer
+  // keeps up to 1000 entries for as long as CaddyUI runs, so on a quiet node
+  // it spans days and time-only stamps read out of order. Same
+  // "YYYY-MM-DD HH:MM:SS" layout as the Activity log, in the timezone CaddyUI
+  // renders everything else in; falls back to the browser's zone when that
+  // name isn't an IANA identifier (e.g. "Local").
+  var displayZone = {{tzName}};
+  function makeWhenFormat(zone) {
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: zone, hourCycle: 'h23',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit'
+    });
+  }
+  var whenFormat;
+  try { whenFormat = makeWhenFormat(displayZone); } catch (_) { whenFormat = makeWhenFormat(undefined); }
+  function formatWhen(ts) {
+    var date = new Date(ts);
+    if (isNaN(date.getTime())) return ts || '';
+    var parts = {};
+    whenFormat.formatToParts(date).forEach(function(part) { parts[part.type] = part.value; });
+    return parts.year + '-' + parts.month + '-' + parts.day + ' ' + parts.hour + ':' + parts.minute + ':' + parts.second;
+  }
+
   function addEntry(entry) {
     if (body.querySelector('[data-entry-id="' + entry.id + '"]')) return;
     var row = document.createElement('tr');
@@ -192,7 +216,7 @@
     var fieldText = entry.fields && Object.keys(entry.fields).length ? JSON.stringify(entry.fields) : '';
     row.dataset.search = ((entry.logger || '') + ' ' + (entry.message || '') + ' ' + fieldText).toLowerCase();
     row.className = 'hover:bg-ink-50/60 transition';
-    addCell(row, new Date(entry.ts).toLocaleTimeString(), 'px-4 py-2.5 align-top whitespace-nowrap text-ink-500', Date.parse(entry.ts));
+    addCell(row, formatWhen(entry.ts), 'px-4 py-2.5 align-top whitespace-nowrap text-ink-500', Date.parse(entry.ts));
     addCell(row, entry.server_name || ('Server ' + entry.server_id), 'px-4 py-2.5 align-top whitespace-nowrap text-ink-700');
     var levelCell = addCell(row, '', 'px-4 py-2.5 align-top');
     var levelBadge = document.createElement('span');
@@ -246,7 +270,28 @@
   });
   filter.addEventListener('input', function() { body.querySelectorAll('tr').forEach(applyFilter); });
   visibleLevel.addEventListener('change', function() { body.querySelectorAll('tr').forEach(applyFilter); });
-  document.getElementById('clear-logs').addEventListener('click', function() { body.replaceChildren(); updateCount(); });
+  // v2.35.5 (issue #60): "Clear" used to empty only the table, and every
+  // entry came straight back on the next page load because CaddyUI's buffer
+  // was untouched. Now it also discards the buffered entries for the selected
+  // server. The cursor is deliberately kept: IDs keep counting up server-side,
+  // so a later reconnect neither replays purged rows nor misses new ones.
+  document.getElementById('clear-logs').addEventListener('click', function() {
+    var button = this;
+    body.replaceChildren();
+    updateCount();
+    if (!selectedID()) return;
+    var form = new URLSearchParams();
+    form.set('server_id', String(selectedID()));
+    button.disabled = true;
+    fetch('/api/server-logs/clear', {method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'Accept': 'application/json'}, body: form.toString()})
+      .then(function(response) { return response.json().then(function(data) { if (!response.ok) throw new Error(data.error || 'Clear failed'); return data; }); })
+      .then(function(data) {
+        var n = data.cleared || 0;
+        setStreamStatus('Cleared ' + n + (n === 1 ? ' buffered entry' : ' buffered entries'), 'active');
+      })
+      .catch(function(error) { setStreamStatus(error.message, 'error'); })
+      .finally(function() { button.disabled = false; });
+  });
   document.getElementById('refresh-logs').addEventListener('click', function() { refreshStatus(); connect(); });
   document.querySelectorAll('[data-log-sort]').forEach(function(button) {
     button.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
Fixes #60.

- **Dates.** The Server Logs page rendered `toLocaleTimeString()` — time only. CaddyUI's runtime-log ring keeps the last 1000 entries for the life of the process, so on a quiet node it spans days and the times read out of order. Entries now show `YYYY-MM-DD HH:MM:SS` in CaddyUI's configured timezone (falls back to the browser's zone if the name isn't IANA, e.g. `Local`) — the same layout the Activity log already uses.
- **Clear.** "Clear screen" only emptied the table; everything came back on the next load because the buffer was untouched. New `Hub.Clear(serverID)` drops that server's buffered entries while keeping IDs monotonic (a reconnecting page's cursor neither replays purged rows nor misses new ones), exposed as `POST /api/server-logs/clear` in the same admin route group as enable/disable. The button is now **Clear logs** and calls it. Nothing on disk is involved — runtime logs are never persisted — and the purge is recorded in the Activity log (`server_logs_clear`).
- Note for the reporter: the **Activity log** page already shows full `YYYY-MM-DD HH:MM:SS` dates (since v1.0.0); only Server Logs had the time-only stamps.

## Test plan
- [x] New `TestHubClearDropsOnlyThatServer`: per-server purge, other servers untouched, IDs stay monotonic after a purge, `Clear(0)` empties everything, buffer still accepts lines afterwards. All `caddylogs`, `web`, and related `internal/server` tests pass; `go vet` and `gofmt` clean.
- [x] End-to-end on a scratch instance with 6 runtime lines injected over the TCP ingest (2 dated the previous day): headless Chrome rendered the cells as `2026-09-03 13:05:56`, `2026-09-04 13:50:56`, … in the configured zone. Clicking **Clear logs** in the browser produced "Cleared 6 buffered entries" (CSRF passed), the stream then returned nothing for `since=0`, the Activity log had the `server_logs_clear` row, and a new line injected afterwards streamed as ID 7 with `since=6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)