### PR TITLE
fix: list Advanced routes' domains in the Certificates page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.36.2] - 2026-09-04 - Certificates page lists Advanced routes
+
+### Fixed
+
+- The **Caddy-managed (ACME)** section of the Certificates page listed the domains of proxy hosts and redirects but never those of Advanced routes — even though Caddy issues certificates for their host matchers in exactly the same way, and CaddyUI's certificate lifecycle tracking already followed them. Enabled Advanced routes without a custom certificate now appear there too, with the same wildcard mapping and issuance status as everything else. (#65)
+
 ## [2.36.1] - 2026-09-04 - Advanced routes on custom ports get their own listener
 
 ### Fixed

--- a/internal/server/certificate_auto_domains.go
+++ b/internal/server/certificate_auto_domains.go
@@ -1,0 +1,67 @@
+package server
+
+import "github.com/X4Applegate/caddyui/internal/models"
+
+// collectAutoManagedDomains lists every hostname Caddy obtains a certificate
+// for automatically — enabled, TLS on, no custom certificate — across proxy
+// hosts, redirects and, since v2.36.2 (issue #65), Advanced routes. Caddy's
+// automatic HTTPS covers a route's host matchers exactly as it covers a proxy
+// host's domains, and certificateProbeTargets already tracked them; the
+// Certificates page simply never listed them, so an Advanced route's
+// certificate was invisible there while the same domain on a proxy host
+// showed up. Duplicates across kinds collapse to the first occurrence, in
+// proxy → redirect → Advanced-route order, matching the previous behaviour.
+func collectAutoManagedDomains(
+	certs []models.Certificate,
+	lifecycleStates []models.CertificateLifecycleStatus,
+	hosts []models.ProxyHost,
+	redirs []models.RedirectionHost,
+	raws []models.RawRoute,
+) []autoDomainView {
+	seen := map[string]bool{}
+	var out []autoDomainView
+	add := func(domain string) {
+		if domain == "" || seen[domain] {
+			return
+		}
+		seen[domain] = true
+		view := autoDomainView{Domain: domain, CertificateName: "Direct certificate"}
+		statusDomains := []string{domain}
+		if cert := managedWildcardForHost(certs, domain); cert != nil {
+			view.CertificateName = cert.Name
+			view.UsesWildcard = true
+			statusDomains = cert.DomainList()
+		}
+		view.Lifecycle = certificateLifecycleForDomains(lifecycleStates, statusDomains)
+		out = append(out, view)
+	}
+	for _, h := range hosts {
+		if !h.Enabled || !h.SSLEnabled || h.CertificateID != 0 {
+			continue
+		}
+		for _, d := range h.DomainList() {
+			add(d)
+		}
+	}
+	for _, rh := range redirs {
+		if !rh.Enabled || !rh.SSLEnabled || rh.CertificateID != 0 {
+			continue
+		}
+		for _, d := range rh.DomainList() {
+			add(d)
+		}
+	}
+	// Advanced routes have no SSL toggle: Caddy secures whatever host matchers
+	// they carry unless a custom certificate is assigned — the same rule
+	// certificateProbeTargets applies. A route with no host matcher (path- or
+	// port-only) has nothing to secure and contributes nothing.
+	for _, rr := range raws {
+		if !rr.Enabled || rr.CertificateID != 0 {
+			continue
+		}
+		for _, d := range rawRouteHosts(rr) {
+			add(d)
+		}
+	}
+	return out
+}

