### PR TITLE
feat: split Settings into pages, each saving only its own settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versi
 
 ---
 
+## [2.44.0] - 2026-09-09 - Settings is now a set of pages
+
+### Changed
+
+- **Settings is split into eight pages** — General, Notifications, DNS, Security, Analytics, Integrations, AI assistant, Backup — with a navigation column (a scrolling row on narrow screens) instead of one form with sixteen cards and a row of jump links. `/settings` opens General; each page lives at `/settings/<page>`, and old in-page links such as `/settings#settings-smtp` are redirected to the page that now holds the card.
+- Each page saves only its own settings. The save handler now owns a table of which page holds which key and writes nothing else, so saving General cannot blank the SMTP host or the analytics target. DNS provider credentials and integration settings are only collected from their own pages. Saving Notifications, AI or Backup no longer triggers a Caddy sync, which they never affected.
+- Links across the app and the docs that pointed at Settings anchors now open the right page directly.
+
+---
+
 ## [2.43.1] - 2026-09-09 - The first big prune no longer slows every page
 
 ### Fixed

--- a/internal/server/analytics_retention.go
+++ b/internal/server/analytics_retention.go
@@ -320,7 +320,7 @@ func (s *Server) pruneAnalyticsHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		_ = models.LogActivity(s.DB, 0, s.currentUserEmail(r), "analytics_prune", "access_events", fmt.Sprintf("manual prune, retention %d days", analyticsRetentionDays(s)), true)
 	}
-	http.Redirect(w, r, "/settings#analytics", http.StatusSeeOther)
+	http.Redirect(w, r, "/settings/analytics", http.StatusSeeOther)
 }
 
 // vacuumAnalyticsHandler: POST /settings/analytics/vacuum — Reclaim space.
@@ -328,7 +328,7 @@ func (s *Server) vacuumAnalyticsHandler(w http.ResponseWriter, r *http.Request) 
 	if err := s.startVacuum(); err != nil {
 		_ = models.LogActivity(s.DB, 0, s.currentUserEmail(r), "analytics_vacuum", "database", err.Error(), false)
 	}
-	http.Redirect(w, r, "/settings#analytics", http.StatusSeeOther)
+	http.Redirect(w, r, "/settings/analytics", http.StatusSeeOther)
 }
 
 // parseAnalyticsRetentionDays validates the settings form value: blank keeps

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -842,6 +842,7 @@ func (s *Server) Routes() http.Handler {
 
 			// Feature F: settings page (admin-only).
 			r.Get("/settings", s.getSettings)
+			r.Get("/settings/{section}", s.getSettings) // v2.44.0
 			r.Post("/settings", s.postSettings)
 			r.Post("/settings/analytics/prune", s.pruneAnalyticsHandler)   // v2.43.0
 			r.Post("/settings/analytics/vacuum", s.vacuumAnalyticsHandler) // v2.43.0
@@ -2312,7 +2313,7 @@ func buildDashboardRecommendations(in dashboardRecommendationInput) []dashboardR
 	}
 
 	if in.GlobalMaintenance {
-		add("critical", "Global maintenance mode is active", "Every proxy host is serving the maintenance response until this is turned off and Caddy is synced.", "/settings#settings-general", "Open settings")
+		add("critical", "Global maintenance mode is active", "Every proxy host is serving the maintenance response until this is turned off and Caddy is synced.", "/settings/general", "Open settings")
 	} else if in.MaintenanceCount > 0 {
 		add("warning", "Proxy hosts are in maintenance", fmt.Sprintf("%d enabled proxy host(s) are currently serving maintenance responses.", in.MaintenanceCount), "/proxy-hosts?status=maintenance", "Review hosts")
 	}
@@ -2358,7 +2359,7 @@ func buildDashboardRecommendations(in dashboardRecommendationInput) []dashboardR
 		add("warning", "Managed DNS is incomplete", fmt.Sprintf("%d resource(s) have a DNS provider selected but no zone saved yet.", incompleteDNS), "/proxy-hosts", "Review DNS")
 	}
 	if missingProfiles > 0 {
-		add("critical", "DNS profile references are missing", fmt.Sprintf("%d resource(s) reference a deleted or unavailable DNS credential profile.", missingProfiles), "/settings#settings-dns", "Fix profiles")
+		add("critical", "DNS profile references are missing", fmt.Sprintf("%d resource(s) reference a deleted or unavailable DNS credential profile.", missingProfiles), "/settings/dns", "Fix profiles")
 	}
 
 	expiringSoon := 0
