### PR TITLE
fix: repair JSON-style transport names and misplaced transport options in Advanced config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.42.2] - 2026-09-08 - Advanced config: JSON-style transport names and misplaced transport options are repaired
+
+### Fixed
+
+- Saving a proxy host whose Advanced config used Caddy's JSON field names inside a transport block — `read_buffer_size 16384` / `write_buffer_size 16384`, as reported for a Nextcloud host — failed with `unrecognized subdirective read_buffer_size`. In a Caddyfile those options are spelled `read_buffer`, `write_buffer` and `max_response_header`; CaddyUI now respells them, and moves transport-only options typed directly under `reverse_proxy` (timeouts, buffers, keepalive, TLS, versions…) into the block's `transport http { … }`, merging with an existing one. The repairs also apply when an already-saved Advanced config is adapted for a sync, so such hosts start working on the next sync without being re-saved.
+- When Caddy still rejects an unknown sub-directive, the message now says which name it is, how it is spelled in a Caddyfile, where transport options go, and that the same settings exist as dedicated form options (Upstream → timeouts and buffers, Streaming → Flush immediately).
+
+---
+
 ## [2.42.1] - 2026-09-08 - Changes Caddy rejects are refused up front, failed syncs are visible
 
 ### Fixed

--- a/internal/server/proxy_advanced_overrides.go
+++ b/internal/server/proxy_advanced_overrides.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -235,4 +236,193 @@ func wrapBareReverseProxySubdirectivesNamed(src string) (string, []string) {
 		return block, names
 	}
 	return body + "\n" + block, names