--- a/internal/server/certificate_auto_domains_test.go
+++ b/internal/server/certificate_auto_domains_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// v2.36.2 (issue #65): the Certificates page's "Caddy-managed (ACME)" list
+// must include Advanced routes' hostnames under the same rule as proxy hosts
+// and redirects — enabled, no custom certificate — with the same wildcard
+// mapping and lifecycle status, and without listing anything twice.
+func TestAutoManagedDomainsIncludeAdvancedRoutes(t *testing.T) {
+	certs := []models.Certificate{
+		{ID: 7, Name: "Example wildcard", Source: models.CertSourceManaged, Domains: "*.example.com"},
+	}
+	states := []models.CertificateLifecycleStatus{
+		{Identifier: "health.example.net", Phase: "active", Level: "INFO", Message: "certificate obtained successfully"},
+	}
+	hosts := []models.ProxyHost{{Domains: "app.example.org", Enabled: true, SSLEnabled: true}}
+	redirs := []models.RedirectionHost{{Domains: "old.example.org", Enabled: true, SSLEnabled: true}}
+	route := func(host string) string {
+		return `{"match":[{"host":["` + host + `"]}],"handle":[{"handler":"static_response","status_code":200}]}`
+	}
+	raws := []models.RawRoute{
+		{Enabled: true, JSONData: route("health.example.net")},                                                                          // must appear
+		{Enabled: true, JSONData: route("api.example.com")},                                                                             // must appear, covered by the wildcard
+		{Enabled: true, JSONData: route("app.example.org")},                                                                             // same domain as the proxy host: listed once
+		{Enabled: false, JSONData: route("off.example.net")},                                                                            // disabled: absent
+		{Enabled: true, CertificateID: 3, JSONData: route("custom.example.net")},                                                        // custom cert: absent (it's a custom cert row instead)
+		{Enabled: true, JSONData: `{"match":[{"path":["/lbhealthcheck"]}],"handle":[{"handler":"static_response","status_code":200}]}`}, // no host: nothing to secure
+	}
+
+	got := collectAutoManagedDomains(certs, states, hosts, redirs, raws)
+
+	wantOrder := []string{"app.example.org", "old.example.org", "health.example.net", "api.example.com"}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("got %d auto-managed domains %v, want %v", len(got), domainsOf(got), wantOrder)
+	}
+	byDomain := map[string]autoDomainView{}
+	for i, v := range got {
+		byDomain[v.Domain] = v
+		if v.Domain != wantOrder[i] {
+			t.Errorf("position %d = %q, want %q (proxy → redirect → Advanced route order)", i, v.Domain, wantOrder[i])
+		}
+	}
+	for _, absent := range []string{"off.example.net", "custom.example.net"} {
+		if _, ok := byDomain[absent]; ok {
+			t.Errorf("%s must not be listed as Caddy-managed", absent)
+		}
+	}
+	if v := byDomain["health.example.net"]; v.Lifecycle == nil || v.Lifecycle.Phase != "active" {
+		t.Errorf("lifecycle status not attached to an Advanced route's domain: %+v", v.Lifecycle)
+	} else if v.UsesWildcard || v.CertificateName != "Direct certificate" {
+		t.Errorf("health.example.net should be a direct certificate, got %+v", v)
+	}
+	if v := byDomain["api.example.com"]; !v.UsesWildcard || v.CertificateName != "Example wildcard" {
+		t.Errorf("api.example.com should map to the managed wildcard, got %+v", v)
+	}
+}
+
+func domainsOf(views []autoDomainView) []string {
+	out := make([]string, 0, len(views))
+	for _, v := range views {
+		out = append(out, v.Domain)
+	}
+	return out
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6685,43 +6685,9 @@ func (s *Server) listCertificates(w http.ResponseWriter, r *http.Request) {
 		mustGetSetting(s.DB, unusedCertificateDismissalKey(sid)) == unusedCertificateFingerprint(certs, referencedCerts)
 
 	// Collect domains auto-managed by Caddy (ssl_enabled, no custom cert).
-	// Use admin view to see all hosts regardless of owner.
-	seen := map[string]bool{}
-	var autoDomains []autoDomainView
-	addAutoDomain := func(domain string) {
-		if seen[domain] {
-			return
-		}
-		seen[domain] = true
-		view := autoDomainView{
-			Domain:          domain,
-			CertificateName: "Direct certificate",
-		}
-		statusDomains := []string{domain}
-		if cert := managedWildcardForHost(certs, domain); cert != nil {
-			view.CertificateName = cert.Name
-			view.UsesWildcard = true
-			statusDomains = cert.DomainList()
-		}
-		view.Lifecycle = certificateLifecycleForDomains(lifecycleStates, statusDomains)
-		autoDomains = append(autoDomains, view)
-	}
-	for _, h := range allHosts {
-		if !h.Enabled || !h.SSLEnabled || h.CertificateID != 0 {
-			continue
-		}
-		for _, d := range h.DomainList() {
-			addAutoDomain(d)
-		}
-	}
-	for _, rh := range allRedirs {
-		if !rh.Enabled || !rh.SSLEnabled || rh.CertificateID != 0 {
-			continue
-		}
-		for _, d := range rh.DomainList() {
-			addAutoDomain(d)
-		}
-	}
+	// Use admin view to see all hosts regardless of owner. v2.36.2 (issue
+	// #65): Advanced routes are included — see collectAutoManagedDomains.
+	autoDomains := collectAutoManagedDomains(certs, lifecycleStates, allHosts, allRedirs, allRoutes)
 
 	pbAPIKey, _ := models.GetSetting(s.DB, settingPBAPIKey)
 	pbSecretKey, _ := models.GetSetting(s.DB, settingPBSecretKey)


### PR DESCRIPTION
## Summary
Fixes #65.

The **Caddy-managed (ACME)** section of `/certificates` built its list from proxy hosts and redirects only ([`listCertificates`](internal/server/server.go)). Advanced routes were never added, even though Caddy issues certificates for their host matchers the same way and `certificateProbeTargets` already tracks them for lifecycle status — so an Advanced route's certificate was invisible on the page while the identical domain on a proxy host showed up.

- Extracted the list-building into `collectAutoManagedDomains` (new `certificate_auto_domains.go`) and added Advanced routes under the same rule the reconciler uses: enabled, no custom certificate, whatever host matchers the route carries. Same wildcard mapping (`managedWildcardForHost`) and lifecycle status (`certificateLifecycleForDomains`); duplicates across kinds collapse, proxy → redirect → Advanced-route order.
- Routes with a custom certificate keep showing as that custom certificate; path-/port-only routes have no hostname and contribute nothing.
- CHANGELOG entry for v2.36.2.

## Test plan
- [x] `TestAutoManagedDomainsIncludeAdvancedRoutes`: Advanced-route hostname listed with its lifecycle state; wildcard-covered hostname maps to the managed wildcard; a hostname shared with a proxy host is listed once; disabled and custom-cert routes absent; path-only route contributes nothing. Full `go test ./...` green; `go vet`/`gofmt` clean.
- [x] Rendered `/certificates` on a scratch instance seeded with a proxy host and three Advanced routes (hostname / path-only / disabled): the table lists `app.example.org` and `health.example.net` only — exactly the expected set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)