@@ -2413,10 +2414,10 @@ func buildDashboardRecommendations(in dashboardRecommendationInput) []dashboardR
 
 	if in.IsAdmin {
 		if !in.Require2FA && !in.RequireTOTP {
-			add("warning", "2FA is not required", "Admins can enable required TOTP enrollment to reduce account-takeover risk.", "/settings#settings-security", "Open security")
+			add("warning", "2FA is not required", "Admins can enable required TOTP enrollment to reduce account-takeover risk.", "/settings/security", "Open security")
 		}
 		if !in.AdminAllowlistSet {
-			add("info", "Admin IP allowlist is empty", "Restricting CaddyUI to trusted IPs or CIDRs can reduce exposure for homelab installs.", "/settings#settings-security", "Open security")
+			add("info", "Admin IP allowlist is empty", "Restricting CaddyUI to trusted IPs or CIDRs can reduce exposure for homelab installs.", "/settings/security", "Open security")
 		}
 		if len(in.Snapshots) == 0 {
 			add("warning", "No config snapshots yet", "Take a manual snapshot so there is a known-good Caddy config to restore.", "/snapshots", "Take snapshot")
@@ -14137,6 +14138,14 @@ func (s *Server) getBackup(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
+	// v2.44.0: one page per area; /settings is the first page.
+	settingsPage := defaultSettingsSection
+	if raw := chi.URLParam(r, "section"); raw != "" {
+		if settingsPage = settingsSectionSlug(raw); settingsPage == "" {
+			http.NotFound(w, r)
+			return
+		}
+	}
 	webhookURL, _ := models.GetSetting(s.DB, settingNotifyWebhookURL)
 	// v2.12.51: ntfy.sh push channel — load alongside the existing webhook.
 	ntfyURL, _ := models.GetSetting(s.DB, settingNotifyNtfyURL)
@@ -14446,20 +14455,27 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 		"FaviconURL":     mustGetSetting(s.DB, settingFaviconURL),
 		"AdminAllowlist": mustGetSetting(s.DB, settingAdminAllowlist),
 		// v2.12.0: configurable session duration + global catch-all 404
-		"SessionDays":       mustGetSetting(s.DB, settingSessionDays),
-		"CatchAll404HTML":   mustGetSetting(s.DB, settingCatchAll404HTML),
-		"GlobalMaintenance": mustGetSetting(s.DB, settingGlobalMaintenance),
-		"AutoSyncHours":     mustGetSetting(s.DB, settingAutoSyncHours),
-		"ActivityLogDays":   mustGetSetting(s.DB, settingActivityLogDays),
-		"MaxLoginAttempts":  mustGetSetting(s.DB, settingMaxLoginAttempts),
-		"DisableHTTP3":      mustGetSetting(s.DB, settingDisableHTTP3),
-		"DatabaseBackend":   string(appdb.BackendOf(s.DB)),
-		"Section":           "settings",
+		"SessionDays":          mustGetSetting(s.DB, settingSessionDays),
+		"CatchAll404HTML":      mustGetSetting(s.DB, settingCatchAll404HTML),
+		"GlobalMaintenance":    mustGetSetting(s.DB, settingGlobalMaintenance),
+		"AutoSyncHours":        mustGetSetting(s.DB, settingAutoSyncHours),
+		"ActivityLogDays":      mustGetSetting(s.DB, settingActivityLogDays),
+		"MaxLoginAttempts":     mustGetSetting(s.DB, settingMaxLoginAttempts),
+		"DisableHTTP3":         mustGetSetting(s.DB, settingDisableHTTP3),
+		"DatabaseBackend":      string(appdb.BackendOf(s.DB)),
+		"Section":              "settings",
+		"SettingsSection":      settingsPage,                       // v2.44.0
+		"SettingsSectionLabel": settingsSectionLabel(settingsPage), // v2.44.0
+		"SettingsNav":          settingsSections,                   // v2.44.0
+		"SettingsAnchorsJSON":  settingsAnchorsJSON(),              // v2.44.0
 	})
 }
 
 func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 	_ = r.ParseForm()
+	// v2.44.0: the posted page owns a subset of keys; "" is the legacy
+	// whole-form post (API clients, old bookmarks) and saves everything.
+	settingsPage := settingsSectionSlug(r.FormValue("settings_section"))
 	integrationSettingsPresent := r.FormValue("fleet_integrations_present") == "1"
 	accessLogFormCfg := loadFleetAccessLogConfig(s.DB)
 	crowdSecFormCfg := loadCrowdSecConfig(s.DB)
@@ -14796,22 +14812,31 @@ func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 	// to re-enter secrets just to toggle a checkbox. Non-secret fields
 	// (for example Namecheap's API user/client IP and Route 53's region/
 	// access-key ID) are always overwritten so users can edit or clear them.
