### PR TITLE
feat: Advanced config accepts a reverse_proxy block, explains bare sub-directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.40.0] - 2026-09-08 - Advanced config accepts a reverse_proxy block
+
+### Added
+
+- A proxy host's **Advanced config** can now carry a `reverse_proxy { … }` block with no upstream address. Its sub-directives — `flush_interval -1`, `header_up` / `header_down`, `transport http { … }`, `lb_policy`, active and passive health checks, `trusted_proxies`, and the rest — are adapted through Caddy and merged into the host's own generated `reverse_proxy` handler, so the Forward host / port and every option in the form still apply and nested settings (a `transport` with TLS already configured, upstream request headers) combine rather than replace. Blocks that name an upstream or sit behind a matcher are refused with a message saying why.
+
+### Fixed
+
+- Typing a reverse_proxy sub-directive bare in Advanced config — the reported case was `flush_interval -1` — came back from Caddy as `Caddyfile:2: unrecognized directive: flush_interval`, which says nothing about what to do. CaddyUI now catches every reverse_proxy sub-directive at the top level before adapting and explains that it belongs inside a `reverse_proxy { … }` block (with the block spelled out), and points at the dedicated form option where one exists (Streaming → Flush immediately for `flush_interval`).
+- The form's help text listed `reverse_proxy` among the rejected directives; it now describes the block instead.
+
+---
+
 ## [2.39.0] - 2026-09-08 - File-path certificates show expiry via a live TLS probe
 
 ### Added