+}
+
+// v2.42.2: users copy option names from Caddy's JSON (read_buffer_size) or
+// put transport options straight under reverse_proxy; Caddy's adapter
+// rejects both with "unrecognized subdirective". Both are unambiguous, so
+// they are repaired rather than reported: JSON-style names become their
+// Caddyfile spelling, and transport-only options found directly under
+// reverse_proxy move into its `transport http { … }` block.
+
+// transportAliases maps JSON field names people type into the Caddyfile
+// spelling of the same `transport http` option.
+var transportAliases = map[string]string{
+	"read_buffer_size":         "read_buffer",
+	"write_buffer_size":        "write_buffer",
+	"max_response_header_size": "max_response_header",
+}
+
+// transportSubdirectives are options that only exist inside `transport http`.
+var transportSubdirectives = []string{
+	"read_buffer", "write_buffer", "max_response_header", "proxy_protocol",
+	"dial_timeout", "dial_fallback_delay", "response_header_timeout", "expect_continue_timeout",
+	"resolvers", "tls", "tls_client_auth", "tls_insecure_skip_verify", "tls_timeout", "tls_trusted_ca_certs",
+	"tls_trust_pool", "tls_server_name", "tls_renegotiation", "tls_except_ports", "tls_curves",
+	"keepalive", "keepalive_interval", "keepalive_idle_conns", "keepalive_idle_conns_per_host",
+	"versions", "compression", "max_conns_per_host", "forward_proxy_url", "network_proxy", "local_address",
+}
+
+// normalizeProxyAdvancedConfig is every repair applied to an Advanced config
+// before it is adapted or saved: bare reverse_proxy sub-directives wrapped
+// (v2.42.1), JSON-style transport names respelled, and transport options
+// under reverse_proxy moved into its transport block.
+func normalizeProxyAdvancedConfig(src string) string {
+	return relocateTransportSubdirectives(respellTransportAliases(wrapBareReverseProxySubdirectives(src)))
+}
+
+func advancedFirstToken(line string) string {
+	t := strings.TrimSpace(line)
+	if i := strings.Index(t, "#"); i >= 0 {
+		t = strings.TrimSpace(t[:i])
+	}
+	if t == "" {
+		return ""
+	}
+	return strings.Fields(t)[0]
+}
+
+func advancedBraceDelta(line string) int {
+	t := strings.TrimSpace(line)
+	if i := strings.Index(t, "#"); i >= 0 {
+		t = t[:i]
+	}
+	d := 0
+	for _, ch := range t {
+		switch ch {
+		case '{':
+			d++
+		case '}':
+			d--
+		}
+	}
+	return d
+}
+
+// respellTransportAliases rewrites the first token of any line that uses a
+// JSON-style transport option name.
+func respellTransportAliases(src string) string {
+	lines := strings.Split(src, "\n")
+	changed := false
+	for i, line := range lines {
+		first := advancedFirstToken(line)
+		alias, ok := transportAliases[first]
+		if !ok {
+			continue
+		}
+		indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+		lines[i] = indent + alias + strings.TrimPrefix(strings.TrimLeft(line, " \t"), first)
+		changed = true
+	}
+	if !changed {
+		return src
+	}
+	return strings.Join(lines, "\n")
+}
+
+// relocateTransportSubdirectives moves transport-only options that sit
+// directly inside a top-level reverse_proxy block into that block's
+// `transport http { … }` (merged into an existing one). Anything else is
+// left exactly as typed.
+func relocateTransportSubdirectives(src string) string {
+	isTransport := map[string]bool{}
+	for _, d := range transportSubdirectives {
+		isTransport[d] = true
+	}
+	lines := strings.Split(src, "\n")
+	// Find the top-level reverse_proxy block.
+	depth, start, end := 0, -1, -1
+	for i, line := range lines {
+		first := advancedFirstToken(line)
+		if depth == 0 && first == "reverse_proxy" && strings.HasSuffix(strings.TrimSpace(strings.SplitN(line, "#", 2)[0]), "{") {
+			start = i
+			d := advancedBraceDelta(line)
+			for j := i + 1; j < len(lines); j++ {
+				d += advancedBraceDelta(lines[j])
+				if d == 0 {
+					end = j
+					break
+				}
+			}
+			break
+		}
+		depth += advancedBraceDelta(line)
+	}
+	if start < 0 || end < 0 {
+		return src
+	}
+	// Walk the block body at relative depth 1: pull out transport options,
+	// remember an existing transport block.
+	var body, moved []string
+	transportOpen, transportClose := -1, -1 // indexes into body
+	rel := 0
+	for i := start + 1; i < end; {
+		line := lines[i]
+		first := advancedFirstToken(line)
+		if rel == 0 && first == "transport" && transportOpen < 0 {
+			transportOpen = len(body)
+			body = append(body, line)
+			d := advancedBraceDelta(line)
+			i++
+			for d > 0 && i < end {
+				body = append(body, lines[i])
+				d += advancedBraceDelta(lines[i])
+				i++
+			}
+			transportClose = len(body) - 1
+			continue
+		}
+		if rel == 0 && isTransport[first] {
+			moved = append(moved, "\t\t"+strings.TrimSpace(line))
+			d := advancedBraceDelta(line)
+			i++
+			for d > 0 && i < end {
+				moved = append(moved, "\t\t"+strings.TrimSpace(lines[i]))
+				d += advancedBraceDelta(lines[i])
+				i++
+			}
+			continue
+		}
+		body = append(body, line)
+		rel += advancedBraceDelta(line)
+		i++
+	}
+	if len(moved) == 0 {
+		return src
+	}
+	var newBody []string
+	if transportOpen >= 0 && transportClose > transportOpen {
+		newBody = append(newBody, body[:transportClose]...)
+		newBody = append(newBody, moved...)
+		newBody = append(newBody, body[transportClose:]...)
+	} else {
+		newBody = append(newBody, body...)
+		newBody = append(newBody, "\ttransport http {")
+		newBody = append(newBody, moved...)
+		newBody = append(newBody, "\t}")
+	}
+	out := append([]string{}, lines[:start+1]...)
+	out = append(out, newBody...)
+	out = append(out, lines[end:]...)
+	return strings.Join(out, "\n")
+}
+
+var unrecognizedSubdirective = regexp.MustCompile(`unrecognized subdirective ([A-Za-z0-9_]+)`)
+
+// friendlyAdvancedRejection turns Caddy's adapter error into advice when it
+// is about an unknown sub-directive — the one people hit when they mix JSON
+// names, Caddyfile names and transport options.
+func friendlyAdvancedRejection(err error) string {
+	msg := err.Error()
+	m := unrecognizedSubdirective.FindStringSubmatch(msg)
+	if m == nil {
+		return "Advanced config rejected by Caddy: " + msg
+	}
+	name := m[1]
+	hint := fmt.Sprintf("`%s` is not an option Caddy knows there.", name)
+	if alias, ok := transportAliases[name]; ok {
+		hint += fmt.Sprintf(" In a Caddyfile it is spelled `%s`, inside `transport http { … }`.", alias)
+	}
+	hint += " Caddyfile names differ from the JSON ones (read_buffer_size → read_buffer, write_buffer_size → write_buffer, max_response_header_size → max_response_header); transport options belong inside `transport http { … }` within the reverse_proxy block; and most have a dedicated option in this form — Upstream → timeouts and buffers, Streaming → Flush immediately — which is the simplest place for them."
+	return "Advanced config rejected by Caddy: " + hint + " Caddy said: " + msg
 }