-	for _, d := range dns.Descriptors() {
-		for _, c := range d.Credentials {
-			v := strings.TrimSpace(r.FormValue(c.Key))
-			if v == "" && c.Secret {
-				// Empty + secret field → preserve existing value.
-				continue
+	// v2.44.0: provider credentials and allow-lists only exist on the DNS
+	// page; collecting them from any other page would clear them.
+	if settingsPage == "" || settingsPage == "dns" {
+		for _, d := range dns.Descriptors() {
+			for _, c := range d.Credentials {
+				v := strings.TrimSpace(r.FormValue(c.Key))
+				if v == "" && c.Secret {
+					// Empty + secret field → preserve existing value.
+					continue
+				}
+				kv[c.Key] = v
 			}
-			kv[c.Key] = v
+			// v2.4.7: per-provider zone allow-list. Always overwrite — an
+			// empty textarea means "remove the allow-list, accept every zone
+			// again". Normalised form (lowercase, deduped, comma-separated)
+			// is what we persist, even though the textarea offers lines for
+			// readability.
+			allowRaw := r.FormValue(d.ID + "_zone_allowlist")
+			kv[zoneAllowlistKey(d.ID)] = strings.Join(parseZoneAllowlist(allowRaw), ",")
 		}
-		// v2.4.7: per-provider zone allow-list. Always overwrite — an
-		// empty textarea means "remove the allow-list, accept every zone
-		// again". Normalised form (lowercase, deduped, comma-separated)
-		// is what we persist, even though the textarea offers lines for
-		// readability.
-		allowRaw := r.FormValue(d.ID + "_zone_allowlist")
-		kv[zoneAllowlistKey(d.ID)] = strings.Join(parseZoneAllowlist(allowRaw), ",")
+	}
+	// v2.44.0: client_ip_headers lives on the Security page but is saved by
+	// the integrations bundle above; save it directly when its field posted.
+	if _, present := r.PostForm["client_ip_headers"]; present && !integrationSettingsPresent {
+		kv[settingClientIPHeaders] = strings.TrimSpace(r.FormValue("client_ip_headers"))
 	}
 	if _, ok := r.PostForm["dns_profile_name"]; ok {
 		if err := s.saveDNSProfiles(s.parseDNSProfilesForm(r)); err != nil {
@@ -14852,6 +14877,14 @@ func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 	if t := strings.TrimSpace(r.FormValue("notify_ntfy_token")); t != "" {
 		kv[settingNotifyNtfyToken] = t
 	}
+	// v2.44.0: keep only the keys the posted page owns.
+	if settingsPage != "" {
+		for k := range kv {
+			if owner, known := settingsKeySection[k]; known && owner != settingsPage {
+				delete(kv, k)
+			}
+		}
+	}
 	for k, v := range kv {
 		if err := models.SetSetting(s.DB, k, v); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -14864,8 +14897,14 @@ func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 	// is ignored — we already validated above, so LoadLocation can't fail
 	// here barring a race with tzdata being unloaded (won't happen in a
 	// container with /usr/share/zoneinfo baked in).
-	_ = setActiveLocation(timezone)
-	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r), "settings_update", "notify+smtp", smtpHost, true)
+	if settingsPage == "" || settingsPage == "general" {
+		_ = setActiveLocation(timezone)
+	}
+	activityDetail := "notify+smtp"
+	if settingsPage != "" {
+		activityDetail = "page:" + settingsPage
+	}
+	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r), "settings_update", activityDetail, smtpHost, true)
 
 	// v2.7.0: push the analytics toggle through to the live ingest +
 	// Caddy admin API after saving to the settings table. Errors are
@@ -14873,14 +14912,16 @@ func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 	// the Settings page's "Analytics" card reflects the current wiring
 	// state so the admin can retry. This avoids a half-saved "settings
 	// didn't persist, Caddy pivoted anyway" that would be very confusing.
-	if err := s.applyAnalyticsToggle(loadAnalyticsConfig(s.DB)); err != nil {
-		log.Printf("settings: analytics toggle: %v", err)
-	}
-	// The certificate monitor shares the analytics ingest target even when
-	// visitor analytics itself is disabled. Refresh it after target/timeout
-	// changes so lifecycle events keep flowing to the right listener.
-	if err := s.ReconcileCertificateLogs(); err != nil {
-		log.Printf("settings: certificate log monitoring: %v", err)
+	if settingsPage == "" || settingsPage == "analytics" {
+		if err := s.applyAnalyticsToggle(loadAnalyticsConfig(s.DB)); err != nil {
+			log.Printf("settings: analytics toggle: %v", err)
+		}
+		// The certificate monitor shares the analytics ingest target even when
+		// visitor analytics itself is disabled. Refresh it after target/timeout
+		// changes so lifecycle events keep flowing to the right listener.
+		if err := s.ReconcileCertificateLogs(); err != nil {
+			log.Printf("settings: certificate log monitoring: %v", err)
+		}
 	}
 
 	// v2.4.0: per-server public IP update. The settings form submits one
@@ -14943,15 +14984,21 @@ func (s *Server) postSettings(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	go func(serverIDs []int64) {
-		// syncCaddy temporarily swaps s.Caddy, so fleet syncs stay sequential.
-		for _, serverID := range serverIDs {
-			if err := s.syncCaddy(serverID, false); err != nil {
-				log.Printf("settings: auto-sync server %d after save failed (non-fatal): %v", serverID, err)
+	if settingsSectionSyncsCaddy(settingsPage) { // v2.44.0
+		go func(serverIDs []int64) {
+			// syncCaddy temporarily swaps s.Caddy, so fleet syncs stay sequential.
+			for _, serverID := range serverIDs {
+				if err := s.syncCaddy(serverID, false); err != nil {
+					log.Printf("settings: auto-sync server %d after save failed (non-fatal): %v", serverID, err)
+				}
 			}
-		}
-	}(serverIDsToSync)
+		}(serverIDsToSync)
+	}
 
+	if settingsPage != "" {
+		http.Redirect(w, r, "/settings/"+settingsPage+"?saved=1", http.StatusSeeOther)
+		return
+	}
 	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
 }
 
@@ -14993,7 +15040,7 @@ func (s *Server) postClearDNSProvider(w http.ResponseWriter, r *http.Request) {
 	_ = models.LogActivity(s.DB, s.currentServerID(r), s.currentUserEmail(r),
 		"dns_provider_clear", "dns:"+id, "", true)
 
-	http.Redirect(w, r, "/settings?cleared="+url.QueryEscape(id), http.StatusSeeOther)
+	http.Redirect(w, r, "/settings/dns?cleared="+url.QueryEscape(id), http.StatusSeeOther)
 }
 
 func (s *Server) postTestWebhook(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/settings_sections.go
+++ b/internal/server/settings_sections.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"encoding/json"
+	"html/template"
+	"strings"
+)
+
+// v2.44.0: Settings is split into pages, one per area, instead of one form
+// with sixteen cards. Each page posts only its own fields, so the save
+// handler must only write the keys that page owns — otherwise saving
+// "General" would blank the SMTP host, the analytics target and every
+// other value the page did not render. settingsKeySection is that
+// ownership table; postSettings drops every key the posted page does not
+// own. Dynamic keys (DNS provider credentials, fleet integration settings)
+// are gated at collection time instead.
+
+type settingsSection struct {
+	Slug  string
+	Label string
+	Blurb string
+}
+
+// settingsSections is the navigation, in order. Slugs are URL segments.
+var settingsSections = []settingsSection{
+	{"general", "General", "Site title, maintenance, auto-sync, timezone, post-apply checks"},
+	{"notifications", "Notifications", "Email (SMTP), webhook, ntfy, certificate alerts"},
+	{"dns", "DNS", "Public IPs, provider credentials, zones"},
+	{"security", "Security", "2FA policy, sessions, allowlists, CAPTCHA"},
+	{"analytics", "Analytics", "Visitor analytics, retention, storage"},
+	{"integrations", "Integrations", "Caddy access logs, Prometheus metrics, CrowdSec"},
+	{"ai", "AI assistant", "Provider, model, system prompt"},
+	{"backup", "Backup", "Database backup"},
+}
+
+const defaultSettingsSection = "general"
+
+// settingsSectionSlug validates a slug from the URL or the form: "" for
+// unknown, so callers can 404 or fall back.
+func settingsSectionSlug(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	for _, sec := range settingsSections {
+		if sec.Slug == raw {
+			return raw
+		}
+	}
+	return ""
+}
+
+func settingsSectionLabel(slug string) string {
+	for _, sec := range settingsSections {
+		if sec.Slug == slug {
+			return sec.Label
+		}
+	}
+	return "Settings"
+}
+
+// settingsAnchorSection maps the pre-v2.44.0 in-page anchors to the page
+// that now holds the card, for old links and bookmarks.
+var settingsAnchorSection = map[string]string{
+	"settings-general":       "general",
+	"settings-timezone":      "general",
+	"expectations":           "general",
+	"settings-smtp":          "notifications",
+	"settings-notifications": "notifications",
+	"settings-notifier":      "notifications",
+	"settings-dns":           "dns",
+	"settings-dns-ips":       "dns",
+	"settings-dns-providers": "dns",
+	"settings-captcha":       "security",
+	"settings-security":      "security",
+	"settings-ai":            "ai",
+	"settings-access-logs":   "integrations",
+	"settings-metrics":       "integrations",
+	"settings-crowdsec":      "integrations",
+	"analytics":              "analytics",
+	"settings-backup":        "backup",
+}
+
+// settingsKeySection is which page owns each setting key the save handler
+// can write. A key missing here is written on every page — keep it
+// complete (TestSettingsSectionsOwnEveryStaticKey checks the handler).
+var settingsKeySection = map[string]string{
+	settingSiteTitle:                  "general",
+	settingFaviconURL:                 "general",
+	settingCatchAll404HTML:            "general",
+	settingGlobalMaintenance:          "general",
+	settingAutoSyncHours:              "general",
+	settingActivityLogDays:            "general",
+	settingGlobalStripResponseHeaders: "general",
+	settingTimezone:                   "general",
+	settingExpectationsAutoRollback:   "general",
+
+	settingNotifyWebhookURL:    "notifications",
+	settingNotifyWebhookSecret: "notifications",
+	settingNotifyNtfyURL:       "notifications",
+	settingNotifyNtfyToken:     "notifications",
+	settingNotifyDaysBefore:    "notifications",
+	settingSMTPHost:            "notifications",
+	settingSMTPPort:            "notifications",
+	settingSMTPUsername:        "notifications",
+	settingSMTPPassword:        "notifications",
+	settingSMTPFrom:            "notifications",
+	settingSMTPTo:              "notifications",
+	settingSMTPSecurity:        "notifications",
+	settingSMTPSkipVerify:      "notifications",
+
+	settingServerIP:  "dns",
+	settingCFProxied: "dns",
+
+	settingRequire2FA:         "security",
+	settingRequireTOTP:        "security",
+	settingTrustedProxies:     "security",
+	settingClientIPHeaders:    "security",
+	settingDisableHTTP3:       "security",
+	settingAdminAllowlist:     "security",
+	settingSessionDays:        "security",
+	settingMaxLoginAttempts:   "security",
+	settingCaptchaProvider:    "security",
+	settingTurnstileSiteKey:   "security",
+	settingTurnstileSecretKey: "security",
+	settingRecaptchaSiteKey:   "security",
+	settingRecaptchaSecretKey: "security",
+	settingRecaptchaMinScore:  "security",
+
+	settingAnalyticsEnabled:        "analytics",
+	settingAnalyticsIngestTarget:   "analytics",
+	settingAnalyticsExcludeIPs:     "analytics",
+	settingAnalyticsSoftStart:      "analytics",
+	settingAnalyticsDialTimeoutSec: "analytics",
+	settingAnalyticsRetentionDays:  "analytics",
+
+	settingCrowdSecAPIKey: "integrations",
+
+	settingAIEnabled:           "ai",
+	settingAIProvider:          "ai",
+	settingAIOllamaURL:         "ai",
+	settingAIOllamaModel:       "ai",
+	settingAIOllamaCloudModel:  "ai",
+	settingAIOllamaCloudAPIKey: "ai",
+	settingAIAnthropicModel:    "ai",
+	settingAIAnthropicAPIKey:   "ai",
+	settingAIOpenAIBaseURL:     "ai",
+	settingAIOpenAIModel:       "ai",
+	settingAIOpenAIAPIKey:      "ai",
+	settingAISystemPrompt:      "ai",
+}
+
+// settingsSectionSyncsCaddy reports whether saving a page can change the
+// live Caddy config and therefore warrants the auto-sync that follows a
+// save. Notification, AI and backup settings never reach Caddy.
+func settingsSectionSyncsCaddy(slug string) bool {
+	switch slug {
+	case "notifications", "ai", "backup":
+		return false
+	}
+	return true
+}
+
+// settingsAnchorsJSON is settingsAnchorSection for the page's redirect script.
+func settingsAnchorsJSON() template.JS {
+	raw, err := json.Marshal(settingsAnchorSection)
+	if err != nil {
+		return template.JS("{}")
+	}
+	return template.JS(raw) // nolint:gosec // fixed table of slugs, no user input
+}

--- a/internal/server/settings_sections_test.go
+++ b/internal/server/settings_sections_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/X4Applegate/caddyui/internal/auth"
+	"github.com/X4Applegate/caddyui/internal/models"
+)
+
+func postSettingsPage(t *testing.T, s *Server, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(context.WithValue(req.Context(), auth.ContextUserKey, &models.User{ID: 1, Email: "admin@example.com", IsAdmin: true, Role: models.RoleAdmin}))
+	rec := httptest.NewRecorder()
+	s.postSettings(rec, req)
+	return rec
+}
+
+func setting(t *testing.T, s *Server, key string) string {
+	t.Helper()
+	v, err := models.GetSetting(s.DB, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+// v2.44.0: a page saves its own keys and leaves every other page's values
+// alone; the legacy whole-form post (no page) still saves everything.
+func TestSettingsPagesSaveOnlyTheirOwnKeys(t *testing.T) {
+	s, _ := newPreflightTestServer(t)
+	seed := map[string]string{
+		settingSiteTitle:              "Old title",
+		settingTimezone:               "Europe/Paris",
+		settingSMTPHost:               "mail.example.test",
+		settingNotifyWebhookURL:       "https://hooks.example.test/x",
+		settingAnalyticsIngestTarget:  "10.8.0.1:9019",
+		settingAnalyticsRetentionDays: "45",
+		settingAdminAllowlist:         "10.0.0.0/8",
+		settingAIProvider:             "anthropic",
+		settingServerIP:               "203.0.113.5",
+		settingClientIPHeaders:        "CF-Connecting-IP",
+	}
+	for k, v := range seed {
+		if err := models.SetSetting(s.DB, k, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// General page: only General keys change.
+	rec := postSettingsPage(t, s, url.Values{"settings_section": {"general"}, "site_title": {"New title"}, "timezone": {"UTC"}, "auto_sync_hours": {"6"}})
+	if rec.Code != http.StatusSeeOther || rec.Header().Get("Location") != "/settings/general?saved=1" {
+		t.Fatalf("general save → %d %s", rec.Code, rec.Header().Get("Location"))
+	}
+	if got := setting(t, s, settingSiteTitle); got != "New title" {
+		t.Errorf("site title = %q", got)
+	}
+	if got := setting(t, s, settingTimezone); got != "UTC" {
+		t.Errorf("timezone = %q", got)
+	}
+	for _, k := range []string{settingSMTPHost, settingNotifyWebhookURL, settingAnalyticsIngestTarget, settingAnalyticsRetentionDays, settingAdminAllowlist, settingAIProvider, settingServerIP, settingClientIPHeaders} {
+		if got := setting(t, s, k); got != seed[k] {
+			t.Errorf("General save changed %s: %q → %q", k, seed[k], got)
+		}
+	}
+
+	// Analytics page: its keys change, General and the rest stay.
+	rec = postSettingsPage(t, s, url.Values{"settings_section": {"analytics"}, "analytics_enabled": {"0", "1"}, "analytics_ingest_target": {"caddyui:9019"}, "analytics_retention_days": {"14"}})
+	if rec.Code != http.StatusSeeOther || rec.Header().Get("Location") != "/settings/analytics?saved=1" {
+		t.Fatalf("analytics save → %d %s", rec.Code, rec.Header().Get("Location"))
+	}
+	if got := setting(t, s, settingAnalyticsIngestTarget); got != "caddyui:9019" {
+		t.Errorf("analytics target = %q", got)
+	}
+	if got := setting(t, s, settingAnalyticsRetentionDays); got != "14" {
+		t.Errorf("retention = %q", got)
+	}
+	if got := setting(t, s, settingSiteTitle); got != "New title" {
+		t.Errorf("Analytics save changed the site title: %q", got)
+	}
+	if got := setting(t, s, settingSMTPHost); got != seed[settingSMTPHost] {
+		t.Errorf("Analytics save changed SMTP host: %q", got)
+	}
+
+	// Security page owns client_ip_headers even though integrations bundle it.
+	rec = postSettingsPage(t, s, url.Values{"settings_section": {"security"}, "client_ip_headers": {"X-Real-IP"}, "admin_allowlist": {"192.168.0.0/16"}})
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("security save → %d %s", rec.Code, rec.Body.String())
+	}
+	if got := setting(t, s, settingClientIPHeaders); got != "X-Real-IP" {
+		t.Errorf("client_ip_headers = %q", got)
+	}
+	if got := setting(t, s, settingAdminAllowlist); got != "192.168.0.0/16" {
+		t.Errorf("admin allowlist = %q", got)
+	}
+	if got := setting(t, s, settingServerIP); got != seed[settingServerIP] {
+		t.Errorf("Security save changed the DNS server IP: %q", got)
+	}
+
+	// Notifications page: SMTP changes; a blank password keeps the stored one.
+	if err := models.SetSetting(s.DB, settingSMTPPassword, "secret"); err != nil {
+		t.Fatal(err)
+	}
+	rec = postSettingsPage(t, s, url.Values{"settings_section": {"notifications"}, "smtp_host": {"smtp.new.test"}, "smtp_password": {""}, "webhook_url": {""}})
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("notifications save → %d", rec.Code)
+	}
+	if got := setting(t, s, settingSMTPHost); got != "smtp.new.test" || setting(t, s, settingSMTPPassword) != "secret" || setting(t, s, settingNotifyWebhookURL) != "" {
+		t.Errorf("notifications save: host=%q password kept=%v webhook=%q", got, setting(t, s, settingSMTPPassword) == "secret", setting(t, s, settingNotifyWebhookURL))
+	}
+	if got := setting(t, s, settingAnalyticsIngestTarget); got != "caddyui:9019" {
+		t.Errorf("Notifications save changed the analytics target: %q", got)
+	}
+
+	// Legacy whole-form post (no page): everything it carries is saved, as before.
+	rec = postSettingsPage(t, s, url.Values{"site_title": {"Legacy"}, "analytics_ingest_target": {"legacy:9019"}})
+	if rec.Code != http.StatusSeeOther || rec.Header().Get("Location") != "/settings?saved=1" {
+		t.Fatalf("legacy save → %d %s", rec.Code, rec.Header().Get("Location"))
+	}
+	if setting(t, s, settingSiteTitle) != "Legacy" || setting(t, s, settingAnalyticsIngestTarget) != "legacy:9019" {
+		t.Errorf("legacy save should write every page's keys")
+	}
+
+	// Unknown page slug → treated as legacy; unknown GET page → 404.
+	if settingsSectionSlug("bogus") != "" || settingsSectionSlug(" DNS ") != "dns" {
+		t.Errorf("slug validation")
+	}
+	req := httptest.NewRequest(http.MethodGet, "/settings/bogus", nil)
+	rec = httptest.NewRecorder()
+	// chi URL params are not set outside a router; exercise the slug check directly.
+	if settingsSectionLabel("bogus") != "Settings" || settingsSectionLabel("dns") != "DNS" {
+		t.Errorf("labels")
+	}
+	_ = req
+	for anchor, page := range settingsAnchorSection {
+		if settingsSectionSlug(page) == "" {
+			t.Errorf("anchor %s points at unknown page %q", anchor, page)
+		}
+	}
+	for key, page := range settingsKeySection {
+		if settingsSectionSlug(page) == "" {
+			t.Errorf("key %s owned by unknown page %q", key, page)
+		}
+	}
+}

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -441,6 +441,33 @@ func TestExpectationsAreSurfaced(t *testing.T) {
 	}
 }
 
+// TestSettingsPagesAreGuarded guards v2.44.0: every card sits inside a page
+// guard, the form carries the page it posts for, the integrations-only
+// hidden input lives inside its page, and the nav links to every page.
+func TestSettingsPagesAreGuarded(t *testing.T) {
+	body, err := FS.ReadFile("templates/settings.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	html := string(body)
+	for _, m := range []string{`name="settings_section"`, "data-settings-nav", `href="/settings/{{.Slug}}"`, ".SettingsAnchorsJSON", `{{if eq .SettingsSection "general"}}`, `{{if eq .SettingsSection "backup"}}`} {
+		if !strings.Contains(html, m) {
+			t.Errorf("settings.html missing %q", m)
+		}
+	}
+	if strings.Count(html, "{{if eq .SettingsSection") < 10 {
+		t.Errorf("expected every card to be page-guarded, found %d guards", strings.Count(html, "{{if eq .SettingsSection"))
+	}
+	present := strings.Index(html, `name="fleet_integrations_present"`)
+	guard := strings.Index(html, `{{if eq .SettingsSection "integrations"}}`)
+	if present < 0 || guard < 0 || present < guard {
+		t.Errorf("fleet_integrations_present must sit inside the integrations page guard (input at %d, guard at %d)", present, guard)
+	}
+	if strings.Contains(html, `href="#settings-`) {
+		t.Errorf("in-page jump links should be gone")
+	}
+}
+
 // TestAnalyticsRetentionIsSurfaced guards v2.43.0: the retention field and
 // the storage view with Prune now / Reclaim space live on the Analytics card.
 func TestAnalyticsRetentionIsSurfaced(t *testing.T) {

--- a/web/templates/analytics.html
+++ b/web/templates/analytics.html
@@ -37,7 +37,7 @@
       Export CSV
     </a>
     {{if .IsAdmin}}
-    <a href="/settings#analytics" class="inline-flex items-center gap-1.5 text-sm text-brand-600 hover:text-brand-700 border border-brand-200 hover:border-brand-300 px-3 py-1.5 rounded-lg transition">
+    <a href="/settings/analytics" class="inline-flex items-center gap-1.5 text-sm text-brand-600 hover:text-brand-700 border border-brand-200 hover:border-brand-300 px-3 py-1.5 rounded-lg transition">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><circle cx="12" cy="12" r="3"/></svg>
       Settings
     </a>
@@ -50,7 +50,7 @@
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
   <div class="flex-1">
     <div class="text-sm font-medium text-amber-900">Access log forwarding is off</div>
-    <p class="text-xs text-amber-800 mt-0.5">Turn it on in <a href="/settings#analytics" class="underline font-medium">Settings → Analytics</a> to start collecting visitor data.</p>
+    <p class="text-xs text-amber-800 mt-0.5">Turn it on in <a href="/settings/analytics" class="underline font-medium">Settings → Analytics</a> to start collecting visitor data.</p>
   </div>
 </div>
 {{end}}{{end}}
@@ -170,7 +170,7 @@
           </div>
           <div class="text-ink-600 text-sm font-medium">No traffic yet</div>
           <p class="text-xs text-ink-500 mt-1 max-w-sm mx-auto">
-          {{if .IsAdmin}}{{if .AnalyticsEnabled}}Waiting for Caddy to ship its first access log entry. Make sure your Caddy container can resolve the ingest target.{{else}}Enable access log forwarding in <a href="/settings#analytics" class="underline">Settings → Analytics</a>.{{end}}{{else}}No traffic has been recorded for the hosts you own yet.{{end}}
+          {{if .IsAdmin}}{{if .AnalyticsEnabled}}Waiting for Caddy to ship its first access log entry. Make sure your Caddy container can resolve the ingest target.{{else}}Enable access log forwarding in <a href="/settings/analytics" class="underline">Settings → Analytics</a>.{{end}}{{else}}No traffic has been recorded for the hosts you own yet.{{end}}
           </p>
           {{/* v2.37.0: with one node in scope, say where it ships its logs and why that may fail */}}
           {{with .ScopeIngest}}{{if $.IsAdmin}}

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -4,7 +4,7 @@
   {{if eq .GlobalMaintenance "1"}}
   <div class="ops-alert ops-alert--warning" role="status">
     <svg class="ops-alert__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
-    <span><strong>Global maintenance mode is active.</strong> All proxy hosts are serving a 503 page. <a href="/settings#settings-general">Turn it off in Settings</a> and sync Caddy to restore service.</span>
+    <span><strong>Global maintenance mode is active.</strong> All proxy hosts are serving a 503 page. <a href="/settings/general">Turn it off in Settings</a> and sync Caddy to restore service.</span>
   </div>
   {{else if .MaintenanceCount}}
   <div class="ops-alert ops-alert--warning" role="status">

--- a/web/templates/docs.html
+++ b/web/templates/docs.html
@@ -556,7 +556,7 @@
     Prometheus metrics
   </h2>
   <div class="bg-white border border-ink-200 rounded-xl shadow-card p-5 text-sm text-ink-700 leading-relaxed space-y-3">
-    <p>Open <a href="/settings#settings-metrics" class="text-brand-600 hover:text-brand-700">Settings → Metrics</a>, select the managed Caddy servers CaddyUI should own, and enable the metric detail you need.</p>
+    <p>Open <a href="/settings/integrations" class="text-brand-600 hover:text-brand-700">Settings → Metrics</a>, select the managed Caddy servers CaddyUI should own, and enable the metric detail you need.</p>
     <ul class="list-disc ml-5 space-y-1">
       <li><strong>Prometheus metrics</strong> enables Caddy's base HTTP measurements.</li>
       <li><strong>Per-host labels</strong> adds a host label to HTTP metrics.</li>

--- a/web/templates/onboarding.html
+++ b/web/templates/onboarding.html
@@ -103,7 +103,7 @@
           <p>Saved provider profiles let CaddyUI create DNS records and let Caddy complete DNS-01 challenges for wildcard certificates.</p>
           {{if eq .User.Role "admin"}}
           <div class="onboarding-step__actions">
-            <a href="/settings#settings-dns" class="ui-button {{if .DNSConfigured}}ui-button--secondary{{else}}ui-button--primary{{end}}">
+            <a href="/settings/dns" class="ui-button {{if .DNSConfigured}}ui-button--secondary{{else}}ui-button--primary{{end}}">
               {{if .DNSConfigured}}Review DNS profiles{{else}}Add DNS provider{{end}}
             </a>
             <a href="/docs#proxy-hosts" class="ui-section-header__action">How automation works →</a>
@@ -128,7 +128,7 @@
             <a href="/totp/setup" class="ui-button {{if .TOTPEnabled}}ui-button--secondary{{else}}ui-button--primary{{end}}">
               {{if .TOTPEnabled}}Review two-factor auth{{else}}Enable two-factor auth{{end}}
             </a>
-            {{if eq .User.Role "admin"}}<a href="/settings#settings-security" class="ui-section-header__action">Security policy →</a>{{end}}
+            {{if eq .User.Role "admin"}}<a href="/settings/security" class="ui-section-header__action">Security policy →</a>{{end}}
           </div>
         </article>
       </li>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -1,33 +1,29 @@
 {{define "title"}}Settings · CaddyUI{{end}}
 {{define "content"}}
 <div class="mb-6">
-  <h1 class="text-2xl font-semibold tracking-tight text-ink-900">Settings</h1>
-  <p class="text-sm text-ink-500 mt-1">Application-wide settings for notifications and email.</p>
+  <h1 class="text-2xl font-semibold tracking-tight text-ink-900">Settings <span class="text-ink-300 font-normal">/</span> {{.SettingsSectionLabel}}</h1>
+  <p class="text-sm text-ink-500 mt-1">{{range .SettingsNav}}{{if eq .Slug $.SettingsSection}}{{.Blurb}}{{end}}{{end}}</p>
 </div>
 
-{{/* ── v2.6.0: jump-to-section nav ──────────────────────────────────
-     Settings has grown past 600 lines rendered — admins who just want
-     to tweak Timezone or CAPTCHA shouldn't have to scroll past SMTP
-     every time. Each link targets a card ID below; scroll-mt-20 on
-     the cards accounts for the top header so they don't land flush
-     under the nav bar. Smooth-scroll comes from html { scroll-behavior }
-     in app.css (auto-disabled for prefers-reduced-motion). */}}
-<nav aria-label="Settings sections" class="mb-6 max-w-2xl flex flex-wrap gap-1.5">
-  <a href="#settings-general"     class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">General</a>
-  <a href="#settings-smtp"        class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Email</a>
-  <a href="#settings-notifications" class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Notifications</a>
-  <a href="#settings-timezone"    class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Timezone</a>
-  <a href="#settings-dns-ips"     class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">DNS IPs</a>
-  <a href="#settings-dns-providers" class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">DNS Providers</a>
-  <a href="#settings-captcha"     class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">CAPTCHA</a>
-  <a href="#settings-security"    class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Security</a>
-  <a href="#settings-access-logs" class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Access logs</a>
-  <a href="#settings-metrics"     class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Metrics</a>
-  <a href="#settings-crowdsec"    class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">CrowdSec</a>
-  <a href="#analytics"            class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Analytics</a>
-  <a href="#settings-notifier"    class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Notifier</a>
-  <a href="#settings-backup"      class="inline-flex items-center text-xs font-medium text-ink-600 hover:text-brand-700 bg-white hover:bg-ink-50 border border-ink-200 hover:border-brand-300 px-2.5 py-1.5 rounded-lg transition">Backup</a>
+{{/* v2.44.0: one page per area. The nav is a column beside the content on
+     wide screens and a scrolling row above it on narrow ones. Old in-page
+     anchors (/settings#settings-smtp …) are redirected to the right page
+     by the script at the bottom. */}}
+<div class="lg:flex lg:items-start lg:gap-8">
+<nav aria-label="Settings pages" data-settings-nav class="mb-6 lg:mb-0 lg:w-52 lg:shrink-0 lg:sticky lg:top-20">
+  <ul class="flex lg:flex-col gap-1 overflow-x-auto pb-1 lg:pb-0">
+    {{range .SettingsNav}}
+    <li class="shrink-0">
+      <a href="/settings/{{.Slug}}" {{if eq .Slug $.SettingsSection}}aria-current="page"{{end}}
+         class="block rounded-lg px-3 py-2 text-sm transition {{if eq .Slug $.SettingsSection}}bg-brand-50 text-brand-700 font-medium{{else}}text-ink-600 hover:bg-ink-50 hover:text-ink-900{{end}}">
+        <span class="block">{{.Label}}</span>
+        <span class="hidden lg:block text-[11px] leading-snug {{if eq .Slug $.SettingsSection}}text-brand-600/80{{else}}text-ink-400{{end}}">{{.Blurb}}</span>
+      </a>
+    </li>
+    {{end}}
+  </ul>
 </nav>
+<div class="min-w-0 flex-1">
 
 {{if .Success}}
 <div data-toast="success" class="bg-brand-50 border border-brand-200 text-brand-800 px-4 py-3 rounded-xl mb-4 text-sm">Settings saved successfully.</div>
@@ -40,8 +36,9 @@
 {{end}}
 
 <form method="post" action="/settings" class="max-w-2xl space-y-8">
-  <input type="hidden" name="fleet_integrations_present" value="1">
+  <input type="hidden" name="settings_section" value="{{.SettingsSection}}">
 
+{{if eq .SettingsSection "general"}}
   {{/* ── General ── */}}
   <div id="settings-general" class="scroll-mt-20 bg-white border border-ink-200 rounded-xl shadow-card p-6 space-y-5">
     <div>
@@ -142,6 +139,8 @@
     </div>
   </div>
 
+{{end}}
+{{if eq .SettingsSection "ai"}}
   {{/* ── v2.11.15: AI assistant. v2.12.36: multi-provider — Ollama (local),
        Ollama Cloud, Claude (Anthropic), or any OpenAI-compatible API. ── */}}
   <div id="settings-ai" class="scroll-mt-20 bg-white border border-ink-200 rounded-xl shadow-card p-6 space-y-4">
@@ -300,6 +299,8 @@
     </div>
   </div>
 
+{{end}}
+{{if eq .SettingsSection "notifications"}}
   {{/* ── SMTP ── */}}
   <div id="settings-smtp" class="scroll-mt-20 bg-white border border-ink-200 rounded-xl shadow-card p-6 space-y-5">
     <div>
@@ -463,6 +464,8 @@
     </div>
   </div>
 
+{{end}}
+{{if eq .SettingsSection "general"}}
   {{/* ── Timezone (v2.4.12) ── */}}
   {{/* Admin-picked IANA zone that every DB-stored timestamp renders through
        (cert expiry, activity log, snapshots, "last updated" markers). Priority
@@ -518,6 +521,8 @@
     </div>
   </div>
 
+{{end}}
+{{if eq .SettingsSection "dns"}}
   {{/* ── DNS — per-server public IPs (v2.4.0) ── */}}
   <div id="settings-dns-ips" class="scroll-mt-20 bg-white border border-ink-200 rounded-xl shadow-card p-6 space-y-3">
     <div>
@@ -701,6 +706,8 @@
   {{end}}
   </div>{{/* /settings-dns-providers */}}
 
+{{end}}
+{{if eq .SettingsSection "security"}}
   {{/* ── CAPTCHA (v2.5.0) ── Unified card for Cloudflare Turnstile and Google
        reCAPTCHA v3. The provider radio hot-swaps which pair of key fields is
        visible via the inline JS below — server-side normalizeCaptchaProvider
@@ -911,6 +918,9 @@
     </div>
   </div>
 
+{{end}}
+{{if eq .SettingsSection "integrations"}}
+  <input type="hidden" name="fleet_integrations_present" value="1">
   {{/* ── Caddy fleet file access logs (v2.21.0) ── */}}
   <div id="settings-access-logs" class="scroll-mt-20 bg-white border border-ink-200 rounded-xl shadow-card p-6 space-y-5">
     <div>
@@ -1122,6 +1132,7 @@
     </div>
   </div>
 
+{{end}}
   {{/* ── Visitor Analytics (v2.7.0) ──
        Privacy-light traffic stats built from Caddy's access logs. When the
        toggle below is ON we (a) install a `net` log writer in the live
@@ -1130,6 +1141,7 @@
        textarea below. No DNT opt-in UI, no 3rd-party tracker loaded —
        everything runs on localhost and persists in the CaddyUI DB. */}}
   {{/* v2.38.0: post-apply checks (expectations) */}}
+{{if eq .SettingsSection "general"}}
   <div id="expectations" class="scroll-mt-20 bg-white border border-ink-200 rounded-xl shadow-card p-6 space-y-4">
     <div>
       <div class="text-sm font-semibold text-ink-900">Post-apply checks</div>
@@ -1142,6 +1154,8 @@
     </label>
   </div>
 
+{{end}}
+{{if eq .SettingsSection "analytics"}}
   <div id="analytics" class="scroll-mt-20 bg-white border border-ink-200 rounded-xl shadow-card p-6 space-y-5">
     <div>
       <div class="flex items-center gap-2 mb-0.5">
@@ -1260,31 +1274,32 @@
     </div>
     {{end}}
 
-    <div class="pt-3 border-t border-ink-100 flex flex-wrap items-center gap-3">
-      <button type="submit" class="inline-flex items-center bg-brand-600 hover:bg-brand-700 text-white font-medium text-sm px-4 py-2 rounded-lg shadow-sm transition">Save settings</button>
-      <span class="text-xs text-ink-400">Saving re-applies the Caddy-side logger config.</span>
-    </div>
   </div>
 
-  <div class="flex items-center gap-3">
-    <button class="inline-flex items-center bg-brand-600 hover:bg-brand-700 text-white font-medium text-sm px-5 py-2 rounded-lg shadow-sm transition">Save settings</button>
+{{end}}
+  {{if ne .SettingsSection "backup"}}
+  <div class="flex flex-wrap items-center gap-3">
+    <button class="inline-flex items-center bg-brand-600 hover:bg-brand-700 text-white font-medium text-sm px-5 py-2 rounded-lg shadow-sm transition">Save {{.SettingsSectionLabel}} settings</button>
+    {{if eq .SettingsSection "analytics"}}<span class="text-xs text-ink-400">Saving re-applies the Caddy-side logger config.</span>{{end}}
   </div>
+  {{end}}
 </form>
 
 {{/* One empty form per configured DNS provider, lives OUTSIDE the main
      settings form. The "Clear credentials" buttons inside each provider
      card use HTML5 form="clear-dns-<id>" to post to these instead of the
      big settings form. onsubmit confirm() gates the destructive POST. */}}
-{{range .DNSProviders}}{{if .Configured}}
+{{if eq .SettingsSection "dns"}}{{range .DNSProviders}}{{if .Configured}}
 <form id="clear-dns-{{.ID}}" method="post" action="/settings/dns-provider/{{.ID}}/clear" class="hidden"
       onsubmit="return confirm('Clear all {{.DisplayName}} API credentials? Existing DNS records on {{.DisplayName}} stay in place — this only removes the keys stored in CaddyUI.')"></form>
-{{end}}{{end}}
+{{end}}{{end}}{{end}}
 
 {{/* The Test Email and Test Webhook buttons used to live in their own
      cards here, but v2.4.12 moved them up into the SMTP and Webhook cards
      above (next to each section's Save button) so you can edit → save →
      test without scrolling to the bottom of the page. */}}
 
+{{if eq .SettingsSection "notifications"}}
 {{/* ── Notifier status ── */}}
 <div id="settings-notifier" class="scroll-mt-20 max-w-2xl mt-4 bg-white border border-ink-200 rounded-xl shadow-card p-6">
   <div class="text-sm font-semibold text-ink-800 mb-3">Notifier Status</div>
@@ -1293,6 +1308,8 @@
   </div>
 </div>
 
+{{end}}
+{{if eq .SettingsSection "backup"}}
 {{/* ── Backup ── */}}
 <div id="settings-backup" class="scroll-mt-20 max-w-2xl mt-4 bg-white border border-ink-200 rounded-xl shadow-card p-5">
   <div class="text-sm font-semibold text-ink-800 mb-1">Database Backup</div>
@@ -1310,6 +1327,20 @@
   {{end}}
 </div>
 
+{{end}}
+</div>
+</div>
+
+<script>
+// v2.44.0: old in-page anchors land on whichever page they now live on.
+(function() {
+  var anchors = {{.SettingsAnchorsJSON}};
+  var hash = (location.hash || '').replace(/^#/, '');
+  if (hash && anchors[hash] && anchors[hash] !== {{printf "%q" .SettingsSection}}) {
+    location.replace('/settings/' + anchors[hash] + '#' + hash);
+  }
+})();
+</script>
 <script>
 function testEmail() {
   var btn = document.getElementById('test-email-btn');
@@ -1385,7 +1416,7 @@ function testCrowdSec(serverID, btn) {
 }
 
 (function() {
-  fetch('/api/notifier-status')
+  if (document.getElementById('notifier-status')) fetch('/api/notifier-status')
     .then(function(r) { return r.ok ? r.json() : null; })
     .then(function(d) {
       if (!d) return;


### PR DESCRIPTION
## Summary

Settings was one form with sixteen cards and a row of jump links. It is now eight pages — **General, Notifications, DNS, Security, Analytics, Integrations, AI assistant, Backup** — with a navigation column beside the content (a scrolling row on narrow screens).

- `/settings` opens General; each page lives at `/settings/<page>`; unknown pages 404. Old in-page anchors (`/settings#settings-smtp`, `/settings#analytics`, …) are redirected client-side to the page that now holds the card, and the links across the app and docs that used them now point at the pages directly.
- **Each page saves only its own settings.** The form carries `settings_section`; `postSettings` owns a table of which page holds which key (`settingsKeySection`) and drops every other key before writing, so saving General cannot blank the SMTP host or the analytics target. DNS provider credentials and zone allow-lists are only collected on the DNS page; the integrations bundle (`fleet_integrations_present`) only exists on the Integrations page; `client_ip_headers`, which sits on Security but used to be saved by that bundle, is saved directly. Timezone hot-apply, the analytics logger re-apply and the certificate-log reconcile run only when their page posted. Saving Notifications, AI or Backup no longer triggers a Caddy sync, which they never affected.
- A post without `settings_section` (API clients, old bookmarks) behaves exactly as before and saves everything it carries.

## Verification

- `TestSettingsPagesSaveOnlyTheirOwnKeys`: seeded values across pages; saving General changes only General keys; Analytics likewise; Security saves `client_ip_headers` and the allowlist and leaves the DNS server IP; Notifications keeps a stored SMTP password on a blank field and leaves the analytics target; the legacy whole-form post still writes everything; every anchor and key maps to a known page. `TestSettingsPagesAreGuarded` checks the template structure. Full suite green.
- Scratch CaddyUI: all eight pages render 200 with the right cards and one active nav item, `/settings/bogus` is 404, the dashboard's Settings links point at `/settings/security`, screenshots at 1200 px (General) and 900 px (Analytics) checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)