### PR TITLE
feat: analytics retention actually runs, is configurable, and space can be reclaimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.43.0] - 2026-09-09 - Analytics retention actually runs, is configurable, and space can be reclaimed
+
+### Fixed
+
+- **Raw analytics events were never pruned.** The 30-day prune loop has existed since v2.7.0, but nothing ever started it, so `access_events` grew without bound — one production database had reached 22 GB with 63 million rows older than 30 days. The loop now starts with the other background workers, runs an hour after start-up and hourly after that, and deletes in batches of 20,000 so the write lock is never held for long even on a first run against months of backlog.
+
+### Added
+
+- **Settings → Analytics → Keep raw events for N days** (default 30; 0 keeps forever). Per-day totals per host are kept in a separate rollup, so shortening the retention does not blank long-range charts.
+- A **Storage** panel on the same card: database file size, space already freed inside the file, oldest and newest event, the last prune (rows removed and kept) and the last reclaim, with **Prune now** and **Reclaim space** buttons. Reclaim runs SQLite's VACUUM in the background — the only thing that actually shrinks the file after rows are deleted — and is refused when the data volume lacks room for a full copy; on MariaDB the panel points at `OPTIMIZE TABLE` instead. Both actions are recorded in the Activity log.
+- The Docker image sets `SQLITE_TMPDIR=/data` so VACUUM has a working directory in the scratch-based image, which has no `/tmp`.
+
+---
+
 ## [2.42.2] - 2026-09-08 - Advanced config: JSON-style transport names and misplaced transport options are repaired
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,10 @@ COPY --chmod=1777 --from=build /out/tmp /tmp
 USER 10001
 
 EXPOSE 8080
-ENV CADDYUI_DB=/data/caddyui.db \
+# SQLITE_TMPDIR: VACUUM (Settings → Analytics → Reclaim space) writes its
+# working copy to a temp directory; the scratch image has no /tmp.
+ENV SQLITE_TMPDIR=/data \
+    CADDYUI_DB=/data/caddyui.db \
     CADDYUI_LISTEN=:8080 \
     CADDY_ADMIN_URL=http://caddy:2019
 VOLUME ["/data"]

--- a/internal/models/access.go
+++ b/internal/models/access.go
@@ -1082,3 +1082,60 @@ func TopBrowsers(db *sql.DB, since time.Time, host string, limit int, serverIDs 
 	}
 	return out, nil
 }
+
+// PruneAccessEventsBatched (v2.43.0) deletes events older than olderThan in
+// batches, so a long-overdue prune never holds the write lock for minutes at
+// a time. Events are appended in time order, so taking the lowest ids first
+// finds the oldest rows without needing a ts index. stop, when non-nil, is
+// polled between batches. Returns how many rows were deleted.
+func PruneAccessEventsBatched(db *sql.DB, olderThan time.Time, batch int, mariadb bool, stop func() bool) (int64, error) {
+	if batch <= 0 {
+		batch = 20000
+	}
+	var total int64
+	for {
+		if stop != nil && stop() {
+			return total, nil
+		}
+		var res sql.Result
+		var err error
+		if mariadb {
+			res, err = db.Exec(`DELETE FROM access_events WHERE ts < ? ORDER BY id LIMIT ?`, olderThan.Unix(), batch)
+		} else {
+			res, err = db.Exec(`DELETE FROM access_events WHERE id IN (SELECT id FROM access_events WHERE ts < ? ORDER BY id LIMIT ?)`, olderThan.Unix(), batch)
+		}
+		if err != nil {
+			return total, err
+		}
+		n, _ := res.RowsAffected()
+		total += n
+		if n < int64(batch) {
+			return total, nil
+		}
+	}
+}
+
+// AccessEventBounds returns the timestamps of the oldest and newest events
+// (zero when the table is empty). Read from the ends of the id order, which
+// is instant however large the table is.
+func AccessEventBounds(db *sql.DB) (oldest, newest time.Time, err error) {
+	var lo, hi int64
+	if err = db.QueryRow(`SELECT ts FROM access_events ORDER BY id ASC LIMIT 1`).Scan(&lo); err != nil {
+		if err == sql.ErrNoRows {
+			return time.Time{}, time.Time{}, nil
+		}
+		return
+	}
+	if err = db.QueryRow(`SELECT ts FROM access_events ORDER BY id DESC LIMIT 1`).Scan(&hi); err != nil {
+		return
+	}
+	return time.Unix(lo, 0).UTC(), time.Unix(hi, 0).UTC(), nil
+}
+
+// CountAccessEvents is a full count — cheap once retention keeps the table
+// small, so it is taken after each prune rather than on every page view.
+func CountAccessEvents(db *sql.DB) (int64, error) {
+	var n int64
+	err := db.QueryRow(`SELECT COUNT(*) FROM access_events`).Scan(&n)
+	return n, err
+}