--- a/internal/server/proxy_advanced_overrides_test.go
+++ b/internal/server/proxy_advanced_overrides_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -118,10 +119,17 @@ func TestAdvancedReverseProxyBlockThroughRealCaddy(t *testing.T) {
 	if s.validateProxyAdvanced(caddy.New(admin, "", ""), &p) != "" {
 		t.Errorf("validateProxyAdvanced should accept the block")
 	}
+	// v2.42.1: a bare sub-directive is wrapped, so it is simply accepted…
 	bare := p
 	bare.AdvancedConfig = "flush_interval -1"
-	if msg := s.validateProxyAdvanced(caddy.New(admin, "", ""), &bare); !strings.Contains(msg, "sub-directive") {
-		t.Errorf("bare sub-directive should be explained, got %q", msg)
+	if msg := s.validateProxyAdvanced(caddy.New(admin, "", ""), &bare); msg != "" {
+		t.Errorf("bare sub-directive should be repaired and accepted, got %q", msg)
+	}
+	// …while a genuinely unknown option gets the v2.42.2 explanation.
+	bogus := p
+	bogus.AdvancedConfig = "reverse_proxy {\n\tbogus_option 1\n}\n"
+	if msg := s.validateProxyAdvanced(caddy.New(admin, "", ""), &bogus); !strings.Contains(msg, "`bogus_option` is not an option Caddy knows there") {
+		t.Errorf("unknown option should be explained, got %q", msg)
 	}
 }
 
@@ -150,5 +158,81 @@ func TestWrapBareReverseProxySubdirectives(t *testing.T) {
 	// After wrapping, validation no longer complains and the block adapts.
 	if msg := validateProxyAdvancedDirectives(wrapBareReverseProxySubdirectives("flush_interval -1")); msg != "" {
 		t.Errorf("wrapped source should validate, got %q", msg)
+	}
+}
+
+// v2.42.2: JSON-style transport names are respelled and transport options
+// under reverse_proxy move into its transport block — including the exact
+// config from the report (flush_interval plus a transport block using
+// read_buffer_size / write_buffer_size).
+func TestNormalizeProxyAdvancedConfigRepairsTransportOptions(t *testing.T) {
+	reported := "flush_interval -1\n\ntransport http {\n    dial_timeout 30s\n    response_header_timeout 300s\n    read_buffer_size 16384\n    write_buffer_size 16384\n}\n"
+	got := normalizeProxyAdvancedConfig(reported)
+	for _, want := range []string{"reverse_proxy {", "\tflush_interval -1", "read_buffer 16384", "write_buffer 16384", "dial_timeout 30s"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("normalized config missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "read_buffer_size") || strings.Contains(got, "write_buffer_size") {
+		t.Errorf("JSON names should be respelled:\n%s", got)
+	}
+	if msg := validateProxyAdvancedDirectives(got); msg != "" {
+		t.Errorf("normalized config should validate, got %q", msg)
+	}
+
+	// Transport options typed directly under reverse_proxy move into a new transport block.
+	got = relocateTransportSubdirectives("reverse_proxy {\n\tflush_interval -1\n\tread_buffer 8192\n\tdial_timeout 10s\n}\n")
+	want := "reverse_proxy {\n\tflush_interval -1\n\ttransport http {\n\t\tread_buffer 8192\n\t\tdial_timeout 10s\n\t}\n}\n"
+	if got != want {
+		t.Errorf("relocate into new block = %q\nwant %q", got, want)
+	}
+	// … or into the existing one.
+	got = relocateTransportSubdirectives("reverse_proxy {\n\tread_buffer 8192\n\ttransport http {\n\t\tdial_timeout 10s\n\t}\n}\n")
+	want = "reverse_proxy {\n\ttransport http {\n\t\tdial_timeout 10s\n\t\tread_buffer 8192\n\t}\n}\n"
+	if got != want {
+		t.Errorf("relocate into existing block = %q\nwant %q", got, want)
+	}
+	for _, unchanged := range []string{"", "encode gzip\n", "reverse_proxy {\n\tflush_interval -1\n\ttransport http {\n\t\tread_buffer 1\n\t}\n}\n"} {
+		if got := normalizeProxyAdvancedConfig(unchanged); got != unchanged {
+			t.Errorf("%q should be untouched, got %q", unchanged, got)
+		}
+	}
+	if got := respellTransportAliases("  max_response_header_size 64KiB # note"); got != "  max_response_header 64KiB # note" {
+		t.Errorf("respell = %q", got)
+	}
+
+	err := errors.New(`caddy rejected Caddyfile: {"error":"adapting config using caddyfile adapter: parsing caddyfile tokens for 'reverse_proxy': unrecognized subdirective read_buffer_size, at Caddyfile:7"}`)
+	msg := friendlyAdvancedRejection(err)
+	if !strings.Contains(msg, "`read_buffer_size` is not an option Caddy knows there") || !strings.Contains(msg, "spelled `read_buffer`") || !strings.Contains(msg, "Upstream") || !strings.Contains(msg, "Caddy said:") {
+		t.Errorf("friendly message = %q", msg)
+	}
+	if msg := friendlyAdvancedRejection(errors.New("something else")); msg != "Advanced config rejected by Caddy: something else" {
+		t.Errorf("non-subdirective errors pass through, got %q", msg)
+	}
+}
+
+// The reported config adapts through a real Caddy once repaired; set
+// CADDYUI_TEST_CADDY_ADMIN to run.
+func TestReportedTransportConfigThroughRealCaddy(t *testing.T) {
+	admin := os.Getenv("CADDYUI_TEST_CADDY_ADMIN")
+	if admin == "" {
+		t.Skip("CADDYUI_TEST_CADDY_ADMIN not set")
+	}
+	s := &Server{}
+	p := models.ProxyHost{Domains: "cloud.example.test", ForwardScheme: "http", ForwardHost: "nextcloud", ForwardPort: 80, Enabled: true,
+		AdvancedConfig: "flush_interval -1\n\ntransport http {\n    dial_timeout 30s\n    response_header_timeout 300s\n    read_buffer_size 16384\n    write_buffer_size 16384\n}\n"}
+	if msg := s.validateProxyAdvanced(caddy.New(admin, "", ""), &p); msg != "" {
+		t.Fatalf("repaired config should be accepted, got %q", msg)
+	}
+	handlers, overrides, err := s.adaptProxyAdvancedWithClient(caddy.New(admin, "", ""), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	route := caddy.BuildProxyRoute(p, handlers)
+	caddy.MergeReverseProxyOverrides(route, overrides)
+	rp := route["handle"].([]any)[len(route["handle"].([]any))-1].(map[string]any)
+	transport, _ := rp["transport"].(map[string]any)
+	if transport == nil || transport["read_buffer_size"] == nil || transport["write_buffer_size"] == nil || transport["response_header_timeout"] == nil || rp["flush_interval"] == nil {
+		t.Errorf("merged handler = %v", rp)
 	}
 }

--- a/internal/server/proxy_host_form.go
+++ b/internal/server/proxy_host_form.go
@@ -191,7 +191,7 @@ func parseProxyHostForm(r *http.Request) (*models.ProxyHost, error) {
 		SSLEnabled:             r.FormValue("ssl_enabled") == "on",
 		SSLForced:              r.FormValue("ssl_forced") == "on",
 		HTTP2Support:           r.FormValue("http2_support") == "on",
-		AdvancedConfig:         wrapBareReverseProxySubdirectives(r.FormValue("advanced_config")), // v2.42.1
+		AdvancedConfig:         normalizeProxyAdvancedConfig(r.FormValue("advanced_config")), // v2.42.1 / v2.42.2
 		Enabled:                r.FormValue("enabled") == "on",
 		CertificateID:          certID,
 		AccessList:             strings.TrimSpace(r.FormValue("access_list")),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8507,11 +8507,12 @@ func (s *Server) validateProxyAdvanced(caddyCl *caddy.Client, p *models.ProxyHos
 	if strings.TrimSpace(p.AdvancedConfig) == "" {
 		return ""
 	}
-	if errMsg := validateProxyAdvancedDirectives(p.AdvancedConfig); errMsg != "" {
+	// v2.42.2: judge the repaired config, exactly what the adapter sees.
+	if errMsg := validateProxyAdvancedDirectives(normalizeProxyAdvancedConfig(p.AdvancedConfig)); errMsg != "" {
 		return errMsg
 	}
 	if _, _, err := s.adaptProxyAdvancedWithClient(caddyCl, *p); err != nil {
-		return "Advanced config rejected by Caddy: " + err.Error()
+		return friendlyAdvancedRejection(err) // v2.42.2
 	}
 	return ""
 }
@@ -8600,7 +8601,9 @@ func (s *Server) adaptProxyAdvanced(p models.ProxyHost) ([]any, map[string]any, 
 // returns the handlers that run before the host's reverse_proxy plus, since
 // v2.40.0, the fields of a `reverse_proxy { … }` block to merge into it.
 func (s *Server) adaptProxyAdvancedWithClient(caddyCl *caddy.Client, p models.ProxyHost) ([]any, map[string]any, error) {
-	src := fmt.Sprintf("localhost {\n%s\n}\n", p.AdvancedConfig)
+	// v2.42.2: repairs applied here too, so configs saved before the
+	// repairs existed adapt on the next sync without being re-saved.
+	src := fmt.Sprintf("localhost {\n%s\n}\n", normalizeProxyAdvancedConfig(p.AdvancedConfig))
 	adapted, err := caddyCl.Adapt(src)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary

Reported in chat right after v2.42.1: saving `cloud.richardapplegate.io` failed with `unrecognized subdirective read_buffer_size, at Caddyfile:7`. The host's Advanced config was

```
flush_interval -1

transport http {
    dial_timeout 30s
    response_header_timeout 300s
    read_buffer_size 16384
    write_buffer_size 16384
}
```

`read_buffer_size` / `write_buffer_size` are Caddy's JSON field names; in a Caddyfile the `transport http` options are spelled `read_buffer` / `write_buffer` (and `max_response_header`).

- CaddyUI now respells those JSON-style names, and moves transport-only options typed directly under `reverse_proxy` (timeouts, buffers, keepalive, TLS, versions…) into the block's `transport http { … }`, merging with an existing one. Together with the v2.42.1 wrap, the config above becomes a valid `reverse_proxy { flush_interval -1; transport http { … read_buffer 16384; write_buffer 16384 } }`.
- The repairs also apply when an already-saved Advanced config is adapted for a sync (`adaptProxyAdvancedWithClient`), so affected hosts start syncing their Advanced config on the next sync without being re-saved. Until now a failing adapt at sync time silently dropped the Advanced handlers for that host.
- `validateProxyAdvanced` judges the repaired text, the same text the adapter sees.
- When Caddy still rejects an unknown sub-directive, the message names it, gives the Caddyfile spelling where one exists, says where transport options go, and points at the dedicated form options (Upstream → timeouts and buffers, Streaming → Flush immediately).

## Verification

- `TestNormalizeProxyAdvancedConfigRepairsTransportOptions` (the reported config, relocation into a new and into an existing transport block, untouched inputs, alias respelling with a trailing comment, the friendly message) and the opt-in `TestReportedTransportConfigThroughRealCaddy`, run green against `caddy:2-alpine`: the repaired config is accepted and the merged handler carries `flush_interval`, `read_buffer_size`, `write_buffer_size` and `response_header_timeout`. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)