### PR TITLE
feat: let custom health checks use any HTTP method, not just GET/HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.36.0] - 2026-09-04 - Health checks can use any HTTP method
+
+### Added
+
+- **Custom monitoring → Method** now offers POST, PUT, PATCH, DELETE and OPTIONS alongside GET and HEAD. A route that only accepts one method — a POST-only API endpoint, say — answers `405` to a GET or HEAD probe from Caddy itself, so the request never reaches the backend and "expected status 405" only ever proved that Caddy was up. Choosing the method the route accepts lets the probe get through to the service. Both HTTP probes (the App/Port check and the Public check) honour it. Methods other than GET/HEAD are sent with an empty body; the form warns that they can have side effects, so point them at an endpoint that tolerates an empty request. Blank or unrecognised values still fall back to GET; TRACE and CONNECT are deliberately not offered. (#59)
+
 ## [2.35.5] - 2026-09-04 - Server logs show the date, and Clear now clears
 
 ### Fixed

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -665,7 +665,7 @@ type ProxyHost struct {
 	// values mean "use the built-in default", so a custom-mode host that only
 	// overrides the path keeps the standard method, interval and timeout.
 	MonitorPath         string // default "/"
-	MonitorMethod       string // "GET" (default) or "HEAD"
+	MonitorMethod       string // one of MonitorMethods; blank/unknown resolve to GET (v2.36.0: any method, not just GET/HEAD)
 	MonitorExpectStatus int    // 0 = default classification; >0 = require exactly this code
 	MonitorIntervalSec  int    // 0 = default 60; rounded up to a multiple of the 60s poll tick
 	MonitorTimeoutSec   int    // 0 = default 5
@@ -687,6 +687,30 @@ func (p *ProxyHost) MonitoringDisabled() bool {
 	return NormalizeMonitorMode(p.MonitorMode) == "off"
 }
 
+// MonitorMethods lists the HTTP methods a custom-mode probe may use, in the
+// order the form offers them. GET is the default and HEAD saves bandwidth on
+// large pages; the rest exist for routes that only accept a specific method
+// (v2.36.0, issue #59). A method-restricted route answers 405 to anything
+// else from Caddy itself — the request never reaches the backend — so probing
+// such a route with GET says nothing about whether the service is up. TRACE
+// and CONNECT are deliberately absent.
+var MonitorMethods = []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}
+
+// NormalizeMonitorMethod coerces a monitor_method value to one of
+// MonitorMethods, defaulting to GET for blank or unrecognised input. Values
+// are normalised on the way in (the proxy host form parser) and resolved
+// through here again on the way out (MonitorSettings), so a row written by an
+// older version or by hand still probes sensibly.
+func NormalizeMonitorMethod(method string) string {
+	method = strings.ToUpper(strings.TrimSpace(method))
+	for _, allowed := range MonitorMethods {
+		if method == allowed {
+			return allowed
+		}
+	}
+	return "GET"
+}
+
 // MonitorSettings resolves the effective probe parameters for this host,
 // applying the built-in defaults for anything left at its zero value. The
 // defaults match the hardcoded behaviour that predated issue #39, so an
@@ -703,9 +727,8 @@ func (p *ProxyHost) MonitorSettings(defaultInterval, defaultTimeout time.Duratio
 		}
 		path = v
 	}
-	if strings.EqualFold(strings.TrimSpace(p.MonitorMethod), "HEAD") {
-		method = "HEAD"
-	}
+	// v2.36.0 (issue #59): any method in MonitorMethods, not just GET/HEAD.
+	method = NormalizeMonitorMethod(p.MonitorMethod)
 	if p.MonitorExpectStatus > 0 {
 		expectStatus = p.MonitorExpectStatus
 	}

--- a/internal/server/app_health_monitor_test.go
+++ b/internal/server/app_health_monitor_test.go
@@ -70,6 +70,36 @@ func TestMonitorSettingsCustomFallsBackPerField(t *testing.T) {
 	}
 }
 