--- a/internal/server/analytics.go
+++ b/internal/server/analytics.go
@@ -871,27 +871,6 @@ func formatWindow(d time.Duration) string {
 	}
 }
 
-// pruneAccessLoop runs forever, deleting access_events older than the
-// configured retention (default 30d) once per day. Started by main.go
-// alongside the ingest listener. Cheap — one DELETE with an indexed
-// WHERE clause; SQLite can knock out 100k rows in a fraction of a second.
-func (s *Server) pruneAccessLoop() {
-	// First prune after 60s so a crashing container that wrote bad events
-	// gets cleaned promptly on next restart, rather than waiting 24h.
-	timer := time.NewTimer(60 * time.Second)
-	defer timer.Stop()
-	for {
-		<-timer.C
-		cutoff := time.Now().Add(-30 * 24 * time.Hour)
-		if n, err := models.PruneAccessEvents(s.DB, cutoff); err != nil {
-			log.Printf("analytics: prune error: %v", err)
-		} else if n > 0 {
-			log.Printf("analytics: pruned %d events older than %s", n, cutoff.Format(time.RFC3339))
-		}
-		timer.Reset(24 * time.Hour)
-	}
-}
-
 // --- Global search ---
 
 // getSearch handles GET /search — full-text search across proxy hosts,

