### PR TITLE
fix: refuse changes Caddy rejects before saving, show failed syncs, auto-wrap bare reverse_proxy sub-directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.42.1] - 2026-09-08 - Changes Caddy rejects are refused up front, failed syncs are visible
+
+### Fixed
+
+- **A proxy host, redirection or certificate that Caddy would not load was saved anyway** ([#74](https://github.com/X4Applegate/caddyui/issues/74)). The form said "saved", the sync failed only in the log, the live config stayed as it was — and every later sync for that server failed the same way. The reported case: a file-path certificate whose files exist on the host but not inside the Caddy container. Proxy hosts, redirections and certificates are now validated against Caddy before they are saved, as Advanced routes already were; a file Caddy cannot open comes back as "Caddy cannot open /path for certificate X … the file must exist inside the Caddy container — mount the directory into Caddy or paste the PEM instead".
+- **A failed sync is now visible.** When a sync is rejected for any reason after a save, an amber banner on every page names the server and Caddy's error, with **Retry sync now** and **Dismiss**, until the next sync succeeds.
+- The Caddyfile view of a host with a custom certificate rendered only a comment; a file-path certificate now renders as a real `tls <cert> <key>` line, and stored PEM / managed certificates say how Caddy gets them. The Caddyfile export does the same.
+- The Caddyfile view and export printed an Advanced config `reverse_proxy { … }` block verbatim after the host's own `reverse_proxy` block, i.e. as a second one; its sub-directives now render inside the generated block, marked "from Advanced config".
+- A reverse_proxy sub-directive typed bare in a host's Advanced config — `flush_interval -1` on its own — is now moved into a `reverse_proxy { … }` block automatically (merged into an existing block when there is one, multi-line sub-directives included) instead of being explained back to you.
+
+### Security
+
+- Two CodeQL findings from v2.38.0: the post-apply banner's "back" redirect no longer accepts a protocol-relative `//host` path, and expectation paths are normalised to exactly one leading slash.
+
+---
+
 ## [2.42.0] - 2026-09-08 - Export a managed certificate to a directory
 
 ### Added

--- a/internal/caddy/exporter.go
+++ b/internal/caddy/exporter.go
@@ -26,7 +26,11 @@ import (
 // `serverName` is just metadata for the file header banner. Disabled hosts
 // are skipped — the export is "what's actually serving traffic", not "every
 // row in the DB". Pass an empty serverName to omit the banner.
-func RenderServerCaddyfile(serverName string, hosts []models.ProxyHost, redirects []models.RedirectionHost, raws []models.RawRoute) string {
+func RenderServerCaddyfile(serverName string, hosts []models.ProxyHost, redirects []models.RedirectionHost, raws []models.RawRoute, certs []models.Certificate) string {
+	certByID := make(map[int64]*models.Certificate, len(certs))
+	for i := range certs {
+		certByID[certs[i].ID] = &certs[i]
+	}
 	var b strings.Builder
 	if serverName != "" {
 		fmt.Fprintf(&b, "# CaddyUI export — %s\n", serverName)
@@ -48,7 +52,7 @@ func RenderServerCaddyfile(serverName string, hosts []models.ProxyHost, redirect
 		if !ph.Enabled {
 			continue
 		}
-		b.WriteString(RenderProxyHostCaddyfile(ph))
+		b.WriteString(RenderProxyHostCaddyfileWithCertificate(ph, certByID[ph.CertificateID]))
 		b.WriteString("\n")
 	}
 	for _, rh := range redirects {
@@ -75,6 +79,14 @@ func RenderServerCaddyfile(serverName string, hosts []models.ProxyHost, redirect
 // any non-default ones in a leading `# Notes:` comment so users know to
 // re-set them in the UI after a round-trip.
 func RenderProxyHostCaddyfile(p models.ProxyHost) string {
+	return RenderProxyHostCaddyfileWithCertificate(p, nil)
+}
+
+// RenderProxyHostCaddyfileWithCertificate is RenderProxyHostCaddyfile with
+// the host's custom certificate resolved (v2.42.1, issue #74): a file-path
+// certificate renders as a real `tls <cert> <key>` line, a stored PEM or a
+// managed definition as a comment saying how Caddy gets it.
+func RenderProxyHostCaddyfileWithCertificate(p models.ProxyHost, cert *models.Certificate) string {
 	var b strings.Builder
 
 	// Site block header — space-separated hostname list per Caddyfile spec.
@@ -134,7 +146,16 @@ func RenderProxyHostCaddyfile(p models.ProxyHost) string {
 	// public hostname; we only need an explicit `tls` directive for custom
 	// certs or specific CA hints.
 	if p.CertificateID > 0 {
-		fmt.Fprintf(&b, "\t# Custom certificate ID %d (uploaded via CaddyUI; not represented in Caddyfile — Caddy will use its automatic cert resolution at runtime)\n", p.CertificateID)
+		switch {
+		case cert != nil && cert.Source == models.CertSourcePath && cert.CertPath != "" && cert.KeyPath != "":
+			fmt.Fprintf(&b, "\ttls %s %s\n", cert.CertPath, cert.KeyPath)
+		case cert != nil && cert.Source == models.CertSourcePEM:
+			fmt.Fprintf(&b, "\t# tls: stored PEM certificate %q — CaddyUI loads it into Caddy's certificate pool directly (load_pem); a Caddyfile would need the files on disk\n", cert.Name)
+		case cert != nil && cert.Source == models.CertSourceManaged:
+			fmt.Fprintf(&b, "\t# tls: managed certificate %q (%s) — Caddy obtains it via DNS-01 and serves it by SNI\n", cert.Name, cert.Domains)
+		default:
+			fmt.Fprintf(&b, "\t# Custom certificate ID %d (uploaded via CaddyUI; not represented in Caddyfile — Caddy will use its automatic cert resolution at runtime)\n", p.CertificateID)
+		}
 	} else if !p.SSLEnabled {
 		// SSL explicitly off — site listens on HTTP only.
 		b.WriteString("\ttls off\n")
@@ -275,13 +296,23 @@ func RenderProxyHostCaddyfile(p models.ProxyHost) string {
 		b.WriteString("\t\t}\n")
 	}
 
+	// v2.42.1: a `reverse_proxy { … }` block in the Advanced config is merged
+	// into the host's own handler at sync time (v2.40.0), so render its
+	// sub-directives inside this block rather than as a second reverse_proxy.
+	advancedRest, advancedInner := splitAdvancedReverseProxyBlock(p.AdvancedConfig)
+	if len(advancedInner) > 0 {
+		b.WriteString("\t\t# from Advanced config\n")
+		for _, line := range advancedInner {
+			fmt.Fprintf(&b, "\t\t%s\n", line)
+		}
+	}
 	b.WriteString("\t}\n")
 
 	// Advanced raw config — verbatim user input, indented to match the site
 	// block. Trailing newline preserved.
-	if strings.TrimSpace(p.AdvancedConfig) != "" {
+	if strings.TrimSpace(advancedRest) != "" {
 		b.WriteString("\n\t# --- Advanced raw config (from CaddyUI) ---\n")
-		for _, line := range strings.Split(p.AdvancedConfig, "\n") {
+		for _, line := range strings.Split(advancedRest, "\n") {
 			if line == "" {
 				b.WriteString("\n")
 			} else {
@@ -380,4 +411,66 @@ func splitCSV(s string) []string {
 		}
 	}
 	return out
+}
+
+// splitAdvancedReverseProxyBlock separates a top-level `reverse_proxy { … }`
+// block from the rest of an Advanced config. inner holds the block's lines
+// with one level of indentation removed; rest is everything else, verbatim.
+func splitAdvancedReverseProxyBlock(src string) (rest string, inner []string) {
+	if strings.TrimSpace(src) == "" {
+		return src, nil
+	}
+	stripped := func(line string) string {
+		t := strings.TrimSpace(line)
+		if i := strings.Index(t, "#"); i >= 0 {
+			t = strings.TrimSpace(t[:i])
+		}
+		return t
+	}
+	braces := func(line string) int {
+		d := 0
+		for _, ch := range stripped(line) {
+			switch ch {
+			case '{':
+				d++
+			case '}':
+				d--
+			}
+		}
+		return d
+	}
+	lines := strings.Split(src, "\n")
+	var kept []string
+	depth := 0
+	for i := 0; i < len(lines); {
+		line := lines[i]
+		t := stripped(line)
+		if depth == 0 && t != "" && strings.Fields(t)[0] == "reverse_proxy" && strings.HasSuffix(t, "{") {
+			d := braces(line)
+			j := i + 1
+			var block []string
+			for ; j < len(lines) && d > 0; j++ {
+				d += braces(lines[j])
+				if d > 0 {
+					block = append(block, lines[j])
+				}
+			}
+			if d == 0 {
+				for _, bl := range block {
+					if strings.TrimSpace(bl) != "" {
+						inner = append(inner, strings.TrimPrefix(strings.TrimSpace(bl), "\t"))
+					}
+				}
+				i = j
+				continue
+			}
+		}
+		kept = append(kept, line)
+		depth += braces(line)
+		i++
+	}
+	if inner == nil {
+		return src, nil
+	}
+	return strings.Join(kept, "\n"), inner
 }

--- a/internal/caddy/exporter_certificate_test.go
+++ b/internal/caddy/exporter_certificate_test.go
@@ -1,0 +1,47 @@
+package caddy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// v2.42.1 (issue #74): the Caddyfile view of a host with a custom
+// certificate shows how Caddy gets it instead of a bare comment.
+func TestRenderProxyHostCaddyfileWithCertificate(t *testing.T) {
+	p := models.ProxyHost{Domains: "app.example.test", ForwardScheme: "http", ForwardHost: "app", ForwardPort: 8080, Enabled: true, SSLForced: true, CertificateID: 7}
+	path := &models.Certificate{ID: 7, Name: "files", Source: models.CertSourcePath, CertPath: "/certs/app/fullchain.pem", KeyPath: "/certs/app/privkey.pem"}
+	if out := RenderProxyHostCaddyfileWithCertificate(p, path); !strings.Contains(out, "\ttls /certs/app/fullchain.pem /certs/app/privkey.pem\n") {
+		t.Errorf("file-path certificate should render a tls line:\n%s", out)
+	}
+	pem := &models.Certificate{ID: 7, Name: "uploaded", Source: models.CertSourcePEM}
+	if out := RenderProxyHostCaddyfileWithCertificate(p, pem); !strings.Contains(out, `stored PEM certificate "uploaded"`) {
+		t.Errorf("PEM certificate should be described:\n%s", out)
+	}
+	if out := RenderProxyHostCaddyfile(p); !strings.Contains(out, "Custom certificate ID 7") {
+		t.Errorf("unknown certificate keeps the legacy comment:\n%s", out)
+	}
+	full := RenderServerCaddyfile("Primary", []models.ProxyHost{p}, nil, nil, []models.Certificate{*path})
+	if !strings.Contains(full, "\ttls /certs/app/fullchain.pem /certs/app/privkey.pem\n") {
+		t.Errorf("server export should resolve certificates:\n%s", full)
+	}
+}
+
+// v2.42.1: the Advanced config's reverse_proxy block renders inside the
+// generated reverse_proxy block, not as a second one; other directives stay.
+func TestRenderProxyHostCaddyfileMergesAdvancedReverseProxyBlock(t *testing.T) {
+	p := models.ProxyHost{Domains: "app.example.test", ForwardScheme: "http", ForwardHost: "app", ForwardPort: 8080, Enabled: true, SSLEnabled: true,
+		AdvancedConfig: "encode gzip\nreverse_proxy {\n\tflush_interval -1\n\ttransport http {\n\t\tread_timeout 30s\n\t}\n}\n"}
+	out := RenderProxyHostCaddyfile(p)
+	if strings.Count(out, "reverse_proxy") != 1 {
+		t.Errorf("expected exactly one reverse_proxy block:\n%s", out)
+	}
+	if !strings.Contains(out, "\t\tflush_interval -1\n") || !strings.Contains(out, "\t\tread_timeout 30s") || !strings.Contains(out, "\tencode gzip\n") {
+		t.Errorf("sub-directives should sit inside the generated block and encode stay outside:\n%s", out)
+	}
+	rest, inner := splitAdvancedReverseProxyBlock("header X 1\n")
+	if rest != "header X 1\n" || inner != nil {
+		t.Errorf("no block: rest=%q inner=%v", rest, inner)
+	}
+}

--- a/internal/models/expectations.go
+++ b/internal/models/expectations.go
@@ -36,12 +36,8 @@ func (e HostExpectation) Normalized() HostExpectation {
 	} else {
 		e.Scheme = "https"
 	}
-	e.Path = strings.TrimSpace(e.Path)
-	if e.Path == "" {
-		e.Path = "/"
-	} else if !strings.HasPrefix(e.Path, "/") {
-		e.Path = "/" + e.Path
-	}
+	// Exactly one leading slash: a request path, never a protocol-relative URL.
+	e.Path = "/" + strings.TrimLeft(strings.TrimSpace(e.Path), "/")
 	if e.ExpectStatus < 100 || e.ExpectStatus > 599 {
 		e.ExpectStatus = 0
 	}

--- a/internal/server/expectations.go
+++ b/internal/server/expectations.go
@@ -361,7 +361,8 @@ func (s *Server) runProxyHostExpectationsHandler(w http.ResponseWriter, r *http.
 
 func redirectBack(w http.ResponseWriter, r *http.Request) {
 	back := "/"
-	if u, err := url.Parse(r.Referer()); err == nil && u != nil && strings.HasPrefix(u.Path, "/") {
+	// Only a local path: "//evil.example" would be a protocol-relative URL.
+	if u, err := url.Parse(r.Referer()); err == nil && u != nil && strings.HasPrefix(u.Path, "/") && !strings.HasPrefix(u.Path, "//") {
 		back = u.Path
 	}
 	http.Redirect(w, r, back, http.StatusSeeOther)

--- a/internal/server/preflight.go
+++ b/internal/server/preflight.go
@@ -1,0 +1,238 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/X4Applegate/caddyui/internal/models"
+	"github.com/go-chi/chi/v5"
+)
+
+// v2.42.1 (issue #74): a change that Caddy will not load used to be saved
+// anyway. The form said "saved", the sync failed in the log, the live config
+// stayed as it was — and every later sync for that server failed the same
+// way until someone noticed. The reported case was a file-path certificate
+// whose files exist on the host but not inside the Caddy container.
+//
+// Two layers now: proxy hosts, redirections and certificates are validated
+// against Caddy before they are saved, the way Advanced routes already were;
+// and when a sync fails for any reason after a save, the failure is kept per
+// server and shown on every page until the next successful sync.
+
+// serverResources loads every resource of a server for a preview build.
+// ok is false when a query failed — callers then skip validation rather than
+// block a save on an unrelated error.
+func (s *Server) serverResources(serverID int64) (proxies []models.ProxyHost, redirs []models.RedirectionHost, raws []models.RawRoute, certs []models.Certificate, ok bool) {
+	var err error
+	if proxies, err = models.ListProxyHosts(s.DB, serverID, 0, true, nil); err != nil {
+		return nil, nil, nil, nil, false
+	}
+	if redirs, err = models.ListRedirectionHosts(s.DB, serverID, 0, true, nil); err != nil {
+		return nil, nil, nil, nil, false
+	}
+	if raws, err = models.ListRawRoutes(s.DB, serverID, 0, true, nil); err != nil {
+		return nil, nil, nil, nil, false
+	}
+	if certs, err = models.ListCertificates(s.DB, serverID); err != nil {
+		return nil, nil, nil, nil, false
+	}
+	return proxies, redirs, raws, certs, true
+}
+
+// previewProxyHostValidate simulates the sync with p saved (replacing the
+// row with the same ID, or added) and asks Caddy to validate the result.
+// Returns a message only when Caddy would reject it.
+func (s *Server) previewProxyHostValidate(serverID int64, p *models.ProxyHost) string {
+	proxies, redirs, raws, certs, ok := s.serverResources(serverID)
+	if !ok {
+		return ""
+	}
+	replaced := false
+	for i := range proxies {
+		if p.ID != 0 && proxies[i].ID == p.ID {
+			proxies[i] = *p
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		proxies = append(proxies, *p)
+	}
+	return friendlyCaddyRejection(s.validateProposedConfig(serverID, proxies, redirs, raws, certs), certs)
+}
+
+// previewRedirectValidate is previewProxyHostValidate for a redirection.
+func (s *Server) previewRedirectValidate(serverID int64, rh *models.RedirectionHost) string {
+	proxies, redirs, raws, certs, ok := s.serverResources(serverID)
+	if !ok {
+		return ""
+	}
+	replaced := false
+	for i := range redirs {
+		if rh.ID != 0 && redirs[i].ID == rh.ID {
+			redirs[i] = *rh
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		redirs = append(redirs, *rh)
+	}
+	return friendlyCaddyRejection(s.validateProposedConfig(serverID, proxies, redirs, raws, certs), certs)
+}
+
+// previewCertificateValidate is the same for a certificate: a file-path
+// certificate whose files Caddy cannot open fails right here, before the
+// row exists, instead of breaking every later sync.
+func (s *Server) previewCertificateValidate(serverID int64, c *models.Certificate) string {
+	proxies, redirs, raws, certs, ok := s.serverResources(serverID)
+	if !ok {
+		return ""
+	}
+	replaced := false
+	for i := range certs {
+		if c.ID != 0 && certs[i].ID == c.ID {
+			certs[i] = *c
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		certs = append(certs, *c)
+	}
+	return friendlyCaddyRejection(s.validateProposedConfig(serverID, proxies, redirs, raws, certs), certs)
+}
+
+// friendlyCaddyRejection turns Caddy's validation error into something a
+// person can act on. The message from validateProposedConfig starts with
+// "Caddy rejected the proposed config: "; the common case — a certificate
+// file that exists on the host but not inside the Caddy container — gets a
+// specific explanation.
+func friendlyCaddyRejection(msg string, certs []models.Certificate) string {
+	if msg == "" {
+		return ""
+	}
+	lower := strings.ToLower(msg)
+	if strings.Contains(lower, "no such file or directory") || strings.Contains(lower, "loading certificates") {
+		for _, c := range certs {
+			if c.Source != models.CertSourcePath {
+				continue
+			}
+			for _, p := range []string{c.CertPath, c.KeyPath} {
+				if p != "" && strings.Contains(msg, p) {
+					return fmt.Sprintf("Caddy cannot open %s for certificate %q. File paths are read by Caddy inside the Caddy container, so the file must exist there — mount the directory into the Caddy container (for example `-v /etc/letsencrypt:/etc/letsencrypt:ro`) and use that path, or paste the PEM instead. Caddy said: %s", p, c.Name, strings.TrimPrefix(msg, "Caddy rejected the proposed config: "))
+				}
+			}
+		}
+	}
+	return strings.Replace(msg, "Caddy rejected the proposed config: ", "Caddy rejected this change, so it was not saved: ", 1)
+}
+
+// --- failed-sync banner --------------------------------------------------
+
+const syncErrorKeyPrefix = "sync_error_server_"
+
+type syncError struct {
+	ServerID   int64     `json:"server_id"`
+	ServerName string    `json:"server_name"`
+	Error      string    `json:"error"`
+	At         time.Time `json:"at"`
+}
+
+func syncErrorKey(serverID int64) string {
+	return syncErrorKeyPrefix + strconv.FormatInt(serverID, 10)
+}
+
+func (s *Server) setSyncError(serverID int64, serverName string, err error) {
+	raw, marshalErr := json.Marshal(syncError{ServerID: serverID, ServerName: serverName, Error: err.Error(), At: time.Now().UTC()})
+	if marshalErr != nil {
+		return
+	}
+	if setErr := models.SetSetting(s.DB, syncErrorKey(serverID), string(raw)); setErr != nil {
+		log.Printf("record sync error for server %d: %v", serverID, setErr)
+	}
+}
+
+func (s *Server) clearSyncError(serverID int64) {
+	_ = models.DeleteSetting(s.DB, syncErrorKey(serverID))
+}
+
+func (s *Server) syncErrorFor(serverID int64) *syncError {
+	raw, err := models.GetSetting(s.DB, syncErrorKey(serverID))
+	if err != nil || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var e syncError
+	if json.Unmarshal([]byte(raw), &e) != nil {
+		return nil
+	}
+	return &e
+}
+
+// activeSyncErrors lists servers whose last sync failed, for the layout
+// banner. Servers under a post-apply hold are left out — the hold banner
+// already covers them.
+func (s *Server) activeSyncErrors(servers []models.CaddyServer) []syncError {
+	var out []syncError
+	for _, sr := range servers {
+		if s.syncHoldFor(sr.ID) != nil {
+			continue
+		}
+		if e := s.syncErrorFor(sr.ID); e != nil {
+			if e.ServerName == "" {
+				e.ServerName = sr.Name
+			}
+			out = append(out, *e)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ServerID < out[j].ServerID })
+	return out
+}
+
+// clearSyncErrorHandler: POST /servers/{id}/sync-error/clear — Dismiss on
+// the banner. The next sync records a fresh result either way.
+func (s *Server) clearSyncErrorHandler(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	s.clearSyncError(id)
+	redirectBack(w, r)
+}
+
+// renderCertificateFormError re-renders the certificate form with what the
+// user typed and an error, for both the create and the edit flow.
+func (s *Server) renderCertificateFormError(w http.ResponseWriter, r *http.Request, c *models.Certificate, errMsg string) {
+	data := map[string]any{
+		"User":         s.currentUser(r),
+		"Cert":         c,
+		"Users":        s.adminUserList(r),
+		"OtherServers": s.otherManagedServers(r),
+		"Error":        errMsg,
+		"Section":      "certs",
+	}
+	s.addCertificateExportViewData(data, c.ID, *c)
+	s.render(w, r, "certificate_form.html", s.applyDNSViewData(s.currentServerID(r), data))
+}
+
+// certificateForCaddyfile loads the certificate a host references so the
+// Caddyfile view can show a real `tls` line for file-path certificates
+// (v2.42.1, issue #74 mentioned the view being "almost empty"). nil when
+// there is none or it cannot be loaded.
+func (s *Server) certificateForCaddyfile(certificateID int64) *models.Certificate {
+	if certificateID == 0 {
+		return nil
+	}
+	c, err := models.GetCertificate(s.DB, certificateID)
+	if err != nil {
+		return nil
+	}
+	return c
+}

--- a/internal/server/preflight_test.go
+++ b/internal/server/preflight_test.go
@@ -1,0 +1,178 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	appdb "github.com/X4Applegate/caddyui/internal/db"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// fakeCaddyAdmin answers the calls a preview validation and a sync make. A
+// validate/load whose body mentions "/missing/" is rejected the way Caddy
+// rejects an unreadable certificate file.
+func fakeCaddyAdmin(t *testing.T) (*httptest.Server, *[]string) {
+	t.Helper()
+	var mu sync.Mutex
+	var loads []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/config"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"apps":{"http":{"servers":{"srv0":{"listen":[":443"],"routes":[]}}}}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/load":
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			loads = append(loads, r.URL.RawQuery)
+			mu.Unlock()
+			if strings.Contains(string(body), "/missing/") {
+				w.WriteHeader(400)
+				_, _ = w.Write([]byte(`{"error":"loading config: loading new config: loading http app module: provision http: getting tls app: loading tls app module: provision tls: loading certificates: open /missing/fullchain.pem: no such file or directory"}`))
+				return
+			}
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &loads
+}
+
+func newPreflightTestServer(t *testing.T) (*Server, int64) {
+	t.Helper()
+	admin, _ := fakeCaddyAdmin(t)
+	conn, err := appdb.Open(filepath.Join(t.TempDir(), "caddyui.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	serverID, err := models.CreateCaddyServer(conn, &models.CaddyServer{Name: "Primary", AdminURL: admin.URL, Type: models.CaddyServerTypeManaged})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Server{DB: conn, Caddy: newCaddyClient(admin.URL, "", "")}, serverID
+}
+
+// v2.42.1 (issue #74): a file-path certificate Caddy cannot open is refused
+// before it is saved, with the container-path explanation; a readable one
+// passes; a host referencing the bad certificate is refused too.
+func TestPreviewValidationRefusesUnreadableCertificateFile(t *testing.T) {
+	s, serverID := newPreflightTestServer(t)
+	bad := &models.Certificate{Name: "letsencrypt-on-host", Domains: "app.example.test", Source: models.CertSourcePath, CertPath: "/missing/fullchain.pem", KeyPath: "/missing/privkey.pem"}
+	msg := s.previewCertificateValidate(serverID, bad)
+	if !strings.Contains(msg, "Caddy cannot open /missing/fullchain.pem") || !strings.Contains(msg, "inside the Caddy container") || !strings.Contains(msg, "letsencrypt-on-host") {
+		t.Fatalf("message = %q", msg)
+	}
+	good := &models.Certificate{Name: "ok", Domains: "app.example.test", Source: models.CertSourcePath, CertPath: "/certs/fullchain.pem", KeyPath: "/certs/privkey.pem"}
+	if msg := s.previewCertificateValidate(serverID, good); msg != "" {
+		t.Fatalf("readable certificate should pass, got %q", msg)
+	}
+
+	// Once a bad certificate exists (say, from before this release), a host
+	// attached to it is refused with the same explanation.
+	badID, err := models.CreateCertificate(s.DB, serverID, 0, bad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := &models.ProxyHost{Domains: "app.example.test", ForwardScheme: "http", ForwardHost: "app", ForwardPort: 8080, Enabled: true, SSLForced: true, CertificateID: badID}
+	if msg := s.previewProxyHostValidate(serverID, host); !strings.Contains(msg, "Caddy cannot open /missing/fullchain.pem") {
+		t.Fatalf("host with unreadable certificate should be refused, got %q", msg)
+	}
+	redirect := &models.RedirectionHost{Domains: "old.example.test", ForwardScheme: "https", ForwardDomain: "new.example.test", ForwardHTTPCode: 301, Enabled: true, SSLEnabled: true, CertificateID: badID}
+	if msg := s.previewRedirectValidate(serverID, redirect); !strings.Contains(msg, "Caddy cannot open") {
+		t.Fatalf("redirect with unreadable certificate should be refused, got %q", msg)
+	}
+	// A generic rejection keeps Caddy's words but says the change was not saved.
+	if got := friendlyCaddyRejection("Caddy rejected the proposed config: something else", nil); !strings.HasPrefix(got, "Caddy rejected this change, so it was not saved: something else") {
+		t.Errorf("generic message = %q", got)
+	}
+}
+
+// A sync Caddy rejects is recorded for the banner and cleared by the next
+// successful sync; a held server is left to the hold banner.
+func TestSyncCaddyRecordsFailuresForTheBanner(t *testing.T) {
+	s, serverID := newPreflightTestServer(t)
+	bad := models.Certificate{Name: "bad", Domains: "app.example.test", Source: models.CertSourcePath, CertPath: "/missing/fullchain.pem", KeyPath: "/missing/privkey.pem"}
+	badID, err := models.CreateCertificate(s.DB, serverID, 0, &bad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := models.ProxyHost{Domains: "app.example.test", ForwardScheme: "http", ForwardHost: "app", ForwardPort: 8080, Enabled: true, SSLForced: true, CertificateID: badID}
+	if _, err := models.CreateProxyHost(s.DB, serverID, 0, &host); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.syncCaddy(serverID, true); err == nil {
+		t.Fatal("sync should fail while the certificate file is unreadable")
+	}
+	rec := s.syncErrorFor(serverID)
+	if rec == nil || !strings.Contains(rec.Error, "no such file or directory") || rec.ServerName != "Primary" {
+		t.Fatalf("recorded sync error = %+v", rec)
+	}
+	servers, _ := models.ListCaddyServers(s.DB)
+	if banners := s.activeSyncErrors(servers); len(banners) != 1 || banners[0].ServerID != serverID {
+		t.Fatalf("activeSyncErrors = %+v", banners)
+	}
+
+	// Fix the certificate → the next sync succeeds and clears the record.
+	bad.ID = badID
+	bad.CertPath, bad.KeyPath = "/certs/fullchain.pem", "/certs/privkey.pem"
+	if err := models.UpdateCertificate(s.DB, &bad); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.syncCaddy(serverID, true); err != nil {
+		t.Fatalf("sync should succeed now: %v", err)
+	}
+	if s.syncErrorFor(serverID) != nil {
+		t.Fatal("a successful sync must clear the recorded error")
+	}
+
+	// A held server reports through the hold banner only.
+	s.setSyncHold(syncHold{ServerID: serverID, ServerName: "Primary", Detail: "held"})
+	_ = s.syncCaddy(serverID, true)
+	if s.syncErrorFor(serverID) != nil {
+		t.Fatal("no sync-error record while a hold is set")
+	}
+	s.clearSyncHold(serverID)
+	s.setSyncError(serverID, "Primary", io.ErrUnexpectedEOF)
+	raw, _ := models.GetSetting(s.DB, syncErrorKey(serverID))
+	var stored syncError
+	if json.Unmarshal([]byte(raw), &stored) != nil || stored.Error != io.ErrUnexpectedEOF.Error() {
+		t.Fatalf("stored = %q", raw)
+	}
+	s.clearSyncError(serverID)
+	if s.syncErrorFor(serverID) != nil {
+		t.Fatal("clearSyncError should remove the record")
+	}
+}
+
+// The banner's "back" redirect never follows a protocol-relative referer.
+func TestRedirectBackStaysLocal(t *testing.T) {
+	for referer, want := range map[string]string{
+		"http://caddyui.local/certificates":    "/certificates",
+		"http://caddyui.local//evil.example/x": "/",
+		"":                                     "/",
+		"http://caddyui.local/proxy-hosts?x=1": "/proxy-hosts",
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/servers/1/sync-error/clear", nil)
+		if referer != "" {
+			req.Header.Set("Referer", referer)
+		}
+		rec := httptest.NewRecorder()
+		redirectBack(rec, req)
+		if got := rec.Header().Get("Location"); got != want {
+			t.Errorf("referer %q → %q, want %q", referer, got, want)
+		}
+	}
+	if e := (models.HostExpectation{Path: "//evil.example/x"}).Normalized(); e.Path != "/evil.example/x" {
+		t.Errorf("expectation path = %q, want a single leading slash", e.Path)
+	}
+}

--- a/internal/server/proxy_advanced_overrides.go
+++ b/internal/server/proxy_advanced_overrides.go
@@ -146,3 +146,93 @@ func describeOverrides(overrides map[string]any) string {
 	}
 	return strings.Join(keys, ", ")
 }
+
+// wrapBareReverseProxySubdirectives (v2.42.1) moves reverse_proxy
+// sub-directives typed at the top level of an Advanced config into a
+// `reverse_proxy { … }` block — merged into an existing one when there is
+// one — so `flush_interval -1` on its own simply works instead of being
+// explained back to the user. Multi-line sub-directives (a transport block)
+// move with their braces. Sources that need no change come back unchanged.
+func wrapBareReverseProxySubdirectives(src string) string {
+	out, _ := wrapBareReverseProxySubdirectivesNamed(src)
+	return out
+}
+
+func wrapBareReverseProxySubdirectivesNamed(src string) (string, []string) {
+	isSub := map[string]bool{}
+	for _, d := range reverseProxySubdirectives {
+		isSub[d] = true
+	}
+	stripped := func(line string) string {
+		t := strings.TrimSpace(line)
+		if i := strings.Index(t, "#"); i >= 0 {
+			t = strings.TrimSpace(t[:i])
+		}
+		return t
+	}
+	braces := func(line string) int {
+		d := 0
+		for _, ch := range stripped(line) {
+			switch ch {
+			case '{':
+				d++
+			case '}':
+				d--
+			}
+		}
+		return d
+	}
+	lines := strings.Split(src, "\n")
+	var top, moved, names []string
+	depth := 0
+	for i := 0; i < len(lines); {
+		line := lines[i]
+		t := stripped(line)
+		first := ""
+		if t != "" {
+			first = strings.Fields(t)[0]
+		}
+		if depth == 0 && first != "" && isSub[first] {
+			names = append(names, first)
+			moved = append(moved, "\t"+strings.TrimSpace(line))
+			d := braces(line)
+			i++
+			for d > 0 && i < len(lines) {
+				moved = append(moved, "\t"+strings.TrimSpace(lines[i]))
+				d += braces(lines[i])
+				i++
+			}
+			continue
+		}
+		top = append(top, line)
+		depth += braces(line)
+		i++
+	}
+	if len(moved) == 0 {
+		return src, nil
+	}
+	// Merge into an existing top-level reverse_proxy block when there is one.
+	depth = 0
+	for i, line := range top {
+		t := stripped(line)
+		if depth == 0 && t != "" && strings.Fields(t)[0] == "reverse_proxy" && strings.HasSuffix(t, "{") {
+			d := braces(line)
+			for j := i + 1; j < len(top); j++ {
+				d += braces(top[j])
+				if d == 0 {
+					merged := append([]string{}, top[:j]...)
+					merged = append(merged, moved...)
+					merged = append(merged, top[j:]...)
+					return strings.TrimRight(strings.Join(merged, "\n"), "\n") + "\n", names
+				}
+			}
+		}
+		depth += braces(line)
+	}
+	body := strings.TrimRight(strings.Join(top, "\n"), "\n")
+	block := "reverse_proxy {\n" + strings.Join(moved, "\n") + "\n}\n"
+	if strings.TrimSpace(body) == "" {
+		return block, names
+	}
+	return body + "\n" + block, names
+}

--- a/internal/server/proxy_advanced_overrides_test.go
+++ b/internal/server/proxy_advanced_overrides_test.go
@@ -124,3 +124,31 @@ func TestAdvancedReverseProxyBlockThroughRealCaddy(t *testing.T) {
 		t.Errorf("bare sub-directive should be explained, got %q", msg)
 	}
 }
+
+// v2.42.1: bare reverse_proxy sub-directives are moved into a reverse_proxy
+// block (merged into an existing one), blocks travel intact, and sources
+// with nothing to move come back byte-identical.
+func TestWrapBareReverseProxySubdirectives(t *testing.T) {
+	got, names := wrapBareReverseProxySubdirectivesNamed("flush_interval -1\nencode gzip\n")
+	if got != "encode gzip\nreverse_proxy {\n\tflush_interval -1\n}\n" || len(names) != 1 || names[0] != "flush_interval" {
+		t.Errorf("simple wrap = %q (%v)", got, names)
+	}
+	got, _ = wrapBareReverseProxySubdirectivesNamed("flush_interval -1")
+	if got != "reverse_proxy {\n\tflush_interval -1\n}\n" {
+		t.Errorf("only a sub-directive = %q", got)
+	}
+	got, names = wrapBareReverseProxySubdirectivesNamed("header X-Frame-Options DENY\ntransport http {\n\tread_timeout 30s\n}\nreverse_proxy {\n\theader_up X-Real-IP {remote_host}\n}\n")
+	want := "header X-Frame-Options DENY\nreverse_proxy {\n\theader_up X-Real-IP {remote_host}\n\ttransport http {\n\tread_timeout 30s\n\t}\n}\n"
+	if got != want || len(names) != 1 || names[0] != "transport" {
+		t.Errorf("merge into existing block = %q (%v)\nwant %q", got, names, want)
+	}
+	for _, unchanged := range []string{"", "encode gzip\n", "reverse_proxy {\n\tflush_interval -1\n}\n", "request_body {\n\tmax_size 10MB\n}\n"} {
+		if got, names := wrapBareReverseProxySubdirectivesNamed(unchanged); got != unchanged || names != nil {
+			t.Errorf("%q should be untouched, got %q (%v)", unchanged, got, names)
+		}
+	}
+	// After wrapping, validation no longer complains and the block adapts.
+	if msg := validateProxyAdvancedDirectives(wrapBareReverseProxySubdirectives("flush_interval -1")); msg != "" {
+		t.Errorf("wrapped source should validate, got %q", msg)
+	}
+}

--- a/internal/server/proxy_host_form.go
+++ b/internal/server/proxy_host_form.go
@@ -191,7 +191,7 @@ func parseProxyHostForm(r *http.Request) (*models.ProxyHost, error) {
 		SSLEnabled:             r.FormValue("ssl_enabled") == "on",
 		SSLForced:              r.FormValue("ssl_forced") == "on",
 		HTTP2Support:           r.FormValue("http2_support") == "on",
-		AdvancedConfig:         r.FormValue("advanced_config"),
+		AdvancedConfig:         wrapBareReverseProxySubdirectives(r.FormValue("advanced_config")), // v2.42.1
 		Enabled:                r.FormValue("enabled") == "on",
 		CertificateID:          certID,
 		AccessList:             strings.TrimSpace(r.FormValue("access_list")),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -814,8 +814,9 @@ func (s *Server) Routes() http.Handler {
 			r.Get("/servers/{id}/config", s.viewServerConfig)
 			r.Post("/servers/{id}", s.updateServer)
 			r.Post("/servers/{id}/sync-from-current", s.syncServerFromCurrent)
-			r.Post("/servers/{id}/sync-reapply", s.reapplySyncHandler)      // v2.38.0
-			r.Post("/servers/{id}/sync-hold/clear", s.clearSyncHoldHandler) // v2.38.0
+			r.Post("/servers/{id}/sync-reapply", s.reapplySyncHandler)        // v2.38.0
+			r.Post("/servers/{id}/sync-hold/clear", s.clearSyncHoldHandler)   // v2.38.0
+			r.Post("/servers/{id}/sync-error/clear", s.clearSyncErrorHandler) // v2.42.1
 			r.Post("/servers/{id}/delete", s.deleteServer)
 			r.Get("/server-logs", s.getServerLogs)
 			r.Get("/api/server-logs/status", s.serverLogStatus)
@@ -1144,6 +1145,12 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, dat
 	if _, ok := data["SyncHolds"]; !ok {
 		if servers, ok := data["Servers"].([]models.CaddyServer); ok && len(servers) > 0 {
 			data["SyncHolds"] = s.activeSyncHolds(servers)
+		}
+	}
+	// v2.42.1: servers whose last sync failed — layout banner.
+	if _, ok := data["SyncErrors"]; !ok {
+		if servers, ok := data["Servers"].([]models.CaddyServer); ok && len(servers) > 0 {
+			data["SyncErrors"] = s.activeSyncErrors(servers)
 		}
 	}
 	if _, ok := data["CurrentServer"]; !ok {
@@ -4530,6 +4537,12 @@ func (s *Server) createProxyHost(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	// v2.42.1 (issue #74): refuse a host Caddy would not load instead of
+	// saving it and failing every later sync.
+	if errMsg := s.previewProxyHostValidate(s.currentServerID(r), p); errMsg != "" {
+		s.renderProxyHostFormError(w, r, p, errMsg)
+		return
+	}
 	id, err := models.CreateProxyHost(s.DB, s.currentServerID(r), ownerID, p)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -4711,6 +4724,10 @@ func (s *Server) updateProxyHost(w http.ResponseWriter, r *http.Request) {
 	needCreate := p.DNSProvider != "" && p.DNSZoneID != "" && !p.DNSSkipRecord &&
 		(p.DNSRecordID == "" || providerChanged || profileChanged || zoneChanged || domainChanged || recordModeChanged)
 
+	if errMsg := s.previewProxyHostValidate(s.currentServerID(r), p); errMsg != "" { // v2.42.1 (issue #74)
+		s.renderProxyHostFormError(w, r, p, errMsg)
+		return
+	}
 	if err := models.UpdateProxyHost(s.DB, p); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -5020,6 +5037,10 @@ func (s *Server) createRedirectionHost(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	if errMsg := s.previewRedirectValidate(s.currentServerID(r), rh); errMsg != "" { // v2.42.1 (issue #74)
+		s.renderRedirectionHostFormError(w, r, rh, errMsg)
+		return
+	}
 	id, err := models.CreateRedirectionHost(s.DB, s.currentServerID(r), rhOwnerID, rh)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -5111,6 +5132,10 @@ func (s *Server) updateRedirectionHost(w http.ResponseWriter, r *http.Request) {
 	// (the form has no hidden field for it — same as proxy hosts).
 	if old != nil {
 		rh.DNSRecordID = old.DNSRecordID
+	}
+	if errMsg := s.previewRedirectValidate(s.currentServerID(r), rh); errMsg != "" { // v2.42.1 (issue #74)
+		s.renderRedirectionHostFormError(w, r, rh, errMsg)
+		return
 	}
 	if err := models.UpdateRedirectionHost(s.DB, rh); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -7187,6 +7212,13 @@ func (s *Server) createCertificate(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	// v2.42.1 (issue #74): a file-path certificate Caddy cannot open is
+	// refused here, with the container-path explanation, instead of being
+	// saved and breaking every later sync of this server.
+	if errMsg := s.previewCertificateValidate(s.currentServerID(r), c); errMsg != "" {
+		s.renderCertificateFormError(w, r, c, errMsg)
+		return
+	}
 	id, err := models.CreateCertificate(s.DB, s.currentServerID(r), ownerID, c)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -7275,6 +7307,10 @@ func (s *Server) updateCertificate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	c.ID = id
+	if errMsg := s.previewCertificateValidate(s.currentServerID(r), c); errMsg != "" { // v2.42.1 (issue #74)
+		s.renderCertificateFormError(w, r, c, errMsg)
+		return
+	}
 	if err := models.UpdateCertificate(s.DB, c); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -7530,20 +7566,8 @@ func (s *Server) adaptRawRouteCaddyfile(caddyCl *caddy.Client, src string) (stri
 // would reject the resulting config — so callers can refuse to save instead of
 // committing a change that breaks the live config on next sync.
 func (s *Server) previewRawRouteValidate(serverID int64, rr *models.RawRoute) string {
-	proxies, err := models.ListProxyHosts(s.DB, serverID, 0, true, nil)
-	if err != nil {
-		return ""
-	}
-	redirs, err := models.ListRedirectionHosts(s.DB, serverID, 0, true, nil)
-	if err != nil {
-		return ""
-	}
-	raws, err := models.ListRawRoutes(s.DB, serverID, 0, true, nil)
-	if err != nil {
-		return ""
-	}
-	certs, err := models.ListCertificates(s.DB, serverID)
-	if err != nil {
+	proxies, redirs, raws, certs, ok := s.serverResources(serverID)
+	if !ok {
 		return ""
 	}
 	replaced := false
@@ -7557,6 +7581,15 @@ func (s *Server) previewRawRouteValidate(serverID int64, rr *models.RawRoute) st
 	if !replaced {
 		raws = append(raws, *rr)
 	}
+	return s.validateProposedConfig(serverID, proxies, redirs, raws, certs)
+}
+
+// validateProposedConfig builds the config a sync would push for these
+// resources and asks Caddy to validate it. Returns "" when Caddy accepts it
+// or cannot be reached — a save must not be blocked by an unrelated outage.
+// v2.42.1 (issue #74): shared by the proxy host, redirection and certificate
+// forms as well as Advanced routes.
+func (s *Server) validateProposedConfig(serverID int64, proxies []models.ProxyHost, redirs []models.RedirectionHost, raws []models.RawRoute, certs []models.Certificate) string {
 	caddyCl := s.caddyForServer(serverID)
 	current, _, err := caddyCl.FetchConfig()
 	if err != nil {
@@ -8167,7 +8200,27 @@ func (s *Server) syncPrometheusMetricsOnly(serverID int64, metricsCfg prometheus
 	return nil
 }
 
+// syncCaddy pushes the DB state for serverID to its Caddy and records the
+// outcome per server (v2.42.1, issue #74): a failure shows on every page
+// until the next successful sync, so a rejected change can no longer fail
+// silently in the log while the form says "saved".
 func (s *Server) syncCaddy(serverID int64, forceTLS bool) error {
+	err := s.syncCaddyInner(serverID, forceTLS)
+	if err == nil {
+		s.clearSyncError(serverID)
+		return nil
+	}
+	if s.syncHoldFor(serverID) == nil { // a post-apply hold has its own banner
+		name := ""
+		if srv, lookupErr := models.GetCaddyServer(s.DB, serverID); lookupErr == nil && srv != nil {
+			name = srv.Name
+		}
+		s.setSyncError(serverID, name, err)
+	}
+	return err
+}
+
+func (s *Server) syncCaddyInner(serverID int64, forceTLS bool) error {
 	// Load the target server so we can use its AdminURL for the Caddy client.
 	srv, err := models.GetCaddyServer(s.DB, serverID)
 	if err != nil {
@@ -10929,7 +10982,7 @@ func (s *Server) apiPreviewProxyHost(w http.ResponseWriter, r *http.Request) {
 	route := caddy.BuildProxyRoute(previewProxy, previewHandlers)
 	caddy.MergeReverseProxyOverrides(route, previewOverrides)
 	route = redactProxyRoutePreview(route).(map[string]any)
-	caddyfile := caddy.RenderProxyHostCaddyfile(*p)
+	caddyfile := caddy.RenderProxyHostCaddyfileWithCertificate(*p, s.certificateForCaddyfile(p.CertificateID))
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	response := map[string]any{"route": route, "caddyfile": caddyfile}
@@ -11987,7 +12040,7 @@ func (s *Server) exportProxyHostCaddyfile(w http.ResponseWriter, r *http.Request
 		http.NotFound(w, r)
 		return
 	}
-	body := caddy.RenderProxyHostCaddyfile(*ph)
+	body := caddy.RenderProxyHostCaddyfileWithCertificate(*ph, s.certificateForCaddyfile(ph.CertificateID))
 	fname := strings.ReplaceAll(strings.SplitN(ph.Domains, ",", 2)[0], "*", "_")
 	fname = strings.TrimSpace(fname)
 	if fname == "" {
@@ -12065,7 +12118,8 @@ func (s *Server) exportServerCaddyfile(w http.ResponseWriter, r *http.Request) {
 		serverName = srv.Name
 	}
 
-	body := caddy.RenderServerCaddyfile(serverName, hosts, redirects, raws)
+	certs, _ := models.ListCertificates(s.DB, sid)
+	body := caddy.RenderServerCaddyfile(serverName, hosts, redirects, raws, certs)
 	ts := time.Now().Format("20060102-150405")
 	fname := "Caddyfile"
 	if serverName != "" {

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -441,6 +441,20 @@ func TestExpectationsAreSurfaced(t *testing.T) {
 	}
 }
 
+// TestFailedSyncBannerIsSurfaced guards v2.42.1 (issue #74): a sync Caddy
+// rejected is shown on every page with retry and dismiss actions.
+func TestFailedSyncBannerIsSurfaced(t *testing.T) {
+	body, err := FS.ReadFile("templates/layout.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range []string{".SyncErrors", "data-sync-error", "/sync-error/clear", "/sync-reapply"} {
+		if !strings.Contains(string(body), m) {
+			t.Errorf("layout.html missing %q", m)
+		}
+	}
+}
+
 // TestCertificateExportIsSurfaced guards v2.42.0: the managed section of
 // the certificate form carries the export settings and status, and the fleet
 // server form carries the data-directory field the export depends on.

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -733,6 +733,18 @@ if ('serviceWorker' in navigator) {
             </div>
           </div>
           {{end}}
+          {{/* v2.42.1 (issue #74): the last sync to a server failed — shown on every page until a sync succeeds */}}
+          {{range .SyncErrors}}
+          <div class="mb-4 rounded-xl border border-amber-300 bg-amber-50 px-5 py-4 text-sm text-amber-900" role="alert" data-sync-error="{{.ServerID}}">
+            <div class="font-semibold">Caddy on {{.ServerName}} rejected the last sync — your latest changes there are <u>not</u> live.</div>
+            <div class="text-xs mt-1 break-words font-mono">{{.Error}}</div>
+            <div class="mt-2 flex flex-wrap items-center gap-2">
+              <form method="post" action="/servers/{{.ServerID}}/sync-reapply"><button type="submit" class="text-xs px-3 py-1.5 rounded-lg bg-amber-600 text-white hover:bg-amber-700 transition">Retry sync now</button></form>
+              <form method="post" action="/servers/{{.ServerID}}/sync-error/clear"><button type="submit" class="text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-900 hover:bg-amber-100 transition">Dismiss</button></form>
+              <span class="text-xs text-amber-800">{{fmtIn .At "2006-01-02 15:04:05"}} · fix the cause (a certificate file Caddy cannot open, for example), then retry</span>
+            </div>
+          </div>
+          {{end}}
           {{block "content" .}}{{end}}
         </div>
       </main>


### PR DESCRIPTION
## Summary

Fixes #74.

- **A proxy host, redirection or certificate that Caddy would not load was saved anyway.** The form said "saved", the sync failed only in the log, the live config stayed as it was — and every later sync for that server failed the same way. Reproduced with a file-path certificate whose files exist on the host but not inside the Caddy container (the reporter's "previously configured environment"). Proxy hosts, redirections and certificates are now validated against Caddy before they are saved, as Advanced routes already were; a file Caddy cannot open comes back as "Caddy cannot open /path for certificate X … the file must exist inside the Caddy container — mount the directory into Caddy or paste the PEM instead".
- **A failed sync is now visible.** When a sync is rejected for any reason after a save, an amber banner on every page names the server and Caddy's error, with **Retry sync now** and **Dismiss**, until the next sync succeeds. Servers under a post-apply hold keep their existing banner only.
- The Caddyfile view of a host with a custom certificate rendered only a comment; a file-path certificate now renders as a real `tls <cert> <key>` line (stored PEM / managed say how Caddy gets them), and an Advanced config `reverse_proxy { … }` block is folded into the generated block instead of printed as a second one. The Caddyfile export does the same.
- A reverse_proxy sub-directive typed bare in Advanced config (`flush_interval -1` on its own) is now moved into a `reverse_proxy { … }` block automatically — merged into an existing block, multi-line sub-directives included — instead of being explained back to the user (reported in chat right after v2.40.0).
- Two CodeQL findings from v2.38.0: `redirectBack` no longer accepts a protocol-relative `//host` path; expectation paths are normalised to exactly one leading slash.

## Verification

- Tests: `internal/server/preflight_test.go` (fake Caddy admin that rejects a `/missing/` certificate file: certificate / host / redirection refused with the container explanation, readable certificate passes; `syncCaddy` records the failure for the banner, clears it on the next success, defers to a hold), `TestWrapBareReverseProxySubdirectives`, `TestRedirectBackStaysLocal`, `internal/caddy/exporter_certificate_test.go`, and a layout guard. Full suite green.
- Scratch CaddyUI against a real `caddy:2-alpine`: creating a file-path certificate with a missing file re-renders the form with the explanation and nothing is saved; with a pre-existing broken certificate every save is refused naming that certificate until it is deleted; a bare `flush_interval -1` is saved wrapped and Caddy's live route carries `flush_interval: -1`; a sync failure caused by a row seeded directly into the DB shows the banner (screenshot) and deleting the row clears it on the next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)