### PR TITLE
fix: give each Caddy node its own log ingest target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.37.0] - 2026-09-04 - Each Caddy node ships its logs to a target it can reach
+
+### Fixed
+
+- Every node in the fleet was configured to send its access logs, certificate events and runtime logs to the one fleet-wide ingest target, which defaults to `caddyui:9019` — a Docker service name that only a Caddy on the same Docker network can resolve. Nodes on other hosts therefore shipped nothing, silently: an empty Analytics page for that server, no certificate issuance status, and no Server Logs capture. Each node now has its own **Log ingest target** on its Caddy Fleet entry (blank = the fleet-wide setting), applied to all three log streams.
+
+### Added
+
+- The Caddy Fleet list shows where each managed node ships its logs, and warns when a node reached at another host was handed a bare Docker service name it cannot resolve; the Analytics page shows the same for the node in scope when it has no traffic, instead of an unexplained empty page. Settings → Analytics now says when the fleet-wide default is not enough.
+
+---
+
 ## [2.36.2] - 2026-09-04 - Certificates page lists Advanced routes
 
 ### Fixed

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -627,6 +627,18 @@ func migrate(db *sql.DB) error {
 	// actually serves the proxy host — not a single global setting. If the
 	// column is new, backfill every row from the legacy global cf_server_ip
 	// setting so existing records keep pointing at the right place.
+	// v2.37.0: per-node log ingest target (host:port). '' = the fleet-wide
+	// Settings → Analytics target. Nodes on other hosts can't resolve the
+	// default Docker service name, so they need their own.
+	hasIngestTarget, err := columnExists(db, "caddy_servers", "ingest_target")
+	if err != nil {
+		return err
+	}
+	if !hasIngestTarget {
+		if _, err := db.Exec(`ALTER TABLE caddy_servers ADD COLUMN ingest_target TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add ingest_target to caddy_servers: %w", err)
+		}
+	}
 	hasPublicIP, err := columnExists(db, "caddy_servers", "public_ip")
 	if err != nil {
 		return err

--- a/internal/models/servers.go
+++ b/internal/models/servers.go
@@ -2,6 +2,9 @@ package models
 
 import (
 	"database/sql"
+	"fmt"
+	"net"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -31,7 +34,14 @@ type CaddyServer struct {
 	// PublicIP is the WAN IP this server answers on — written into the A
 	// record content by every DNS provider when a proxy host is created on
 	// this server. Empty = fall back to the legacy global setting.
-	PublicIP      string
+	PublicIP string
+	// IngestTarget (v2.37.0) is the host:port THIS node connects to to ship
+	// access logs, certificate events and runtime logs to CaddyUI. Empty =
+	// the fleet-wide target from Settings → Analytics. One global target
+	// defaulted to "caddyui:9019" — a Docker service name only containers on
+	// the same network can resolve — so every node on another host silently
+	// shipped nothing: no analytics, no certificate status, no runtime logs.
+	IngestTarget  string
 	LastContactAt sql.NullTime
 	CreatedAt     time.Time
 }
@@ -48,14 +58,62 @@ func (c CaddyServer) TagList() []string {
 	return out
 }
 
-const caddyServerCols = `id, name, admin_url, type, tags, status, COALESCE(version,''), COALESCE(admin_username,''), COALESCE(admin_password,''), COALESCE(public_ip,''), last_contact_at, created_at`
+const caddyServerCols = `id, name, admin_url, type, tags, status, COALESCE(version,''), COALESCE(admin_username,''), COALESCE(admin_password,''), COALESCE(public_ip,''), COALESCE(ingest_target,''), last_contact_at, created_at`
 
 func scanCaddyServer(s interface {
 	Scan(dest ...any) error
 }) (CaddyServer, error) {
 	var c CaddyServer
-	err := s.Scan(&c.ID, &c.Name, &c.AdminURL, &c.Type, &c.Tags, &c.Status, &c.Version, &c.AdminUsername, &c.AdminPassword, &c.PublicIP, &c.LastContactAt, &c.CreatedAt)
+	err := s.Scan(&c.ID, &c.Name, &c.AdminURL, &c.Type, &c.Tags, &c.Status, &c.Version, &c.AdminUsername, &c.AdminPassword, &c.PublicIP, &c.IngestTarget, &c.LastContactAt, &c.CreatedAt)
 	return c, err
+}
+
+// EffectiveIngestTarget is where this node ships its logs: its own
+// IngestTarget when set, otherwise the fleet-wide target from Settings →
+// Analytics. v2.37.0.
+func (c CaddyServer) EffectiveIngestTarget(global string) string {
+	if t := strings.TrimSpace(c.IngestTarget); t != "" {
+		return t
+	}
+	return strings.TrimSpace(global)
+}
+
+// LooksDockerInternalHost reports whether hostport names a bare, single-label
+// host such as "caddyui:9019" — resolvable only inside the Docker network
+// that defines it. IP addresses, "localhost", dotted names and unix sockets
+// return false.
+func LooksDockerInternalHost(hostport string) bool {
+	host := hostport
+	if h, _, err := net.SplitHostPort(strings.TrimSpace(hostport)); err == nil {
+		host = h
+	}
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" || host == "localhost" || strings.Contains(host, ".") || strings.Contains(host, "/") || net.ParseIP(host) != nil {
+		return false
+	}
+	return true
+}
+
+// IngestTargetWarning explains, in one sentence, why this node very likely
+// cannot deliver its logs to effectiveTarget, or returns "" when nothing looks
+// wrong. Only the unambiguous case is flagged: a node whose admin API lives on
+// another host (an IP address or a dotted name) that was handed a bare Docker
+// service name. A node reached at a bare name itself ("http://caddy:2019")
+// shares CaddyUI's Docker network, where the default target works; unix
+// sockets are left alone because their placement is ambiguous.
+func (c CaddyServer) IngestTargetWarning(effectiveTarget string) string {
+	if !LooksDockerInternalHost(effectiveTarget) {
+		return ""
+	}
+	u, err := url.Parse(strings.TrimSpace(c.AdminURL))
+	if err != nil || u.Scheme == "unix" {
+		return ""
+	}
+	adminHost := strings.ToLower(u.Hostname())
+	if adminHost == "" || adminHost == "localhost" || (!strings.Contains(adminHost, ".") && net.ParseIP(adminHost) == nil) {
+		return ""
+	}
+	return fmt.Sprintf("This node is reached at %s but was told to send its logs to %q — a Docker service name another host cannot resolve, so CaddyUI receives nothing from it (no analytics, certificate status or runtime logs). Give it an ingest target it can reach: the CaddyUI host as seen from that node, e.g. 192.168.1.10:9019 on a LAN or 10.8.0.1:9019 over a VPN.", adminHost, effectiveTarget)
 }
 
 func SetCaddyServerVersion(db *sql.DB, id int64, version string) error {
@@ -107,11 +165,11 @@ func CreateCaddyServer(db *sql.DB, c *CaddyServer) (int64, error) {
 		c.Status = CaddyServerStatusUnknown
 	}
 	res, err := db.Exec(
-		`INSERT INTO caddy_servers (name, admin_url, type, tags, status, admin_username, admin_password, public_ip) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO caddy_servers (name, admin_url, type, tags, status, admin_username, admin_password, public_ip, ingest_target) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strings.TrimSpace(c.Name), strings.TrimRight(strings.TrimSpace(c.AdminURL), "/"),
 		c.Type, strings.TrimSpace(c.Tags), c.Status,
 		strings.TrimSpace(c.AdminUsername), c.AdminPassword,
-		strings.TrimSpace(c.PublicIP),
+		strings.TrimSpace(c.PublicIP), strings.TrimSpace(c.IngestTarget),
 	)
 	if err != nil {
 		return 0, err
@@ -122,11 +180,11 @@ func CreateCaddyServer(db *sql.DB, c *CaddyServer) (int64, error) {
 func UpdateCaddyServer(db *sql.DB, c *CaddyServer) error {
 	c.Type = normalizeServerType(c.Type)
 	_, err := db.Exec(
-		`UPDATE caddy_servers SET name=?, admin_url=?, type=?, tags=?, version=?, admin_username=?, admin_password=?, public_ip=? WHERE id=?`,
+		`UPDATE caddy_servers SET name=?, admin_url=?, type=?, tags=?, version=?, admin_username=?, admin_password=?, public_ip=?, ingest_target=? WHERE id=?`,
 		strings.TrimSpace(c.Name), strings.TrimRight(strings.TrimSpace(c.AdminURL), "/"),
 		c.Type, strings.TrimSpace(c.Tags), strings.TrimSpace(c.Version),
 		strings.TrimSpace(c.AdminUsername), c.AdminPassword,
-		strings.TrimSpace(c.PublicIP), c.ID,
+		strings.TrimSpace(c.PublicIP), strings.TrimSpace(c.IngestTarget), c.ID,
 	)
 	return err
 }

--- a/internal/models/servers_ingest_test.go
+++ b/internal/models/servers_ingest_test.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+// v2.37.0: one fleet-wide ingest target defaulted to "caddyui:9019", a Docker
+// service name only containers on the same network can resolve, so every
+// node on another host silently shipped nothing. Each node now has its own
+// target, and the unambiguous misconfiguration is called out.
+func TestEffectiveIngestTarget(t *testing.T) {
+	if got := (CaddyServer{}).EffectiveIngestTarget(" caddyui:9019 "); got != "caddyui:9019" {
+		t.Errorf("blank per-node target should fall back to the global one, got %q", got)
+	}
+	if got := (CaddyServer{IngestTarget: " 10.8.0.1:9019 "}).EffectiveIngestTarget("caddyui:9019"); got != "10.8.0.1:9019" {
+		t.Errorf("per-node target should win, got %q", got)
+	}
+}
+
+func TestLooksDockerInternalHost(t *testing.T) {
+	for in, want := range map[string]bool{
+		"caddyui:9019": true, "caddyui": true, "CaddyUI:9019": true,
+		"localhost:9019": false, "10.8.0.1:9019": false, "[::1]:9019": false,
+		"host.docker.internal:9019": false, "ingest.example.com:9019": false,
+		"unix//run/ingest.sock": false, "": false,
+	} {
+		if got := LooksDockerInternalHost(in); got != want {
+			t.Errorf("LooksDockerInternalHost(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestIngestTargetWarningFlagsOnlyRemoteNodesWithDockerNames(t *testing.T) {
+	remote := CaddyServer{Name: "Richard Prod", AdminURL: "http://10.8.0.3:2019"}
+	if w := remote.IngestTargetWarning("caddyui:9019"); !strings.Contains(w, "10.8.0.3") || !strings.Contains(w, `"caddyui:9019"`) {
+		t.Errorf("remote node + Docker name must warn and name both sides, got %q", w)
+	}
+	if w := remote.IngestTargetWarning("10.8.0.1:9019"); w != "" {
+		t.Errorf("remote node with a reachable target must not warn, got %q", w)
+	}
+	for _, local := range []CaddyServer{
+		{AdminURL: "http://caddy:2019"},            // same Docker network as CaddyUI
+		{AdminURL: "http://localhost:2019"},        // same host
+		{AdminURL: "unix:///run/caddy-admin.sock"}, // ambiguous placement: leave alone
+		{AdminURL: "http://edge.example.com:2019", Type: "external"},
+	} {
+		if w := local.IngestTargetWarning("caddyui:9019"); (local.AdminURL == "http://edge.example.com:2019") != (w != "") {
+			t.Errorf("AdminURL %q: warning = %q", local.AdminURL, w)
+		}
+	}
+}

--- a/internal/server/analytics.go
+++ b/internal/server/analytics.go
@@ -180,7 +180,8 @@ func (s *Server) applyAnalyticsToggle(cfg analyticsConfig) error {
 		}
 		cli := newCaddyClient(sr.AdminURL, sr.AdminUsername, sr.AdminPassword)
 		if cfg.Enabled {
-			if err := cli.EnableAccessLogs(cfg.Target, caddy.AccessLogOptions{
+			// v2.37.0: each node ships to the target IT can reach.
+			if err := cli.EnableAccessLogs(sr.EffectiveIngestTarget(cfg.Target), caddy.AccessLogOptions{
 				SoftStart: cfg.SoftStart, DialTimeout: cfg.DialTimeout,
 				ServerID: sr.ID, ServerName: sr.Name,
 			}); err != nil {
@@ -588,6 +589,23 @@ func (s *Server) getAnalytics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfg := loadAnalyticsConfig(s.DB)
+	// v2.37.0: with one node in scope, say where that node ships its logs —
+	// and warn when it plainly can't reach that address. A remote node handed
+	// the default Docker service name showed an empty page with no clue why.
+	var scopeIngest map[string]any
+	if serverScopeID > 0 {
+		for _, sr := range allServers {
+			if sr.ID != serverScopeID {
+				continue
+			}
+			target := sr.EffectiveIngestTarget(cfg.Target)
+			scopeIngest = map[string]any{
+				"ServerID": sr.ID, "ServerName": sr.Name, "Target": target,
+				"Warning": sr.IngestTargetWarning(target),
+			}
+			break
+		}
+	}
 	s.render(w, r, "analytics.html", map[string]any{
 		"User":               u,
 		"IsAdmin":            isAdmin,
@@ -602,6 +620,7 @@ func (s *Server) getAnalytics(w http.ResponseWriter, r *http.Request) {
 		"Status":             statusBuckets,
 		"IngestStats":        ingestStats,
 		"AnalyticsEnabled":   cfg.Enabled,
+		"ScopeIngest":        scopeIngest,
 		// Server-switcher data. AllServers feeds the <select>; the template
 		// only renders the picker when len > 1 so a one-server deployment
 		// doesn't get a useless dropdown. SelectedServerID is 0 for "all

--- a/internal/server/caddy_logs.go
+++ b/internal/server/caddy_logs.go
@@ -54,7 +54,7 @@ func (s *Server) ReconcileCertificateLogs() error {
 			continue
 		}
 		client := newCaddyClient(server.AdminURL, server.AdminUsername, server.AdminPassword)
-		if err := client.EnableCertificateLogs(cfg.Target, caddyLogOptions(server, cfg)); err != nil {
+		if err := client.EnableCertificateLogs(server.EffectiveIngestTarget(cfg.Target), caddyLogOptions(server, cfg)); err != nil { // v2.37.0
 			failures = append(failures, fmt.Sprintf("%s: %v", server.Name, err))
 		}
 	}
@@ -422,7 +422,7 @@ func (s *Server) enableRuntimeLogCapture(server models.CaddyServer, cfg analytic
 	defer s.runtimeLogMu.Unlock()
 
 	client := newCaddyClient(server.AdminURL, server.AdminUsername, server.AdminPassword)
-	if err := client.EnableRuntimeLogs(cfg.Target, level, caddyLogOptions(server, cfg)); err != nil {
+	if err := client.EnableRuntimeLogs(server.EffectiveIngestTarget(cfg.Target), level, caddyLogOptions(server, cfg)); err != nil { // v2.37.0
 		return err
 	}
 

--- a/internal/server/caddy_servers.go
+++ b/internal/server/caddy_servers.go
@@ -59,12 +59,30 @@ func (s *Server) listServersPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// v2.37.0: effective log-ingest target per managed node, plus a warning
+	// when a remote node was handed a bare Docker service name it can't
+	// resolve — the silent cause of "analytics is empty for that server".
+	analyticsCfg := loadAnalyticsConfig(s.DB)
+	ingestTargets := map[int64]string{}
+	ingestWarnings := map[int64]string{}
+	for _, sr := range servers {
+		if sr.Type != models.CaddyServerTypeManaged {
+			continue
+		}
+		target := sr.EffectiveIngestTarget(analyticsCfg.Target)
+		ingestTargets[sr.ID] = target
+		if warn := sr.IngestTargetWarning(target); warn != "" {
+			ingestWarnings[sr.ID] = warn
+		}
+	}
 	s.render(w, r, "servers.html", map[string]any{
-		"User":    s.currentUser(r),
-		"Servers": servers,
-		"Section": "servers",
-		"Flash":   strings.TrimSpace(r.URL.Query().Get("flash")),
-		"Error":   strings.TrimSpace(r.URL.Query().Get("error")),
+		"User":           s.currentUser(r),
+		"Servers":        servers,
+		"IngestTargets":  ingestTargets,
+		"IngestWarnings": ingestWarnings,
+		"Section":        "servers",
+		"Flash":          strings.TrimSpace(r.URL.Query().Get("flash")),
+		"Error":          strings.TrimSpace(r.URL.Query().Get("error")),
 	})
 }
 
@@ -120,6 +138,7 @@ func (s *Server) createServer(w http.ResponseWriter, r *http.Request) {
 		Version:       strings.TrimSpace(r.FormValue("version")),
 		AdminUsername: strings.TrimSpace(r.FormValue("admin_username")),
 		AdminPassword: r.FormValue("admin_password"),
+		IngestTarget:  strings.TrimSpace(r.FormValue("ingest_target")), // v2.37.0
 	}
 	renderErr := func(msg string) {
 		s.render(w, r, "server_form.html", map[string]any{
@@ -187,6 +206,7 @@ func (s *Server) updateServer(w http.ResponseWriter, r *http.Request) {
 	existing.Tags = strings.TrimSpace(r.FormValue("tags"))
 	existing.Version = strings.TrimSpace(r.FormValue("version"))
 	existing.AdminUsername = strings.TrimSpace(r.FormValue("admin_username"))
+	existing.IngestTarget = strings.TrimSpace(r.FormValue("ingest_target")) // v2.37.0
 	// Password: if the form submitted a blank value AND the user didn't explicitly
 	// check the "clear password" box, keep the existing one. Protects against
 	// masked-field UX where the password isn't re-typed on every edit.

--- a/internal/server/caddy_servers_ingest_test.go
+++ b/internal/server/caddy_servers_ingest_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"path/filepath"
+	"testing"
+
+	appdb "github.com/X4Applegate/caddyui/internal/db"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// v2.37.0: the per-node ingest target must survive create → get → list →
+// update, and the migration must add the column to an existing database.
+func TestCaddyServerIngestTargetRoundTrips(t *testing.T) {
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	id, err := models.CreateCaddyServer(conn, &models.CaddyServer{Name: "Richard Prod", AdminURL: "http://10.8.0.3:2019", Type: "managed", IngestTarget: " 10.8.0.1:9019 "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := models.GetCaddyServer(conn, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.IngestTarget != "10.8.0.1:9019" {
+		t.Fatalf("GetCaddyServer ingest target = %q, want trimmed 10.8.0.1:9019", got.IngestTarget)
+	}
+	if got.EffectiveIngestTarget("caddyui:9019") != "10.8.0.1:9019" || got.IngestTargetWarning(got.EffectiveIngestTarget("caddyui:9019")) != "" {
+		t.Errorf("configured node should use its own target with no warning: %+v", got)
+	}
+	list, err := models.ListCaddyServers(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, sr := range list {
+		if sr.ID == id {
+			found = sr.IngestTarget == "10.8.0.1:9019"
+		}
+	}
+	if !found {
+		t.Fatalf("ListCaddyServers lost the ingest target: %+v", list)
+	}
+	got.IngestTarget = ""
+	if err := models.UpdateCaddyServer(conn, got); err != nil {
+		t.Fatal(err)
+	}
+	again, _ := models.GetCaddyServer(conn, id)
+	if again.IngestTarget != "" {
+		t.Errorf("after clearing, ingest target = %q", again.IngestTarget)
+	}
+	if w := again.IngestTargetWarning(again.EffectiveIngestTarget("caddyui:9019")); w == "" {
+		t.Error("a remote node back on the Docker-name default must be warned about")
+	}
+}

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -396,6 +396,28 @@ func TestAdvancedRouteListenIsSurfaced(t *testing.T) {
 	}
 }
 
+// TestPerNodeIngestTargetIsSurfaced guards v2.37.0: the server form must offer
+// the per-node log ingest target, the Fleet list must show each node's
+// effective target and the unreachable-target warning, and the Analytics page
+// must explain the scoped node's target when it has no traffic.
+func TestPerNodeIngestTargetIsSurfaced(t *testing.T) {
+	for file, markers := range map[string][]string{
+		"templates/server_form.html": {`name="ingest_target"`, "{{.Target.IngestTarget}}"},
+		"templates/servers.html":     {"$.IngestTargets", "$.IngestWarnings"},
+		"templates/analytics.html":   {".ScopeIngest"},
+	} {
+		body, err := FS.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		for _, m := range markers {
+			if !strings.Contains(string(body), m) {
+				t.Errorf("%s missing %q", file, m)
+			}
+		}
+	}
+}
+
 // TestCSRFClientPlumbing guards the two client-side halves of CSRF protection.
 // The hidden form input is stamped into rendered HTML server-side (see
 // csrfInjectForms), but scripted callers depend on these two pieces: the meta

--- a/web/templates/analytics.html
+++ b/web/templates/analytics.html
@@ -172,6 +172,10 @@
           <p class="text-xs text-ink-500 mt-1 max-w-sm mx-auto">
           {{if .IsAdmin}}{{if .AnalyticsEnabled}}Waiting for Caddy to ship its first access log entry. Make sure your Caddy container can resolve the ingest target.{{else}}Enable access log forwarding in <a href="/settings#analytics" class="underline">Settings → Analytics</a>.{{end}}{{else}}No traffic has been recorded for the hosts you own yet.{{end}}
           </p>
+          {{/* v2.37.0: with one node in scope, say where it ships its logs and why that may fail */}}
+          {{with .ScopeIngest}}{{if $.IsAdmin}}
+          <p class="text-xs text-ink-500 mt-2 max-w-md mx-auto">{{.ServerName}} sends its logs to <code class="font-mono text-ink-700">{{.Target}}</code>{{if .Warning}} — <span class="text-amber-700">{{.Warning}}</span> <a href="/servers/{{.ServerID}}/edit" class="underline">Set its ingest target.</a>{{else}}.{{end}}</p>
+          {{end}}{{end}}
         </td>
       </tr>
       {{end}}

--- a/web/templates/server_form.html
+++ b/web/templates/server_form.html
@@ -51,6 +51,16 @@
         </ul>
       </div>
     </div>
+
+    {{/* v2.37.0: per-node log ingest target. One fleet-wide target defaulted to
+         a Docker service name that nodes on other hosts can't resolve, so they
+         silently shipped nothing. */}}
+    <div>
+      <label class="block text-sm font-medium text-ink-800 mb-1.5">Log ingest target <span class="text-ink-400 font-normal text-xs">(optional — host:port this node sends its logs to)</span></label>
+      <input type="text" name="ingest_target" value="{{.Target.IngestTarget}}" placeholder="blank = fleet-wide target from Settings → Analytics"
+        class="w-full px-3 py-2 border border-ink-200 rounded-lg text-sm font-mono bg-white focus:outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 transition" />
+      <p class="text-xs text-ink-500 mt-1.5">CaddyUI configures this node to ship its access logs, certificate events and runtime logs here — that is what powers Analytics, certificate status and Server Logs for it. Blank uses the fleet-wide target from Settings → Analytics (default <code class="bg-ink-100 px-1 rounded font-mono">caddyui:9019</code>), which only works for a Caddy on the same Docker network as CaddyUI. A node on another host needs an address it can actually reach — the CaddyUI host as seen from that node, e.g. <code class="bg-ink-100 px-1 rounded font-mono">10.8.0.1:9019</code> over a VPN or <code class="bg-ink-100 px-1 rounded font-mono">192.168.1.10:9019</code> on a LAN — with port 9019 published on the CaddyUI container.</p>
+    </div>
   </div>
 
   {{/* ── Optional Basic Auth for the admin endpoint ── */}}

--- a/web/templates/servers.html
+++ b/web/templates/servers.html
@@ -76,7 +76,9 @@
               {{else if eq .Status "offline"}}<span class="ui-status ui-status--danger">Offline</span>
               {{else}}<span class="ui-status ui-status--neutral">Unknown</span>{{end}}
             </td>
-            <td><code class="fleet-endpoint" title="{{.AdminURL}}">{{.AdminURL}}</code></td>
+            <td><code class="fleet-endpoint" title="{{.AdminURL}}">{{.AdminURL}}</code>
+              {{/* v2.37.0: where this node ships its logs, with a warning when it plainly can't get there */}}
+              {{$sid := .ID}}{{with index $.IngestTargets .ID}}<div class="text-xs text-ink-400 mt-1">logs → <code class="font-mono">{{.}}</code></div>{{end}}{{with index $.IngestWarnings $sid}}<div class="text-xs text-amber-700 mt-1" title="{{.}}">⚠ this node can't reach its log target — <a href="/servers/{{$sid}}/edit" class="underline">set one it can</a></div>{{end}}</td>
             <td>
               {{if eq .Type "managed"}}<span class="ui-status ui-status--automation">Managed</span>
               {{else}}<span class="ui-status ui-status--neutral">External</span>{{end}}
@@ -129,6 +131,7 @@
               {{if and $.CurrentServer (eq $.CurrentServer.ID .ID)}}<span class="ui-status ui-status--info">Current</span>{{end}}
             </div>
             <code class="fleet-endpoint">{{.AdminURL}}</code>
+            {{$sid := .ID}}{{with index $.IngestTargets .ID}}<div class="text-xs text-ink-400 mt-1">logs → <code class="font-mono">{{.}}</code></div>{{end}}{{with index $.IngestWarnings $sid}}<div class="text-xs text-amber-700 mt-1" title="{{.}}">⚠ this node can't reach its log target — <a href="/servers/{{$sid}}/edit" class="underline">set one it can</a></div>{{end}}
           </div>
           {{if eq .Status "online"}}<span class="ui-status ui-status--success">Online</span>
           {{else if eq .Status "offline"}}<span class="ui-status ui-status--danger">Offline</span>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -1169,6 +1169,7 @@
         Default <code class="font-mono text-ink-700">{{.AnalyticsTargetPlaceholder}}</code> assumes both containers share a Docker network and CaddyUI's service name is <code class="font-mono">caddyui</code>.
         On host-network deployments use <code class="font-mono">host.docker.internal:9019</code> (macOS/Windows) or the LAN IP (Linux).
         The listener binds on <code class="font-mono">:9019</code> inside the CaddyUI container — no host port exposed by default.
+        Nodes on <em>other hosts</em> cannot resolve Docker service names: give each remote node its own ingest target on its <a href="/servers" class="underline">Caddy Fleet</a> entry (the CaddyUI host as that node sees it, e.g. <code class="font-mono">10.8.0.1:9019</code>) and publish port 9019.
       </p>
     </div>
 


### PR DESCRIPTION
## Summary
Analytics (and certificate status, and Server Logs capture) were empty for every node except the local one on a five-node fleet. Cause: all nodes are configured to ship logs to the one fleet-wide ingest target, whose default `caddyui:9019` is a Docker service name only a Caddy on CaddyUI's own Docker network can resolve. Remote nodes' `net` log writers silently dial nothing. Verified read-only on the affected fleet: every remote node's `caddyui_access`/`caddyui_certificates`/`caddyui_certificate_events` loggers had `writer.address = caddyui:9019`, and `access_events` had rows only for `server_id = 1`.

- **Per-node target:** `caddy_servers.ingest_target` (migration; blank = fleet-wide setting) + `CaddyServer.EffectiveIngestTarget`, used by `EnableAccessLogs`, `EnableCertificateLogs` and `EnableRuntimeLogs` — i.e. all three streams.
- **Surface it:** "Log ingest target" field on the server form; the Fleet list shows each managed node's effective target and a warning (`IngestTargetWarning`) when a node reached at another host (IP or dotted name) was handed a bare Docker name — the unambiguous case only; nodes reached at a bare name share CaddyUI's network, unix sockets are left alone. The Analytics empty state names the scoped node's target and the same warning. Settings → Analytics copy points remote nodes at the per-node field.
- CHANGELOG v2.37.0.

## Test plan
- [x] Unit: `EffectiveIngestTarget`, `LooksDockerInternalHost`, `IngestTargetWarning` (remote+Docker name warns; remote+reachable, local bare-name, localhost, unix socket don't); DB round-trip incl. migration on a fresh DB; template guards. Full `go test ./...` green; vet/gofmt clean.
- [x] End to end against a throwaway real Caddy reached by IP: with the default target the Fleet page shows `logs → caddyui:9019` **and** the warning, and the scoped Analytics page explains it; after setting `host.docker.internal:19019` on the node's form, Caddy's `caddyui_access` writer address changed to it (with `caddyui_server_id` stamped) and the warning cleared. Event delivery itself couldn't be exercised in the sandbox (this host blocks container→host traffic, `nc` confirmed) — that path is Caddy's unchanged `net` writer.

Operator note: after upgrading, set each remote node's Log ingest target to the CaddyUI host's address as that node sees it (e.g. `10.8.0.1:9019` over the VPN); the Fleet page tells you which nodes need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)