--- a/internal/server/analytics_retention.go
+++ b/internal/server/analytics_retention.go
@@ -1,0 +1,335 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	appdb "github.com/X4Applegate/caddyui/internal/db"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+// v2.43.0: analytics retention.
+//
+// pruneAccessLoop existed since v2.7.0 but nothing ever started it, so
+// access_events grew without bound: one production database reached 22 GB
+// with 63 million rows older than the intended 30 days. The loop is now
+// started with the other pollers, the retention is a setting, deletes run
+// in batches so the write lock is never held for long, and Settings →
+// Analytics shows what the table holds with Prune now and Reclaim space
+// actions. Reclaiming (VACUUM) is what actually shrinks the SQLite file —
+// deleting rows only frees pages inside it.
+
+const (
+	settingAnalyticsRetentionDays = "analytics_retention_days" // "" = default; "0" = keep forever
+	settingAnalyticsPruneStatus   = "analytics_prune_status"
+	settingAnalyticsVacuumStatus  = "analytics_vacuum_status"
+
+	defaultAnalyticsRetentionDays = 30
+	maxAnalyticsRetentionDays     = 3650
+	accessPruneBatch              = 20000
+	accessPruneEvery              = time.Hour
+	accessPruneFirstAfter         = 60 * time.Second
+)
+
+// analyticsRetentionDays is the configured retention: default 30, 0 = keep
+// forever, clamped to [1, 3650] otherwise.
+func analyticsRetentionDays(s *Server) int {
+	raw := strings.TrimSpace(mustGetSetting(s.DB, settingAnalyticsRetentionDays))
+	if raw == "" {
+		return defaultAnalyticsRetentionDays
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return defaultAnalyticsRetentionDays
+	}
+	if n <= 0 {
+		return 0
+	}
+	if n > maxAnalyticsRetentionDays {
+		return maxAnalyticsRetentionDays
+	}
+	return n
+}
+
+type accessPruneStatus struct {
+	StartedAt  time.Time  `json:"started_at"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+	Cutoff     *time.Time `json:"cutoff,omitempty"`
+	Deleted    int64      `json:"deleted"`
+	Remaining  int64      `json:"remaining"` // -1 = not counted
+	Error      string     `json:"error,omitempty"`
+	Manual     bool       `json:"manual,omitempty"`
+}
+
+type analyticsVacuumStatus struct {
+	StartedAt   time.Time  `json:"started_at"`
+	FinishedAt  *time.Time `json:"finished_at,omitempty"`
+	BeforeBytes int64      `json:"before_bytes"`
+	AfterBytes  int64      `json:"after_bytes"`
+	Error       string     `json:"error,omitempty"`
+}
+
+func (s *Server) storeJSONSetting(key string, v any) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	if err := models.SetSetting(s.DB, key, string(raw)); err != nil {
+		log.Printf("analytics: store %s: %v", key, err)
+	}
+}
+
+func (s *Server) lastPruneStatus() *accessPruneStatus {
+	raw, err := models.GetSetting(s.DB, settingAnalyticsPruneStatus)
+	if err != nil || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var st accessPruneStatus
+	if json.Unmarshal([]byte(raw), &st) != nil {
+		return nil
+	}
+	return &st
+}
+
+func (s *Server) lastVacuumStatus() *analyticsVacuumStatus {
+	raw, err := models.GetSetting(s.DB, settingAnalyticsVacuumStatus)
+	if err != nil || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var st analyticsVacuumStatus
+	if json.Unmarshal([]byte(raw), &st) != nil {
+		return nil
+	}
+	return &st
+}
+
+// runAccessPrune deletes events older than the retention, in batches, and
+// records the outcome. It is serialized: a scheduled pass and a manual one
+// never overlap. Returns the status it recorded.
+func (s *Server) runAccessPrune(manual bool) accessPruneStatus {
+	s.accessPruneMu.Lock()
+	defer s.accessPruneMu.Unlock()
+	st := accessPruneStatus{StartedAt: time.Now().UTC(), Remaining: -1, Manual: manual}
+	days := analyticsRetentionDays(s)
+	if days == 0 {
+		done := time.Now().UTC()
+		st.FinishedAt = &done
+		s.storeJSONSetting(settingAnalyticsPruneStatus, st)
+		return st
+	}
+	cutoff := time.Now().Add(-time.Duration(days) * 24 * time.Hour).UTC()
+	st.Cutoff = &cutoff
+	s.storeJSONSetting(settingAnalyticsPruneStatus, st) // visible as "running"
+	mariadb := appdb.BackendOf(s.DB) == appdb.BackendMariaDB
+	deleted, err := models.PruneAccessEventsBatched(s.DB, cutoff, accessPruneBatch, mariadb, nil)
+	st.Deleted = deleted
+	if err != nil {
+		st.Error = err.Error()
+		log.Printf("analytics: prune error after %d rows: %v", deleted, err)
+	} else {
+		if n, countErr := models.CountAccessEvents(s.DB); countErr == nil {
+			st.Remaining = n
+		}
+		if deleted > 0 {
+			log.Printf("analytics: pruned %d events older than %s (%d days); %d remain", deleted, cutoff.Format(time.RFC3339), days, st.Remaining)
+		}
+	}
+	done := time.Now().UTC()
+	st.FinishedAt = &done
+	s.storeJSONSetting(settingAnalyticsPruneStatus, st)
+	return st
+}
+
+// pruneAccessLoop runs the first prune shortly after start-up, then hourly.
+// Started by New with the other pollers (it never was before v2.43.0).
+func (s *Server) pruneAccessLoop() {
+	timer := time.NewTimer(accessPruneFirstAfter)
+	defer timer.Stop()
+	for {
+		<-timer.C
+		s.runAccessPrune(false)
+		timer.Reset(accessPruneEvery)
+	}
+}
+
+// startAccessPrune runs a manual prune in the background unless one is
+// already running. Returns false when it was.
+func (s *Server) startAccessPrune() bool {
+	if !s.accessPruneMu.TryLock() {
+		return false
+	}
+	s.accessPruneMu.Unlock()
+	go s.runAccessPrune(true)
+	return true
+}
+
+// analyticsStorage is what Settings → Analytics shows about the table and
+// the database file.
+type analyticsStorage struct {
+	SQLite          bool
+	DBPath          string
+	DBBytes         int64
+	FreePageBytes   int64 // pages freed by deletes, not yet returned to the OS
+	DiskFreeBytes   int64
+	Oldest          time.Time
+	Newest          time.Time
+	RetentionDays   int
+	LastPrune       *accessPruneStatus
+	PruneRunning    bool
+	LastVacuum      *analyticsVacuumStatus
+	VacuumRunning   bool
+	VacuumPossible  bool
+	VacuumBlockedBy string
+}
+
+func (s *Server) analyticsStorageView() analyticsStorage {
+	v := analyticsStorage{
+		SQLite:        appdb.BackendOf(s.DB) != appdb.BackendMariaDB,
+		DBPath:        s.DBPath,
+		RetentionDays: analyticsRetentionDays(s),
+		LastPrune:     s.lastPruneStatus(),
+		LastVacuum:    s.lastVacuumStatus(),
+	}
+	if v.LastPrune != nil && v.LastPrune.FinishedAt == nil {
+		v.PruneRunning = true
+	}
+	if v.LastVacuum != nil && v.LastVacuum.FinishedAt == nil {
+		v.VacuumRunning = true
+	}
+	if oldest, newest, err := models.AccessEventBounds(s.DB); err == nil {
+		v.Oldest, v.Newest = oldest, newest
+	}
+	if v.SQLite {
+		if s.DBPath != "" {
+			if fi, err := os.Stat(s.DBPath); err == nil {
+				v.DBBytes = fi.Size()
+			}
+			v.DiskFreeBytes = diskFreeBytes(filepath.Dir(s.DBPath))
+		}
+		var pageSize, freelist int64
+		if err := s.DB.QueryRow(`PRAGMA page_size`).Scan(&pageSize); err == nil {
+			if err := s.DB.QueryRow(`PRAGMA freelist_count`).Scan(&freelist); err == nil {
+				v.FreePageBytes = pageSize * freelist
+			}
+		}
+		switch {
+		case s.DBPath == "":
+			v.VacuumBlockedBy = "the database path is not known to this process"
+		case v.VacuumRunning:
+			v.VacuumBlockedBy = "a reclaim is already running"
+		case v.DiskFreeBytes > 0 && v.DiskFreeBytes < v.DBBytes+v.DBBytes/10:
+			v.VacuumBlockedBy = fmt.Sprintf("only %s free on the data volume; reclaiming needs room for a full copy (%s)", fmtBytesShort(v.DiskFreeBytes), fmtBytesShort(v.DBBytes))
+		default:
+			v.VacuumPossible = true
+		}
+	}
+	return v
+}
+
+func diskFreeBytes(dir string) int64 {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(dir, &st); err != nil {
+		return 0
+	}
+	return int64(st.Bavail) * int64(st.Bsize)
+}
+
+func fmtBytesShort(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+// startVacuum runs VACUUM in the background (SQLite only). Deleted rows only
+// free pages inside the file; VACUUM rewrites it without them. It needs room
+// for a full copy next to the database and blocks writers while it runs, so
+// it is an explicit action with a status, never automatic.
+func (s *Server) startVacuum() error {
+	view := s.analyticsStorageView()
+	if !view.SQLite {
+		return fmt.Errorf("reclaiming space is a SQLite operation; on MariaDB run OPTIMIZE TABLE access_events")
+	}
+	if !view.VacuumPossible {
+		return fmt.Errorf("cannot reclaim space now: %s", view.VacuumBlockedBy)
+	}
+	if !s.vacuumMu.TryLock() {
+		return fmt.Errorf("a reclaim is already running")
+	}
+	st := analyticsVacuumStatus{StartedAt: time.Now().UTC(), BeforeBytes: view.DBBytes}
+	s.storeJSONSetting(settingAnalyticsVacuumStatus, st)
+	// SQLite writes VACUUM's working copy to a temp directory; the scratch
+	// image has no /tmp, so point it at the data volume when nothing else
+	// was set (the Dockerfile sets SQLITE_TMPDIR=/data too).
+	if os.Getenv("SQLITE_TMPDIR") == "" {
+		_ = os.Setenv("SQLITE_TMPDIR", filepath.Dir(s.DBPath))
+	}
+	go func() {
+		defer s.vacuumMu.Unlock()
+		_, err := s.DB.Exec("VACUUM")
+		if err == nil {
+			// In WAL mode the rewritten database reaches the main file, and
+			// the file is truncated, only at a checkpoint — do it now so the
+			// new size is real rather than pending.
+			_, _ = s.DB.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+		}
+		done := time.Now().UTC()
+		st.FinishedAt = &done
+		if err != nil {
+			st.Error = err.Error()
+			log.Printf("analytics: reclaim space (VACUUM): %v", err)
+		} else if fi, statErr := os.Stat(s.DBPath); statErr == nil {
+			st.AfterBytes = fi.Size()
+			log.Printf("analytics: reclaimed space: database %s → %s", fmtBytesShort(st.BeforeBytes), fmtBytesShort(st.AfterBytes))
+		}
+		s.storeJSONSetting(settingAnalyticsVacuumStatus, st)
+		_ = models.LogActivity(s.DB, 0, "system", "analytics_vacuum", "database", fmt.Sprintf("%s → %s", fmtBytesShort(st.BeforeBytes), fmtBytesShort(st.AfterBytes)), err == nil)
+	}()
+	return nil
+}
+
+// pruneAnalyticsHandler: POST /settings/analytics/prune — Prune now.
+func (s *Server) pruneAnalyticsHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.startAccessPrune() {
+		log.Printf("analytics: manual prune requested while one is running")
+	} else {
+		_ = models.LogActivity(s.DB, 0, s.currentUserEmail(r), "analytics_prune", "access_events", fmt.Sprintf("manual prune, retention %d days", analyticsRetentionDays(s)), true)
+	}
+	http.Redirect(w, r, "/settings#analytics", http.StatusSeeOther)
+}
+
+// vacuumAnalyticsHandler: POST /settings/analytics/vacuum — Reclaim space.
+func (s *Server) vacuumAnalyticsHandler(w http.ResponseWriter, r *http.Request) {
+	if err := s.startVacuum(); err != nil {
+		_ = models.LogActivity(s.DB, 0, s.currentUserEmail(r), "analytics_vacuum", "database", err.Error(), false)
+	}
+	http.Redirect(w, r, "/settings#analytics", http.StatusSeeOther)
+}
+
+// parseAnalyticsRetentionDays validates the settings form value: blank keeps
+// the current value, 0 = keep forever, else 1..3650.
+func parseAnalyticsRetentionDays(raw string, current int) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return current, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 || n > maxAnalyticsRetentionDays {
+		return 0, fmt.Errorf("analytics retention must be between 0 (keep forever) and %d days", maxAnalyticsRetentionDays)
+	}
+	return n, nil
+}

--- a/internal/server/analytics_retention_test.go
+++ b/internal/server/analytics_retention_test.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	appdb "github.com/X4Applegate/caddyui/internal/db"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+func newRetentionTestServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "caddyui.db")
+	conn, err := appdb.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return &Server{DB: conn, DBPath: path}, path
+}
+
+func seedAccessEvents(t *testing.T, s *Server, n int, age time.Duration) {
+	t.Helper()
+	ts := time.Now().Add(-age)
+	for i := 0; i < n; i++ {
+		if err := models.InsertAccessEvent(s.DB, models.AccessEvent{TS: ts.Add(time.Duration(i) * time.Second), ServerID: 1, Host: "app.example.test", Path: "/x", Method: "GET", Status: 200, ClientIP: "10.0.0.1", UserAgent: strings.Repeat("ua", 40), BytesOut: 1234}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// v2.43.0: the prune respects the retention setting, deletes in batches,
+// records what it did, and leaves newer rows alone; 0 keeps everything.
+func TestRunAccessPruneHonoursRetention(t *testing.T) {
+	s, _ := newRetentionTestServer(t)
+	seedAccessEvents(t, s, 45, 40*24*time.Hour) // old
+	seedAccessEvents(t, s, 5, time.Hour)        // recent
+	if days := analyticsRetentionDays(s); days != defaultAnalyticsRetentionDays {
+		t.Fatalf("default retention = %d", days)
+	}
+
+	st := s.runAccessPrune(true)
+	if st.Error != "" || st.Deleted != 45 || st.Remaining != 5 || st.FinishedAt == nil || st.Cutoff == nil || !st.Manual {
+		t.Fatalf("status = %+v", st)
+	}
+	if got := s.lastPruneStatus(); got == nil || got.Deleted != 45 {
+		t.Fatalf("stored status = %+v", got)
+	}
+	oldest, newest, err := models.AccessEventBounds(s.DB)
+	if err != nil || time.Since(oldest) > 2*time.Hour || newest.Before(oldest) {
+		t.Fatalf("bounds = %v .. %v, %v", oldest, newest, err)
+	}
+
+	// Batches smaller than the backlog still remove everything old.
+	seedAccessEvents(t, s, 30, 60*24*time.Hour)
+	n, err := models.PruneAccessEventsBatched(s.DB, time.Now().Add(-30*24*time.Hour), 7, false, nil)
+	if err != nil || n != 30 {
+		t.Fatalf("batched prune = %d, %v", n, err)
+	}
+	// stop is honoured between batches.
+	seedAccessEvents(t, s, 20, 60*24*time.Hour)
+	calls := 0
+	n, err = models.PruneAccessEventsBatched(s.DB, time.Now().Add(-30*24*time.Hour), 5, false, func() bool { calls++; return calls > 2 })
+	if err != nil || n != 10 {
+		t.Fatalf("stopped prune = %d, %v", n, err)
+	}
+
+	// Retention 0 = keep forever.
+	if err := models.SetSetting(s.DB, settingAnalyticsRetentionDays, "0"); err != nil {
+		t.Fatal(err)
+	}
+	if st := s.runAccessPrune(false); st.Deleted != 0 || st.Cutoff != nil {
+		t.Fatalf("retention 0 must not delete: %+v", st)
+	}
+	if got, _ := models.CountAccessEvents(s.DB); got != 15 {
+		t.Fatalf("count after keep-forever = %d, want 15", got)
+	}
+	if v, err := parseAnalyticsRetentionDays("", 30); err != nil || v != 30 {
+		t.Errorf("blank keeps current: %d, %v", v, err)
+	}
+	if _, err := parseAnalyticsRetentionDays("4000", 30); err == nil {
+		t.Error("out of range must be rejected")
+	}
+	if v, err := parseAnalyticsRetentionDays(" 7 ", 30); err != nil || v != 7 {
+		t.Errorf("7 days: %d, %v", v, err)
+	}
+}
+
+// Reclaim space rewrites the SQLite file without the deleted rows: the file
+// shrinks, the status records before/after, and a second run is refused
+// while one is in flight.
+func TestStartVacuumShrinksTheDatabase(t *testing.T) {
+	s, path := newRetentionTestServer(t)
+	seedAccessEvents(t, s, 4000, 40*24*time.Hour)
+	if _, err := s.DB.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		t.Fatal(err)
+	}
+	before, _ := os.Stat(path)
+	if st := s.runAccessPrune(true); st.Deleted != 4000 {
+		t.Fatalf("prune = %+v", st)
+	}
+	view := s.analyticsStorageView()
+	if !view.SQLite || view.DBBytes == 0 || view.FreePageBytes == 0 || !view.VacuumPossible {
+		t.Fatalf("storage view before reclaim = %+v", view)
+	}
+	if err := s.startVacuum(); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		if st := s.lastVacuumStatus(); st != nil && st.FinishedAt != nil {
+			if st.Error != "" || st.AfterBytes >= st.BeforeBytes || st.BeforeBytes != before.Size() {
+				t.Fatalf("vacuum status = %+v (before %d)", st, before.Size())
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("vacuum did not finish")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	after := s.analyticsStorageView()
+	if after.FreePageBytes != 0 || after.DBBytes >= before.Size() {
+		t.Fatalf("storage view after reclaim = %+v", after)
+	}
+	if os.Getenv("SQLITE_TMPDIR") == "" {
+		t.Error("SQLITE_TMPDIR should have been pointed at the data directory")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -115,6 +115,9 @@ type Server struct {
 	certProbeTargetFn func(serverID int64, probeName string) string
 	// v2.42.0: serializes certificate export passes (certificate_export.go).
 	certExportRunMu sync.Mutex
+	// v2.43.0: analytics retention — one prune and one VACUUM at a time.
+	accessPruneMu sync.Mutex
+	vacuumMu      sync.Mutex
 }
 
 type apiTokenScopeContextKey struct{}
@@ -164,6 +167,9 @@ func New(db *sql.DB, caddyClient *caddy.Client, templates fs.FS, static fs.FS, c
 	go s.runMaintenanceWindowLoop()
 	go s.runActivityLogCleanup()
 	go s.runAccessDailyAggregator()
+	// v2.43.0: this loop existed since v2.7.0 but was never started, so
+	// access_events grew without bound (analytics_retention.go).
+	go s.pruneAccessLoop()
 	return s, nil
 }
 
@@ -837,6 +843,8 @@ func (s *Server) Routes() http.Handler {
 			// Feature F: settings page (admin-only).
 			r.Get("/settings", s.getSettings)
 			r.Post("/settings", s.postSettings)
+			r.Post("/settings/analytics/prune", s.pruneAnalyticsHandler)   // v2.43.0
+			r.Post("/settings/analytics/vacuum", s.vacuumAnalyticsHandler) // v2.43.0
 			r.Post("/settings/test-webhook", s.postTestWebhook)
 			r.Post("/settings/test-email", s.postTestEmail)
 			r.Post("/settings/test-crowdsec", s.postTestCrowdSec)
@@ -14402,6 +14410,8 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		"AnalyticsSoftStart":         analyticsCfg.SoftStart,
 		"AnalyticsDialTimeoutSec":    int(analyticsCfg.DialTimeout / time.Second),
 		"AnalyticsIngestStats":       analyticsIngestSnap,
+		"AnalyticsRetentionDays":     analyticsRetentionDays(s), // v2.43.0
+		"AnalyticsStorage":           s.analyticsStorageView(),  // v2.43.0
 		// Fleet access logging and CrowdSec integrations (v2.21.0).
 		"AccessLogEnabled":        accessLogCfg.Enabled,
 		"AccessLogPath":           accessLogCfg.Path,
@@ -14603,6 +14613,12 @@ func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	// v2.43.0: retention days (0 = keep forever).
+	analyticsRetention, err := parseAnalyticsRetentionDays(r.FormValue("analytics_retention_days"), analyticsRetentionDays(s))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	analyticsDialTimeoutSec := int(currentAnalyticsCfg.DialTimeout / time.Second)
 	if raw, present := r.PostForm["analytics_dial_timeout_sec"]; present && len(raw) > 0 && strings.TrimSpace(raw[0]) != "" {
 		n, err := strconv.Atoi(strings.TrimSpace(raw[0]))
@@ -14721,6 +14737,7 @@ func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 		settingAnalyticsExcludeIPs:      analyticsExclude,
 		settingAnalyticsSoftStart:       analyticsSoftStart,
 		settingAnalyticsDialTimeoutSec:  strconv.Itoa(analyticsDialTimeoutSec),
+		settingAnalyticsRetentionDays:   strconv.Itoa(analyticsRetention), // v2.43.0
 		// v2.10.0: trusted proxies + custom site title
 		settingTrustedProxies: strings.TrimSpace(r.FormValue("trusted_proxies")),
 		settingSiteTitle:      strings.TrimSpace(r.FormValue("site_title")),

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -441,6 +441,20 @@ func TestExpectationsAreSurfaced(t *testing.T) {
 	}
 }
 
+// TestAnalyticsRetentionIsSurfaced guards v2.43.0: the retention field and
+// the storage view with Prune now / Reclaim space live on the Analytics card.
+func TestAnalyticsRetentionIsSurfaced(t *testing.T) {
+	body, err := FS.ReadFile("templates/settings.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range []string{`name="analytics_retention_days"`, "data-analytics-storage", `formaction="/settings/analytics/prune"`, `formaction="/settings/analytics/vacuum"`, ".FreePageBytes"} {
+		if !strings.Contains(string(body), m) {
+			t.Errorf("settings.html missing %q", m)
+		}
+	}
+}
+
 // TestFailedSyncBannerIsSurfaced guards v2.42.1 (issue #74): a sync Caddy
 // rejected is shown on every page with retry and dismiss actions.
 func TestFailedSyncBannerIsSurfaced(t *testing.T) {

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -1211,6 +1211,39 @@
       <p class="text-xs text-ink-500 mt-1.5">Drops events from these IPs/CIDRs before the DB insert — useful for hiding your own LAN, an uptime-monitor provider, or a VPN subnet. Changes take effect immediately (no Caddy reload required).</p>
     </div>
 
+    {{/* v2.43.0: retention + storage */}}
+    <div data-analytics-retention>
+      <label class="block text-sm font-medium text-ink-800 mb-1.5">Keep raw events for <span class="text-ink-400 font-normal text-xs">(days · 0 = forever)</span></label>
+      <input name="analytics_retention_days" value="{{.AnalyticsRetentionDays}}" type="number" min="0" max="3650" step="1"
+        class="w-40 rounded-lg border border-ink-200 px-3 py-2 text-sm bg-white focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none transition" />
+      <p class="text-xs text-ink-500 mt-1.5">Older events are deleted every hour, in small batches. Per-day totals per host are kept separately for long-range charts, so shortening this does not blank the Analytics history. Deleting rows frees space <em>inside</em> the database file; <strong>Reclaim space</strong> below returns it to the disk.</p>
+    </div>
+
+    {{with .AnalyticsStorage}}
+    <div class="pt-3 border-t border-ink-100" data-analytics-storage>
+      <div class="text-xs font-medium text-ink-600 mb-2">Storage</div>
+      <dl class="grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs">
+        {{if .SQLite}}<div><dt class="text-ink-500">Database file</dt><dd class="font-mono text-ink-800">{{fmtBytes .DBBytes}}</dd></div>
+        <div><dt class="text-ink-500">Reclaimable</dt><dd class="font-mono text-ink-800">{{fmtBytes .FreePageBytes}}</dd></div>{{end}}
+        <div><dt class="text-ink-500">Oldest event</dt><dd class="font-mono text-ink-800">{{if .Oldest.IsZero}}—{{else}}{{fmtIn .Oldest "2006-01-02"}}{{end}}</dd></div>
+        <div><dt class="text-ink-500">Newest event</dt><dd class="font-mono text-ink-800">{{if .Newest.IsZero}}—{{else}}{{fmtRel .Newest}}{{end}}</dd></div>
+      </dl>
+      <div class="mt-3 text-xs text-ink-600 space-y-1">
+        {{with .LastPrune}}
+          <div>Last prune: {{if not .FinishedAt}}<span class="ui-status ui-status--info">running</span> since {{fmtRel .StartedAt}}{{else if .Error}}<span class="ui-status ui-status--danger">failed</span> {{fmtRel .StartedAt}} — <span class="font-mono">{{.Error}}</span>{{else}}{{fmtRel .StartedAt}} — removed <span class="font-mono">{{.Deleted}}</span> events{{if ge .Remaining 0}}, <span class="font-mono">{{.Remaining}}</span> kept{{end}}{{if .Cutoff}} (older than {{fmtIn .Cutoff "2006-01-02"}}){{end}}{{end}}</div>
+        {{else}}<div>Last prune: not yet run.</div>{{end}}
+        {{with .LastVacuum}}
+          <div>Last reclaim: {{if not .FinishedAt}}<span class="ui-status ui-status--info">running</span> since {{fmtRel .StartedAt}}{{else if .Error}}<span class="ui-status ui-status--danger">failed</span> {{fmtRel .StartedAt}} — <span class="font-mono">{{.Error}}</span>{{else}}{{fmtRel .StartedAt}} — <span class="font-mono">{{fmtBytes .BeforeBytes}} → {{fmtBytes .AfterBytes}}</span>{{end}}</div>
+        {{end}}
+      </div>
+      <div class="mt-3 flex flex-wrap items-center gap-2">
+        <button type="submit" formaction="/settings/analytics/prune" formmethod="post" class="ui-button ui-button--secondary text-xs"{{if .PruneRunning}} disabled{{end}}>Prune now</button>
+        {{if .SQLite}}<button type="submit" formaction="/settings/analytics/vacuum" formmethod="post" class="ui-button ui-button--secondary text-xs"{{if not .VacuumPossible}} disabled title="{{.VacuumBlockedBy}}"{{end}}>Reclaim space</button>{{end}}
+        <span class="text-xs text-ink-400">{{if .SQLite}}Reclaim rewrites the database file without the deleted rows. It needs free disk for a full copy and pauses writes (including analytics ingest) while it runs — a few seconds per GB. Run it after a large prune, at a quiet moment.{{else}}On MariaDB, run <code class="font-mono">OPTIMIZE TABLE access_events</code> to reclaim space.{{end}}</span>
+      </div>
+    </div>
+    {{end}}
+
     {{/* Live ingest metrics — rendered only when the listener is up, which
          is always in a normal run but would be nil in tests. Atomic counters
          so reading them is safe from the request handler's goroutine. */}}


### PR DESCRIPTION
## Summary

Diagnosed on a production database: 22 GB, 72 million `access_events` rows, 63 million of them older than 30 days, oldest from April, zero free pages. Cause: `pruneAccessLoop` has existed since v2.7.0 but nothing ever started it.

- **Fixed:** the prune loop now starts with the other background workers (an hour after start-up, then hourly) and deletes in batches of 20,000 — lowest ids first, which finds the oldest rows without a ts index — so the write lock is never held for long even against months of backlog. MariaDB uses `DELETE … ORDER BY id LIMIT`.
- **Added:** Settings → Analytics → **Keep raw events for N days** (default 30; 0 = forever). Per-day totals per host live in the separate rollup, so shortening retention keeps long-range charts.
- **Added:** a **Storage** panel on the same card — database file size, space already freed inside the file (`freelist_count × page_size`), oldest/newest event, the last prune (rows removed and kept) and the last reclaim — with **Prune now** and **Reclaim space**. Reclaim runs `VACUUM` in the background (the only thing that shrinks the SQLite file after deletes), is refused when the data volume lacks room for a full copy, and checkpoints the WAL afterwards so the new size is real. On MariaDB it points at `OPTIMIZE TABLE access_events`. Both actions are recorded in the Activity log.
- The Docker image sets `SQLITE_TMPDIR=/data` so VACUUM has a working directory in the scratch-based image (no `/tmp`); the process also sets it at run time when unset.

## Verification

- Tests: `TestRunAccessPruneHonoursRetention` (old rows removed, recent kept, status recorded, batches smaller than the backlog, stop callback, retention 0, form parsing) and `TestStartVacuumShrinksTheDatabase` (4,000 rows inserted and pruned, VACUUM shrinks the file, status before/after, storage view free pages back to zero). Template guard. Full suite green.
- Scratch CaddyUI: 300,000 events 120 days old plus 2,000 recent ones seeded; **Prune now** removed 300,000 in about three seconds and kept 2,000; **Reclaim space** took the file from 84.7 MB to 584 KB; the Storage panel and the Activity log show both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)