+// v2.36.0 (issue #59): any HTTP method, not just GET/HEAD. A route that only
+// accepts POST answers 405 to a GET probe from Caddy itself, so the probe never
+// reaches the backend; letting the operator pick POST is what makes such a
+// route monitorable. Blank or unrecognised input must still resolve to GET,
+// and TRACE/CONNECT are deliberately not offered.
+func TestMonitorSettingsAcceptsEveryHTTPMethod(t *testing.T) {
+	for input, want := range map[string]string{
+		"": "GET", "get": "GET", "HEAD": "HEAD", "post": "POST", " Put ": "PUT",
+		"patch": "PATCH", "DELETE": "DELETE", "options": "OPTIONS",
+		"TRACE": "GET", "CONNECT": "GET", "bogus": "GET",
+	} {
+		p := models.ProxyHost{MonitorMode: "custom", MonitorMethod: input}
+		_, method, _, _, _ := p.MonitorSettings(60*time.Second, 5*time.Second)
+		if method != want {
+			t.Errorf("custom host with MonitorMethod %q probes with %q, want %q", input, method, want)
+		}
+		if got := models.NormalizeMonitorMethod(input); got != want {
+			t.Errorf("NormalizeMonitorMethod(%q) = %q, want %q", input, got, want)
+		}
+	}
+	// An auto-mode host ignores the field entirely, whatever it holds.
+	p := models.ProxyHost{MonitorMode: "auto", MonitorMethod: "POST"}
+	if _, method, _, _, _ := p.MonitorSettings(60*time.Second, 5*time.Second); method != "GET" {
+		t.Errorf("auto-mode host probes with %q, want GET regardless of MonitorMethod", method)
+	}
+	if len(models.MonitorMethods) != 7 || models.MonitorMethods[0] != "GET" {
+		t.Errorf("MonitorMethods = %v; want seven entries with GET first, matching the form's select", models.MonitorMethods)
+	}
+}
+
 func TestMonitoringDisabledOnlyForOff(t *testing.T) {
 	for mode, want := range map[string]bool{"": false, "auto": false, "custom": false, "off": true, "OFF": true, " off ": true} {
 		if got := (&models.ProxyHost{MonitorMode: mode}).MonitoringDisabled(); got != want {
@@ -140,6 +170,40 @@ func TestProbeAppUsesCustomPathAndMethod(t *testing.T) {
 	// round-tripped and the verdict is ok.
 	if entry.Status != "ok" || entry.Code != 204 {
 		t.Errorf("entry = %+v, want ok/204", entry)
+	}
+}
+
+// v2.36.0 (issue #59): the scenario from the report — a route that only
+// accepts POST. Probing it with GET gets a 405 (from Caddy's matcher in
+// production, from the upstream here), which the default classifier reports
+// as "degraded": a verdict about the matcher, not the service. Probing with
+// POST reaches the service and is "ok". Both verdicts must follow from the
+// configured method alone, with no expect-status override.
+func TestProbeAppReachesPostOnlyRouteWithPost(t *testing.T) {
+	gotMethod := make(chan string, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod <- r.Method
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	for method, wantStatus := range map[string]string{"POST": "ok", "GET": "degraded"} {
+		s := &Server{appHealth: map[int64]appHealthEntry{}}
+		host := models.ProxyHost{
+			ID: 1, Enabled: true, Domains: hostportOf(t, srv.URL), SSLEnabled: false,
+			MonitorMode: "custom", MonitorPath: "/api/ping", MonitorMethod: method,
+		}
+		entry := s.probeApp(context.Background(), host)
+		if m := <-gotMethod; m != method {
+			t.Errorf("configured %s but the upstream saw %s", method, m)
+		}
+		if entry.Status != wantStatus {
+			t.Errorf("method %s: status = %q (HTTP %d), want %q", method, entry.Status, entry.Code, wantStatus)
+		}
 	}
 }
 

--- a/internal/server/proxy_host_form.go
+++ b/internal/server/proxy_host_form.go
@@ -675,7 +675,9 @@ func parseProxyHostForm(r *http.Request) (*models.ProxyHost, error) {
 	// take effect (see models.ProxyHost.MonitorSettings).
 	ph.MonitorMode = models.NormalizeMonitorMode(r.FormValue("monitor_mode"))
 	ph.MonitorPath = strings.TrimSpace(r.FormValue("monitor_path"))
-	ph.MonitorMethod = strings.ToUpper(strings.TrimSpace(r.FormValue("monitor_method")))
+	// v2.36.0 (issue #59): any method in models.MonitorMethods; blank or
+	// unrecognised input is stored as GET so the row is canonical on disk.
+	ph.MonitorMethod = models.NormalizeMonitorMethod(r.FormValue("monitor_method"))
 	ph.MonitorExpectStatus = clampAtoi(r.FormValue("monitor_expect_status"), 0, 100, 599)
 	// Floor the interval at the poller's own tick: a smaller value can't be
 	// honoured (the poller only wakes every appHealthInterval) and storing it

--- a/internal/server/public_health_monitor_test.go
+++ b/internal/server/public_health_monitor_test.go
@@ -132,6 +132,47 @@ func TestCheckAllProxyHostsUsesCustomPathMethodAndExpectStatus(t *testing.T) {
 	}
 }
 
+// v2.36.0 (issue #59): the same POST-only scenario for the persisted Public
+// check. The stored method is lowercase on purpose — rows written by hand or
+// by an older build must still resolve, since only the form parser canonicalises.
+func TestCheckAllProxyHostsReachesPostOnlyRouteWithPost(t *testing.T) {
+	s := newPublicHealthTestServer(t)
+
+	gotMethod := make(chan string, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod <- r.Method
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	host := &models.ProxyHost{
+		Domains: hostportOfURL(t, srv.URL), ForwardScheme: "http", ForwardHost: "backend",
+		ForwardPort: 80, Enabled: true, SSLEnabled: false,
+		MonitorMode: "custom", MonitorPath: "/api/ping", MonitorMethod: "post",
+	}
+	id, err := models.CreateProxyHost(s.DB, 1, 0, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s.checkAllProxyHosts()
+
+	if m := <-gotMethod; m != "POST" {
+		t.Errorf("probed method = %q, want POST", m)
+	}
+	history, err := models.GetProxyHealthHistory(s.DB, id, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 1 || !history[0].OK || history[0].StatusCode != 200 {
+		t.Fatalf("history = %+v, want one OK row with HTTP 200 — the POST probe must reach the upstream", history)
+	}
+}
+
 // The pre-existing failure mode: a custom health path answering something
 // other than the default-accepted codes (2xx/3xx/401/403) must show as down
 // when no expectStatus is set, matching the App-dot semantics exactly.

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -337,6 +337,41 @@ func TestMonitoringControlsAndOffStateAreWired(t *testing.T) {
 	}
 }
 
+// TestMonitorMethodSelectOffersEveryMethod guards v2.36.0 (issue #59): the
+// custom-monitoring Method select must offer every method the backend
+// whitelist (models.MonitorMethods) accepts — a POST-only route can't be
+// probed any other way — must not offer TRACE/CONNECT, and must keep GET as
+// the selected choice for blank (legacy/default) rows.
+func TestMonitorMethodSelectOffersEveryMethod(t *testing.T) {
+	form, err := FS.ReadFile("templates/proxy_host_form.html")
+	if err != nil {
+		t.Fatalf("read proxy_host_form.html: %v", err)
+	}
+	html := string(form)
+	start := strings.Index(html, `name="monitor_method"`)
+	if start < 0 {
+		t.Fatal("proxy host form has no monitor_method select")
+	}
+	end := strings.Index(html[start:], "</select>")
+	if end < 0 {
+		t.Fatal("monitor_method select is never closed")
+	}
+	sel := html[start : start+end]
+	for _, m := range []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"} {
+		if !strings.Contains(sel, `value="`+m+`"`) {
+			t.Errorf("monitor_method select is missing %s", m)
+		}
+	}
+	for _, m := range []string{"TRACE", "CONNECT"} {
+		if strings.Contains(sel, `value="`+m+`"`) {
+			t.Errorf("monitor_method select must not offer %s", m)
+		}
+	}
+	if !strings.Contains(sel, `(eq .Host.MonitorMethod "")`) {
+		t.Error("GET option must be selected when MonitorMethod is blank, or legacy rows would render with nothing chosen")
+	}
+}
+
 // TestCSRFClientPlumbing guards the two client-side halves of CSRF protection.
 // The hidden form input is stamped into rendered HTML server-side (see
 // csrfInjectForms), but scripted callers depend on these two pieces: the meta

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -1353,9 +1353,20 @@ document.addEventListener('DOMContentLoaded', function() {
               <label class="block text-sm font-medium text-ink-800 mb-1.5">Method</label>
               <select name="monitor_method"
                 class="w-full rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition">
-                <option value="GET" {{if ne .Host.MonitorMethod "HEAD"}}selected{{end}}>GET (default)</option>
+                {{/* v2.36.0 (issue #59): every method, not just GET/HEAD. A route that only
+                     accepts POST answers 405 to GET/HEAD from Caddy itself — the probe never
+                     reaches the backend — so letting the operator pick the method the route
+                     accepts is what makes such a route monitorable. Keep this list in step
+                     with models.MonitorMethods; web/embed_test.go checks it. */}}
+                <option value="GET" {{if or (eq .Host.MonitorMethod "") (eq .Host.MonitorMethod "GET")}}selected{{end}}>GET (default)</option>
                 <option value="HEAD" {{if eq .Host.MonitorMethod "HEAD"}}selected{{end}}>HEAD (no response body)</option>
+                <option value="POST" {{if eq .Host.MonitorMethod "POST"}}selected{{end}}>POST (empty body)</option>
+                <option value="PUT" {{if eq .Host.MonitorMethod "PUT"}}selected{{end}}>PUT (empty body)</option>
+                <option value="PATCH" {{if eq .Host.MonitorMethod "PATCH"}}selected{{end}}>PATCH (empty body)</option>
+                <option value="DELETE" {{if eq .Host.MonitorMethod "DELETE"}}selected{{end}}>DELETE</option>
+                <option value="OPTIONS" {{if eq .Host.MonitorMethod "OPTIONS"}}selected{{end}}>OPTIONS</option>
               </select>
+              <p class="text-xs text-ink-500 mt-1">Use the method the probe path actually accepts. A POST-only API route answers <code>405</code> to GET/HEAD from Caddy itself — the request never reaches your backend, so it proves nothing about the service. Methods other than GET/HEAD are sent with an empty body and can have side effects; point them at an endpoint that tolerates that.</p>
             </div>
           </div>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">


### PR DESCRIPTION
## Summary
Closes #59.

A route that only accepts one method (e.g. a POST-only API endpoint) answers `405` to a GET/HEAD probe from Caddy's **matcher** — the request never reaches the backend, so "expected status 405" only proves Caddy is up. The custom-monitoring Method select was hard-coded to GET/HEAD with a HEAD-else-GET resolver behind it.

- `models.MonitorMethods` = GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS (TRACE/CONNECT deliberately not offered) and `NormalizeMonitorMethod` (blank/unknown → GET), used by the form parser on the way in and by `MonitorSettings` on the way out, so hand-written or older rows still resolve.
- Both HTTP probes — the App/Port check (`probeApp`) and the persisted Public check (`checkProxyHost`) — already take the method from `MonitorSettings`, so they honour it with no further change.
- Form: full method list; helper text explains the 405-from-Caddy trap and warns that non-GET/HEAD methods are sent with an **empty body and can have side effects** — point them at an endpoint that tolerates that.
- CHANGELOG entry for v2.36.0. (Will need a trivial rebase once #62 / v2.35.5 lands first.)

## Test plan
- [x] `TestMonitorSettingsAcceptsEveryHTTPMethod` — every whitelisted method resolves (case/whitespace-insensitive); blank, TRACE, CONNECT, junk → GET; auto mode ignores the field.
- [x] `TestMonitorMethodSelectOffersEveryMethod` (web) — the select lists exactly the whitelist, not TRACE/CONNECT, and keeps GET selected for blank rows.
- [x] Behavioural, against `httptest` upstreams that 405 everything but POST: `TestProbeAppReachesPostOnlyRouteWithPost` (POST → ok, GET → degraded, upstream sees the configured method) and `TestCheckAllProxyHostsReachesPostOnlyRouteWithPost` (stored lowercase `post` → POST on the wire → OK/200 persisted).
- [x] Full `go test ./...` green; `go vet`, `gofmt` clean. Rendered the form on a scratch server: all seven options present, GET preselected, helper text shown, no template errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)