--- a/internal/caddy/overrides.go
+++ b/internal/caddy/overrides.go
@@ -1,0 +1,75 @@
+package caddy
+
+// v2.40.0: a proxy host's Advanced config may carry a `reverse_proxy { … }`
+// block whose sub-directives (flush_interval, header_up, transport,
+// lb_policy, health checks, …) belong inside the host's own reverse_proxy
+// handler rather than in front of it. The server adapts that block through
+// Caddy and hands the resulting handler fields here to be folded into the
+// generated handler.
+
+// MergeReverseProxyOverrides deep-merges overrides into the first
+// reverse_proxy handler found in route (descending into subroutes).
+// "handler" and "upstreams" are never taken from overrides — the upstream
+// comes from Forward host / port. Nested maps merge key by key with the
+// override winning on conflicts; any other value replaces the generated one
+// outright. Returns false when route has no reverse_proxy handler (for
+// example a host in maintenance mode), in which case nothing changes.
+func MergeReverseProxyOverrides(route map[string]any, overrides map[string]any) bool {
+	if len(overrides) == 0 {
+		return false
+	}
+	rp := findReverseProxyHandler(route)
+	if rp == nil {
+		return false
+	}
+	for k, v := range overrides {
+		if k == "handler" || k == "upstreams" {
+			continue
+		}
+		rp[k] = mergeValue(rp[k], v)
+	}
+	return true
+}
+
+func findReverseProxyHandler(route map[string]any) map[string]any {
+	handlers, _ := route["handle"].([]any)
+	for _, h := range handlers {
+		hm, ok := h.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch hm["handler"] {
+		case "reverse_proxy":
+			return hm
+		case "subroute":
+			routes, _ := hm["routes"].([]any)
+			for _, r := range routes {
+				if rm, ok := r.(map[string]any); ok {
+					if found := findReverseProxyHandler(rm); found != nil {
+						return found
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// mergeValue returns src merged over dst: two maps merge recursively (a
+// fresh map, so the generated config is never aliased), anything else is
+// replaced by src.
+func mergeValue(dst, src any) any {
+	dm, dok := dst.(map[string]any)
+	sm, sok := src.(map[string]any)
+	if !dok || !sok {
+		return src
+	}
+	out := make(map[string]any, len(dm)+len(sm))
+	for k, v := range dm {
+		out[k] = v
+	}
+	for k, v := range sm {
+		out[k] = mergeValue(out[k], v)
+	}
+	return out
+}

--- a/internal/caddy/overrides_test.go
+++ b/internal/caddy/overrides_test.go
@@ -1,0 +1,51 @@
+package caddy
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// v2.40.0: a reverse_proxy block from the Advanced config is folded into the
+// host's generated handler — nested maps merge, the override wins on
+// conflicts, and the upstream is never taken from it.
+func TestMergeReverseProxyOverrides(t *testing.T) {
+	p := models.ProxyHost{Domains: "app.example.test", ForwardScheme: "https", ForwardHost: "app", ForwardPort: 8443, Enabled: true, SSLEnabled: true}
+	route := BuildProxyRoute(p, nil)
+	overrides := map[string]any{
+		"handler":        "reverse_proxy",
+		"upstreams":      []any{map[string]any{"dial": "evil:1"}},
+		"flush_interval": -1,
+		"transport":      map[string]any{"protocol": "http", "read_timeout": 30000000000, "tls": map[string]any{"server_name": "inner.example.test"}},
+		"headers":        map[string]any{"request": map[string]any{"set": map[string]any{"X-Real-Ip": []any{"{http.request.remote.host}"}}}},
+	}
+	if !MergeReverseProxyOverrides(route, overrides) {
+		t.Fatal("expected the reverse_proxy handler to be found")
+	}
+	rp := findReverseProxyHandler(route)
+	if rp["flush_interval"] != -1 {
+		t.Errorf("flush_interval = %v", rp["flush_interval"])
+	}
+	if ups := rp["upstreams"].([]any); !reflect.DeepEqual(ups[0], map[string]any{"dial": "app:8443"}) {
+		t.Errorf("upstreams must stay as generated, got %v", ups)
+	}
+	transport := rp["transport"].(map[string]any)
+	tlsCfg := transport["tls"].(map[string]any)
+	if transport["read_timeout"] != 30000000000 || tlsCfg["server_name"] != "inner.example.test" || tlsCfg["insecure_skip_verify"] != true {
+		t.Errorf("transport should merge generated TLS settings with the override: %v", transport)
+	}
+	set := rp["headers"].(map[string]any)["request"].(map[string]any)["set"].(map[string]any)
+	if _, ok := set["X-Real-Ip"]; !ok {
+		t.Errorf("header_up should be merged into headers.request.set: %v", set)
+	}
+	if !MergeReverseProxyOverrides(map[string]any{"handle": []any{map[string]any{"handler": "subroute", "routes": []any{map[string]any{"handle": []any{map[string]any{"handler": "reverse_proxy"}}}}}}}, map[string]any{"flush_interval": -1}) {
+		t.Error("a reverse_proxy inside a subroute should be found")
+	}
+	if MergeReverseProxyOverrides(map[string]any{"handle": []any{map[string]any{"handler": "static_response"}}}, overrides) {
+		t.Error("no reverse_proxy handler means nothing to merge")
+	}
+	if MergeReverseProxyOverrides(route, nil) {
+		t.Error("empty overrides must be a no-op")
+	}
+}

--- a/internal/server/proxy_advanced_overrides.go
+++ b/internal/server/proxy_advanced_overrides.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+)
+
+// v2.40.0: the proxy host's Advanced config box wraps its directives in a
+// site block and adapts them through Caddy; the resulting handlers run
+// before the host's own reverse_proxy. Anything that belongs *inside*
+// reverse_proxy — flush_interval, header_up, transport, lb_policy, health
+// checks — therefore had no home: typed bare it came back from Caddy as
+// "Caddyfile:2: unrecognized directive: flush_interval", and a reverse_proxy
+// block was rejected as a second terminal handler. Now a reverse_proxy block
+// with no upstream is accepted and its sub-directives are merged into the
+// host's generated handler (see caddy.MergeReverseProxyOverrides), and a
+// bare sub-directive gets an error that says where it goes.
+
+// reverseProxySubdirectives is every sub-directive of Caddy's reverse_proxy
+// directive. Seen at the top level of an Advanced config they are a sure
+// sign the user meant the reverse_proxy block.
+var reverseProxySubdirectives = []string{
+	"to", "dynamic",
+	"lb_policy", "lb_retries", "lb_try_duration", "lb_try_interval", "lb_retry_match",
+	"health_uri", "health_upstream", "health_port", "health_interval", "health_timeout",
+	"health_status", "health_body", "health_method", "health_request_body",
+	"health_follow_redirects", "health_headers", "health_passes", "health_fails",
+	"fail_duration", "max_fails", "unhealthy_status", "unhealthy_latency", "unhealthy_request_count",
+	"flush_interval", "request_buffers", "response_buffers", "stream_timeout", "stream_close_delay",
+	"buffer_requests", "buffer_responses", "max_buffer_size", "verbose_logs",
+	"trusted_proxies", "header_up", "header_down", "method", "rewrite",
+	"transport", "replace_status", "handle_response", "copy_response", "copy_response_headers",
+}
+
+// reverseProxySubdirectiveError explains a bare reverse_proxy sub-directive
+// at the top level of an Advanced config, or returns "" when there is none.
+func reverseProxySubdirectiveError(src string) string {
+	bad := scanTopLevelDirective(src, reverseProxySubdirectives)
+	if bad == "" {
+		return ""
+	}
+	hint := ""
+	switch bad {
+	case "flush_interval":
+		hint = " This one also has a dedicated option: Streaming → Flush immediately / Flush interval."
+	case "header_up", "header_down":
+		hint = " Upstream request/response headers also have dedicated options under Headers."
+	case "transport":
+		hint = " Timeouts, TLS and HTTP version to the upstream also have dedicated options under Upstream."
+	case "lb_policy", "lb_retries", "lb_try_duration", "lb_try_interval":
+		hint = " Load balancing also has dedicated options under Upstreams."
+	}
+	return fmt.Sprintf("`%s` is a reverse_proxy sub-directive, not a site directive, so Caddy rejects it here. Wrap it in a reverse_proxy block and CaddyUI merges it into this host's own reverse_proxy:\n\nreverse_proxy {\n    %s …\n}\n\nLeave the upstream address out — it comes from Forward host / port.%s", bad, bad, hint)
+}
+
+// extractReverseProxyOverrides removes the reverse_proxy handler that a
+// `reverse_proxy { … }` block in the Advanced config adapted to — walking
+// into the subroute Caddy wraps site directives in — and returns the
+// remaining handlers (which still run before the proxy) plus that handler's
+// fields, ready for caddy.MergeReverseProxyOverrides. It is an error for the
+// block to name an upstream or to sit behind a matcher: neither can be
+// folded into the host's single generated handler.
+func extractReverseProxyOverrides(handlers []any) ([]any, map[string]any, error) {
+	var overrides map[string]any
+	var walk func(hs []any, matched bool) ([]any, error)
+	walk = func(hs []any, matched bool) ([]any, error) {
+		out := make([]any, 0, len(hs))
+		for _, h := range hs {
+			hm, ok := h.(map[string]any)
+			if !ok {
+				out = append(out, h)
+				continue
+			}
+			switch hm["handler"] {
+			case "reverse_proxy":
+				if matched {
+					return nil, fmt.Errorf("a reverse_proxy block behind a matcher can't be merged into this host's reverse_proxy — create an Advanced route for a matched proxy")
+				}
+				if overrides != nil {
+					return nil, fmt.Errorf("Advanced config may contain only one reverse_proxy block")
+				}
+				if ups, _ := hm["upstreams"].([]any); len(ups) > 0 {
+					return nil, fmt.Errorf("the reverse_proxy block in Advanced config must not name an upstream — the address comes from Forward host / port; keep only sub-directives such as flush_interval, header_up or transport")
+				}
+				overrides = map[string]any{}
+				for k, v := range hm {
+					if k != "handler" && k != "upstreams" {
+						overrides[k] = v
+					}
+				}
+			case "subroute":
+				routes, _ := hm["routes"].([]any)
+				kept := make([]any, 0, len(routes))
+				for _, r := range routes {
+					rm, ok := r.(map[string]any)
+					if !ok {
+						kept = append(kept, r)
+						continue
+					}
+					_, hasMatch := rm["match"]
+					inner, _ := rm["handle"].([]any)
+					newInner, err := walk(inner, matched || hasMatch)
+					if err != nil {
+						return nil, err
+					}
+					if len(inner) > 0 && len(newInner) == 0 {
+						continue // the block was this route's only handler
+					}
+					copyRoute := make(map[string]any, len(rm))
+					for k, v := range rm {
+						copyRoute[k] = v
+					}
+					copyRoute["handle"] = newInner
+					kept = append(kept, copyRoute)
+				}
+				if len(routes) > 0 && len(kept) == 0 {
+					continue
+				}
+				copyHandler := make(map[string]any, len(hm))
+				for k, v := range hm {
+					copyHandler[k] = v
+				}
+				copyHandler["routes"] = kept
+				out = append(out, copyHandler)
+			default:
+				out = append(out, hm)
+			}
+		}
+		return out, nil
+	}
+	rest, err := walk(handlers, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rest, overrides, nil
+}
+
+// describeOverrides lists the merged sub-directive keys for log lines.
+func describeOverrides(overrides map[string]any) string {
+	if len(overrides) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(overrides))
+	for k := range overrides {
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, ", ")
+}

--- a/internal/server/proxy_advanced_overrides_test.go
+++ b/internal/server/proxy_advanced_overrides_test.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/X4Applegate/caddyui/internal/caddy"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// adaptedAdvanced mimics what Caddy's adapter returns for a site block: a
+// subroute wrapping one route per directive group.
+func adaptedAdvanced(routes ...map[string]any) []any {
+	rs := make([]any, 0, len(routes))
+	for _, r := range routes {
+		rs = append(rs, r)
+	}
+	return []any{map[string]any{"handler": "subroute", "routes": rs}}
+}
+
+// v2.40.0: a reverse_proxy block is lifted out of the pre-handlers and its
+// fields returned for merging; the other directives keep running before the
+// proxy; matched or upstream-bearing blocks are refused.
+func TestExtractReverseProxyOverrides(t *testing.T) {
+	headers := map[string]any{"handler": "headers", "response": map[string]any{"set": map[string]any{"X-Frame-Options": []any{"DENY"}}}}
+	rp := map[string]any{"handler": "reverse_proxy", "flush_interval": -1, "headers": map[string]any{"request": map[string]any{"set": map[string]any{"X-Real-Ip": []any{"{http.request.remote.host}"}}}}}
+
+	rest, overrides, err := extractReverseProxyOverrides(adaptedAdvanced(map[string]any{"handle": []any{headers, rp}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if overrides["flush_interval"] != -1 || overrides["handler"] != nil || overrides["headers"] == nil {
+		t.Errorf("overrides = %v", overrides)
+	}
+	sub := rest[0].(map[string]any)
+	kept := sub["routes"].([]any)[0].(map[string]any)["handle"].([]any)
+	if len(rest) != 1 || len(kept) != 1 || kept[0].(map[string]any)["handler"] != "headers" {
+		t.Errorf("the headers handler should remain before the proxy: %v", rest)
+	}
+
+	// A block that was the only directive leaves no pre-handlers at all.
+	rest, overrides, err = extractReverseProxyOverrides(adaptedAdvanced(map[string]any{"handle": []any{rp}}))
+	if err != nil || len(rest) != 0 || overrides["flush_interval"] != -1 {
+		t.Errorf("only-block: rest=%v overrides=%v err=%v", rest, overrides, err)
+	}
+
+	// No block at all: handlers pass through untouched.
+	rest, overrides, err = extractReverseProxyOverrides(adaptedAdvanced(map[string]any{"handle": []any{headers}}))
+	if err != nil || overrides != nil || len(rest) != 1 {
+		t.Errorf("no block: rest=%v overrides=%v err=%v", rest, overrides, err)
+	}
+
+	withUpstream := map[string]any{"handler": "reverse_proxy", "upstreams": []any{map[string]any{"dial": "other:80"}}}
+	if _, _, err := extractReverseProxyOverrides(adaptedAdvanced(map[string]any{"handle": []any{withUpstream}})); err == nil || !strings.Contains(err.Error(), "Forward host / port") {
+		t.Errorf("an upstream in the block must be refused, got %v", err)
+	}
+	matched := map[string]any{"match": []any{map[string]any{"path": []any{"/api/*"}}}, "handle": []any{rp}}
+	if _, _, err := extractReverseProxyOverrides(adaptedAdvanced(matched)); err == nil || !strings.Contains(err.Error(), "matcher") {
+		t.Errorf("a matched block must be refused, got %v", err)
+	}
+	if _, _, err := extractReverseProxyOverrides(adaptedAdvanced(map[string]any{"handle": []any{rp, rp}})); err == nil || !strings.Contains(err.Error(), "only one") {
+		t.Errorf("two blocks must be refused, got %v", err)
+	}
+}
+
+// Bare sub-directives are explained before Caddy ever sees them; a
+// reverse_proxy block is no longer banned; terminal handlers still are.
+func TestValidateProxyAdvancedDirectivesExplainsSubdirectives(t *testing.T) {
+	msg := validateProxyAdvancedDirectives("flush_interval -1\nencode gzip")
+	if !strings.Contains(msg, "`flush_interval` is a reverse_proxy sub-directive") || !strings.Contains(msg, "reverse_proxy {") || !strings.Contains(msg, "Flush immediately") {
+		t.Errorf("flush_interval message = %q", msg)
+	}
+	if msg := validateProxyAdvancedDirectives("header_up X-Real-IP {remote_host}"); !strings.Contains(msg, "`header_up`") {
+		t.Errorf("header_up message = %q", msg)
+	}
+	if msg := validateProxyAdvancedDirectives("reverse_proxy {\n\tflush_interval -1\n\theader_up X-Real-IP {remote_host}\n}\nencode gzip"); msg != "" {
+		t.Errorf("a reverse_proxy block must pass validation, got %q", msg)
+	}
+	if msg := validateProxyAdvancedDirectives("respond \"hi\""); !strings.Contains(msg, "`respond`") {
+		t.Errorf("respond must still be banned, got %q", msg)
+	}
+	// Inside a block the words are not directives.
+	if msg := validateProxyAdvancedDirectives("request_body {\n\tmax_size 10MB\n}\n"); msg != "" {
+		t.Errorf("nested lines must not trigger, got %q", msg)
+	}
+}
+
+// Opt-in end-to-end check against a real Caddy admin API: adapt a block
+// through /adapt and merge it into a built route. Set
+// CADDYUI_TEST_CADDY_ADMIN=http://127.0.0.1:2019 to run it.
+func TestAdvancedReverseProxyBlockThroughRealCaddy(t *testing.T) {
+	admin := os.Getenv("CADDYUI_TEST_CADDY_ADMIN")
+	if admin == "" {
+		t.Skip("CADDYUI_TEST_CADDY_ADMIN not set")
+	}
+	s := &Server{}
+	p := models.ProxyHost{Domains: "app.example.test", ForwardScheme: "http", ForwardHost: "app", ForwardPort: 8080, Enabled: true,
+		AdvancedConfig: "header X-Frame-Options DENY\nreverse_proxy {\n\tflush_interval -1\n\theader_up X-Real-IP {remote_host}\n\ttransport http {\n\t\tread_timeout 30s\n\t}\n}\n"}
+	handlers, overrides, err := s.adaptProxyAdvancedWithClient(caddy.New(admin, "", ""), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	route := caddy.BuildProxyRoute(p, handlers)
+	if !caddy.MergeReverseProxyOverrides(route, overrides) {
+		t.Fatal("merge found no reverse_proxy handler")
+	}
+	rp := route["handle"].([]any)[len(route["handle"].([]any))-1].(map[string]any)
+	if rp["handler"] != "reverse_proxy" || rp["flush_interval"] != float64(-1) && rp["flush_interval"] != -1 {
+		t.Errorf("flush_interval not merged: %v", rp)
+	}
+	if rp["upstreams"].([]any)[0].(map[string]any)["dial"] != "app:8080" {
+		t.Errorf("upstream must come from the form: %v", rp["upstreams"])
+	}
+	if rp["transport"].(map[string]any)["read_timeout"] == nil {
+		t.Errorf("transport read_timeout not merged: %v", rp["transport"])
+	}
+	if s.validateProxyAdvanced(caddy.New(admin, "", ""), &p) != "" {
+		t.Errorf("validateProxyAdvanced should accept the block")
+	}
+	bare := p
+	bare.AdvancedConfig = "flush_interval -1"
+	if msg := s.validateProxyAdvanced(caddy.New(admin, "", ""), &bare); !strings.Contains(msg, "sub-directive") {
+		t.Errorf("bare sub-directive should be explained, got %q", msg)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8406,7 +8406,7 @@ func (s *Server) validateProxyAdvanced(caddyCl *caddy.Client, p *models.ProxyHos
 	if errMsg := validateProxyAdvancedDirectives(p.AdvancedConfig); errMsg != "" {
 		return errMsg
 	}
-	if _, err := s.adaptProxyAdvancedWithClient(caddyCl, *p); err != nil {
+	if _, _, err := s.adaptProxyAdvancedWithClient(caddyCl, *p); err != nil {
 		return "Advanced config rejected by Caddy: " + err.Error()
 	}
 	return ""
@@ -8419,11 +8419,15 @@ func validateProxyAdvancedDirectives(src string) string {
 	// any of these as top-level directives here would splice a second terminal
 	// handler before it, silently breaking routing. Reject at save time rather
 	// than waiting for the sync to succeed with a broken result.
-	banned := []string{"reverse_proxy", "redir", "respond", "file_server"}
+	// v2.40.0: reverse_proxy is no longer banned — a `reverse_proxy { … }`
+	// block with no upstream is merged into the host's own handler (see
+	// proxy_advanced_overrides.go); one that names an upstream or sits
+	// behind a matcher is rejected after adapting.
+	banned := []string{"redir", "respond", "file_server"}
 	if bad := scanTopLevelDirective(src, banned); bad != "" {
 		return fmt.Sprintf("Advanced config can't contain `%s` — this field runs BEFORE the proxy's own reverse_proxy handler. Put request-side directives here (header, encode, request_body, rewrite, etc.) and let the Forward host/port handle the upstream.", bad)
 	}
-	return ""
+	return reverseProxySubdirectiveError(src)
 }
 
 // scanTopLevelDirective returns the first top-level (brace-depth 0) directive
@@ -8484,22 +8488,25 @@ func (s *Server) renderProxyHostFormError(w http.ResponseWriter, r *http.Request
 // adapter has a valid site-address context. The adapter normally enforces
 // directive order inside the site block, so we get a handle[] list in the
 // correct order — we return that list untouched for the caller to splice in.
-func (s *Server) adaptProxyAdvanced(p models.ProxyHost) ([]any, error) {
+func (s *Server) adaptProxyAdvanced(p models.ProxyHost) ([]any, map[string]any, error) {
 	return s.adaptProxyAdvancedWithClient(s.Caddy, p)
 }
 
-func (s *Server) adaptProxyAdvancedWithClient(caddyCl *caddy.Client, p models.ProxyHost) ([]any, error) {
+// adaptProxyAdvancedWithClient adapts the Advanced config through Caddy and
+// returns the handlers that run before the host's reverse_proxy plus, since
+// v2.40.0, the fields of a `reverse_proxy { … }` block to merge into it.
+func (s *Server) adaptProxyAdvancedWithClient(caddyCl *caddy.Client, p models.ProxyHost) ([]any, map[string]any, error) {
 	src := fmt.Sprintf("localhost {\n%s\n}\n", p.AdvancedConfig)
 	adapted, err := caddyCl.Adapt(src)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	routes := extractAdaptedRoutes(adapted.Result)
 	if len(routes) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	handle, _ := routes[0]["handle"].([]any)
-	return handle, nil
+	return extractReverseProxyOverrides(handle)
 }
 
 // --- build helpers ---
@@ -8524,18 +8531,21 @@ func (s *Server) buildMergedRoutes(proxies []models.ProxyHost, redirs []models.R
 			}
 		}
 		var advanced []any
+		var advancedOverrides map[string]any
 		if strings.TrimSpace(p.AdvancedConfig) != "" {
-			h, err := s.adaptProxyAdvanced(p)
+			h, overrides, err := s.adaptProxyAdvanced(p)
 			if err != nil {
 				// Don't fail the whole sync — log and push the route without advanced
 				// handlers. The form-level validation should have caught bad syntax
 				// before save, so this branch is for rare drift cases.
 				log.Printf("caddy sync: proxy id=%d advanced_config adapt failed: %v", p.ID, err)
 			} else {
-				advanced = h
+				advanced, advancedOverrides = h, overrides
 			}
 		}
-		routes = append(routes, caddy.BuildProxyRoute(p, append(preHandlers, advanced...)))
+		route := caddy.BuildProxyRoute(p, append(preHandlers, advanced...))
+		caddy.MergeReverseProxyOverrides(route, advancedOverrides)
+		routes = append(routes, route)
 	}
 	for _, rd := range redirs {
 		if !rd.Enabled || len(rd.DomainList()) == 0 {
@@ -10831,6 +10841,7 @@ func (s *Server) apiPreviewProxyHost(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	advancedError := ""
+	var previewOverrides map[string]any
 	if strings.TrimSpace(p.AdvancedConfig) != "" {
 		if validationError := validateProxyAdvancedDirectives(p.AdvancedConfig); validationError != "" {
 			advancedError = validationError
@@ -10841,10 +10852,11 @@ func (s *Server) apiPreviewProxyHost(w http.ResponseWriter, r *http.Request) {
 			}
 			if caddyClient == nil {
 				advancedError = "Caddy adapter is unavailable"
-			} else if handlers, adaptErr := s.adaptProxyAdvancedWithClient(caddyClient, *p); adaptErr != nil {
+			} else if handlers, overrides, adaptErr := s.adaptProxyAdvancedWithClient(caddyClient, *p); adaptErr != nil {
 				advancedError = adaptErr.Error()
 			} else {
 				previewHandlers = append(previewHandlers, handlers...)
+				previewOverrides = overrides
 			}
 		}
 	}
@@ -10864,6 +10876,7 @@ func (s *Server) apiPreviewProxyHost(w http.ResponseWriter, r *http.Request) {
 	previewProxy.ForwardProxyURL = redactPreviewURL(previewProxy.ForwardProxyURL)
 	previewProxy.ForwardAuthURL = redactPreviewURL(previewProxy.ForwardAuthURL)
 	route := caddy.BuildProxyRoute(previewProxy, previewHandlers)
+	caddy.MergeReverseProxyOverrides(route, previewOverrides)
 	route = redactProxyRoutePreview(route).(map[string]any)
 	caddyfile := caddy.RenderProxyHostCaddyfile(*p)
 	enc := json.NewEncoder(w)

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -441,6 +441,24 @@ func TestExpectationsAreSurfaced(t *testing.T) {
 	}
 }
 
+// TestAdvancedConfigReverseProxyHintIsSurfaced guards v2.40.0: the form
+// tells users that a reverse_proxy block (no upstream) is merged into the
+// host's own handler, and no longer lists reverse_proxy as rejected.
+func TestAdvancedConfigReverseProxyHintIsSurfaced(t *testing.T) {
+	body, err := FS.ReadFile("templates/proxy_host_form.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range []string{"data-advanced-reverse-proxy-hint", "flush_interval -1", "without</em> an upstream address"} {
+		if !strings.Contains(string(body), m) {
+			t.Errorf("proxy_host_form.html missing %q", m)
+		}
+	}
+	if strings.Contains(string(body), `Terminal handlers are rejected: <code class="font-mono bg-ink-100 px-1 rounded">reverse_proxy</code>`) {
+		t.Error("reverse_proxy must no longer be listed as a rejected directive")
+	}
+}
+
 // TestLiveCertificateProbeIsSurfaced guards v2.39.0: file-path certificates
 // CaddyUI cannot read get their expiry from a live TLS probe of the node, and
 // every page that shows a custom certificate says where the data came from.

--- a/web/templates/proxy_host_form.html
+++ b/web/templates/proxy_host_form.html
@@ -3901,9 +3901,15 @@ document.addEventListener('DOMContentLoaded', function() {
       <p class="text-xs text-ink-500 mt-1.5">
         Extra Caddyfile directives that run before <code class="font-mono bg-ink-100 px-1 rounded">reverse_proxy</code> — headers, compression,
         body limits, matchers, etc. Validated via Caddy's <code class="font-mono bg-ink-100 px-1 rounded">/adapt</code> on save.
-        Terminal handlers are rejected: <code class="font-mono bg-ink-100 px-1 rounded">reverse_proxy</code>, <code class="font-mono bg-ink-100 px-1 rounded">redir</code>,
+        Terminal handlers are rejected: <code class="font-mono bg-ink-100 px-1 rounded">redir</code>,
         <code class="font-mono bg-ink-100 px-1 rounded">respond</code>, <code class="font-mono bg-ink-100 px-1 rounded">file_server</code> can't be used here —
         create an <a href="/raw-routes/new" class="text-brand-600 hover:text-brand-700">Advanced route</a> for those.
+      </p>
+      <p class="text-xs text-ink-500 mt-1.5" data-advanced-reverse-proxy-hint>
+        To tune the proxy itself, add a <code class="font-mono bg-ink-100 px-1 rounded">reverse_proxy { … }</code> block <em>without</em> an upstream address:
+        its sub-directives (<code class="font-mono bg-ink-100 px-1 rounded">flush_interval -1</code>, <code class="font-mono bg-ink-100 px-1 rounded">header_up</code>,
+        <code class="font-mono bg-ink-100 px-1 rounded">transport http { … }</code>, <code class="font-mono bg-ink-100 px-1 rounded">lb_policy</code>, health checks…) are merged into
+        this host's own reverse_proxy, where your Forward host / port and the options above still apply. Typed bare, those lines are not site directives and Caddy rejects them.
       </p>
     </div>
   </details>


### PR DESCRIPTION
## Summary

Reported in chat: saving a proxy host with `flush_interval -1` in **Advanced config** failed with `Advanced config rejected by Caddy: … Caddyfile:2: unrecognized directive: flush_interval`.

The box wraps its directives in a site block and adapts them through Caddy; the resulting handlers run *before* the host's own `reverse_proxy`. Anything that belongs *inside* `reverse_proxy` — `flush_interval`, `header_up`, `transport`, `lb_policy`, health checks — therefore had no home: typed bare, Caddy rejects it as an unknown site directive; as a `reverse_proxy { … }` block it was banned as a second terminal handler.

- **Added:** a `reverse_proxy { … }` block with no upstream address is now accepted. It is adapted through Caddy, lifted out of the pre-handlers and deep-merged into the host's generated handler (`caddy.MergeReverseProxyOverrides`), so Forward host / port and every option in the form still apply and nested settings (an existing `transport` with TLS, upstream request headers) combine rather than replace. Blocks that name an upstream or sit behind a matcher are refused with a message saying why.
- **Fixed:** every reverse_proxy sub-directive at the top level is caught before adapting; the error spells out the block to use and points at the dedicated form option where one exists (Streaming → Flush immediately for `flush_interval`).
- The form's help text no longer lists `reverse_proxy` as rejected and describes the block instead.

## Verification

- Unit tests: `internal/caddy/overrides_test.go` (deep merge, upstream never overridden, subroute lookup), `internal/server/proxy_advanced_overrides_test.go` (extraction from adapter-shaped output, refusal of upstream / matcher / duplicate blocks, validation messages) and an opt-in test against a real Caddy admin API (`CADDYUI_TEST_CADDY_ADMIN`), run green against `caddy:2-alpine`.
- End-to-end on a scratch CaddyUI + real Caddy: creating a host through the form with `header X-Frame-Options DENY` plus `reverse_proxy { flush_interval -1; header_up X-Real-IP {remote_host}; transport http { read_timeout 30s } }` produced a live route whose reverse_proxy handler has `flush_interval: -1`, `transport.read_timeout`, `headers.request.set.X-Real-Ip` and the form's `app:8080` upstream, with the headers pre-handler intact. A bare `flush_interval -1` re-renders the form with the new explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)